### PR TITLE
WIP: Test informational response

### DIFF
--- a/httpcore/dispatch/http11.py
+++ b/httpcore/dispatch/http11.py
@@ -2,14 +2,8 @@ import typing
 
 import h11
 
-from ..config import (
-    DEFAULT_SSL_CONFIG,
-    DEFAULT_TIMEOUT_CONFIG,
-    SSLConfig,
-    TimeoutConfig,
-)
-from ..exceptions import ConnectTimeout, ReadTimeout
-from ..interfaces import BaseReader, BaseWriter, Dispatcher
+from ..config import TimeoutConfig
+from ..interfaces import BaseReader, BaseWriter
 from ..models import Request, Response
 
 H11Event = typing.Union[

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -139,7 +139,7 @@ def test_delete(server):
 def test_informational(server):
     with httpcore.Client() as http:
         response = http.put(
-            "http://127.0.0.1:8000/",
+            "http://127.0.0.1:8000/informational",
             headers={"Expect": "100-continue"},
             data=b"Hello, world!",
         )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -133,3 +133,14 @@ def test_delete(server):
         response = http.delete("http://127.0.0.1:8000/")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
+
+
+@threadpool
+def test_informational(server):
+    with httpcore.Client() as http:
+        response = http.put(
+            "http://127.0.0.1:8000/",
+            headers={"Expect": "100-continue"},
+            data=b"Hello, world!",
+        )
+    assert response.status_code == 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ async def app(scope, receive, send):
         await slow_response(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
+    elif scope["path"].startswith("/informational"):
+        await informational(scope, receive, send)
     else:
         await hello_world(scope, receive, send)
 
@@ -49,6 +51,17 @@ async def status_code(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+
+async def informational(scope, recieve, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 100,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    await send({"type": "http.response.body", "body": b""})
 
 
 @pytest.fixture


### PR DESCRIPTION
Trying out [your advice](https://github.com/encode/httpcore/issues/26#issuecomment-492389772)  seems the headers don't make a difference and uvicorn simply returns the response from the endpoint. But I found that we do enter [the path not covered by the tests](https://github.com/encode/httpcore/blob/master/httpcore/dispatch/http11.py#L69) if the server returns a 100.

However h11 errors with `h11._util.RemoteProtocolError: malformed data`. [The RFC](https://tools.ietf.org/html/rfc7231#section-6.2.1) states that the client should then proceed to send the data but our next action is to receive a following h11 event from the response so I'm a bit confused as to what the server is supposed to be sending back to the client.

In this PR I created an temporary `informational` endpoint on the server fixture to try out combinations of [ASGI response bodies](https://asgi.readthedocs.io/en/latest/specs/www.html#response-body) but I keep getting the same error.

Any ideas?