### PR TITLE
optimize str bytes concatenation

### DIFF
--- a/httpcore/models.py
+++ b/httpcore/models.py
@@ -482,10 +482,7 @@ class Request:
         Read and return the response content.
         """
         if not hasattr(self, "content"):
-            content = b""
-            async for part in self.stream():
-                content += part
-            self.content = content
+            self.content = b"".join([part async for part in self.stream()])
         return self.content
 
     async def stream(self) -> typing.AsyncIterator[bytes]:
@@ -670,10 +667,7 @@ class Response:
         Read and return the response content.
         """
         if not hasattr(self, "_content"):
-            content = b""
-            async for part in self.stream():
-                content += part
-            self._content = content
+            self._content = b"".join([part async for part in self.stream()])
         return self._content
 
     async def stream(self) -> typing.AsyncIterator[bytes]:


### PR DESCRIPTION
while investigating this https://github.com/huge-success/sanic/issues/1569, i found most of the increased build time has been spent on str/bytes concatenation (https://github.com/encode/httpcore/blob/master/httpcore/models.py#L675) with 100% cpu bounded.

FYI: those tests (https://github.com/huge-success/sanic/blob/master/tests/test_request_stream.py#L8) are the root cause of longer time build.

and they become pretty fast after this patch.