### PR TITLE
Add __str__ method to URL to convert url components to url string

### DIFF
--- a/httpcore/datastructures.py
+++ b/httpcore/datastructures.py
@@ -67,6 +67,9 @@ class URL:
     def origin(self) -> "Origin":
         return Origin(self)
 
+    def __str__(self) -> str:
+        return self.components.geturl()
+
 
 class Origin:
     def __init__(self, url: typing.Union[str, URL]) -> None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -70,15 +70,19 @@ def test_override_content_length_header():
 
 
 def test_url():
-    request = httpcore.Request("GET", "http://example.org")
+    url = "http://example.org"
+    request = httpcore.Request("GET", url)
     assert request.url.scheme == "http"
     assert request.url.port == 80
     assert request.url.target == "/"
+    assert str(request.url) == url
 
-    request = httpcore.Request("GET", "https://example.org/abc?foo=bar")
+    url = "https://example.org/abc?foo=bar"
+    request = httpcore.Request("GET", url)
     assert request.url.scheme == "https"
     assert request.url.port == 443
     assert request.url.target == "/abc?foo=bar"
+    assert str(request.url) == url
 
 
 def test_invalid_urls():


### PR DESCRIPTION
I think it's slightly nicer to be able to convert a url to a string via `str()`.