### PR TITLE
Add test to https server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ mypy
 pytest
 pytest-asyncio
 pytest-cov
+trustme
 uvicorn

--- a/tests/dispatch/test_connections.py
+++ b/tests/dispatch/test_connections.py
@@ -1,6 +1,6 @@
 import pytest
 
-from httpcore import HTTPConnection, Request
+from httpcore import HTTPConnection, Request, SSLConfig
 
 
 @pytest.mark.asyncio
@@ -9,6 +9,14 @@ async def test_get(server):
     request = Request("GET", "http://127.0.0.1:8000/")
     request.prepare()
     response = await conn.send(request)
+    assert response.status_code == 200
+    assert response.content == b"Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_https_get(https_server):
+    http = HTTPConnection(origin="https://127.0.0.1:8001/", ssl=SSLConfig(verify=False))
+    response = await http.request("GET", "https://127.0.0.1:8001/")
     assert response.status_code == 200
     assert response.content == b"Hello, world!"
 


### PR DESCRIPTION
Add `https_server` test fixture.

The self-signed certificate was created using [these steps](https://devcenter.heroku.com/articles/ssl-certificate-self).