### PR TITLE
Support thread-pooled dispatch

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -28,7 +28,14 @@ from .exceptions import (
     TooManyRedirects,
     WriteTimeout,
 )
-from .interfaces import BaseReader, BaseWriter, ConcurrencyBackend, Dispatcher, Protocol
+from .interfaces import (
+    AsyncDispatcher,
+    BaseReader,
+    BaseWriter,
+    ConcurrencyBackend,
+    Dispatcher,
+    Protocol,
+)
 from .models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
 from .status_codes import StatusCode, codes
 

--- a/httpcore/client.py
+++ b/httpcore/client.py
@@ -544,13 +544,13 @@ class Client:
 
         async def async_iterator(backend, data):  # type: ignore
             while True:
-                print(123)
                 try:
-                    yield await self.concurrency_backend.run_in_threadpool(
+                    chunk = await self.concurrency_backend.run_in_threadpool(
                         data.__next__
                     )
                 except StopIteration:
                     raise StopAsyncIteration()
+                yield chunk
 
         return async_iterator(self.concurrency_backend, data)
 

--- a/httpcore/client.py
+++ b/httpcore/client.py
@@ -541,18 +541,7 @@ class Client:
             return data
 
         assert hasattr(data, "__iter__")
-
-        async def async_iterator(backend, data):  # type: ignore
-            while True:
-                try:
-                    chunk = await self.concurrency_backend.run_in_threadpool(
-                        data.__next__
-                    )
-                except StopIteration:
-                    raise StopAsyncIteration()
-                yield chunk
-
-        return async_iterator(self.concurrency_backend, data)
+        return self.concurrency_backend.iterate_in_threadpool(data)
 
     def request(
         self,

--- a/httpcore/concurrency.py
+++ b/httpcore/concurrency.py
@@ -135,9 +135,12 @@ class AsyncioBackend(ConcurrencyBackend):
         SSL_MONKEY_PATCH_APPLIED = True
 
     @property
-    def loop(self) -> asyncio.BaseEventLoop:
-        if not hasattr(self, '_loop'):
-            self._loop = asyncio.get_event_loop()
+    def loop(self) -> asyncio.AbstractEventLoop:
+        if not hasattr(self, "_loop"):
+            try:
+                self._loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self._loop = asyncio.new_event_loop()
         return self._loop
 
     async def connect(
@@ -169,11 +172,18 @@ class AsyncioBackend(ConcurrencyBackend):
 
         return (reader, writer, protocol)
 
-    async def run_in_threadpool(self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+    async def run_in_threadpool(
+        self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
         if kwargs:
             # loop.run_in_executor doesn't accept 'kwargs', so bind them in here
             func = functools.partial(func, **kwargs)
         return await self.loop.run_in_executor(None, func, *args)
+
+    def run(
+        self, coroutine: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        return self.loop.run_until_complete(coroutine(*args, **kwargs))
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         return PoolSemaphore(limits)

--- a/httpcore/concurrency.py
+++ b/httpcore/concurrency.py
@@ -9,6 +9,7 @@ protocols, and help keep the rest of the package more `async`/`await`
 based, and less strictly `asyncio`-specific.
 """
 import asyncio
+import functools
 import ssl
 import typing
 
@@ -133,6 +134,12 @@ class AsyncioBackend(ConcurrencyBackend):
             ssl_monkey_patch()
         SSL_MONKEY_PATCH_APPLIED = True
 
+    @property
+    def loop(self) -> asyncio.BaseEventLoop:
+        if not hasattr(self, '_loop'):
+            self._loop = asyncio.get_event_loop()
+        return self._loop
+
     async def connect(
         self,
         hostname: str,
@@ -161,6 +168,12 @@ class AsyncioBackend(ConcurrencyBackend):
         protocol = Protocol.HTTP_2 if ident == "h2" else Protocol.HTTP_11
 
         return (reader, writer, protocol)
+
+    async def run_in_threadpool(self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        if kwargs:
+            # loop.run_in_executor doesn't accept 'kwargs', so bind them in here
+            func = functools.partial(func, **kwargs)
+        return await self.loop.run_in_executor(None, func, *args)
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         return PoolSemaphore(limits)

--- a/httpcore/dispatch/connection.py
+++ b/httpcore/dispatch/connection.py
@@ -15,7 +15,7 @@ from ..config import (
     VerifyTypes,
 )
 from ..exceptions import ConnectTimeout
-from ..interfaces import ConcurrencyBackend, Dispatcher, Protocol
+from ..interfaces import AsyncDispatcher, ConcurrencyBackend, Protocol
 from ..models import Origin, Request, Response
 from .http2 import HTTP2Connection
 from .http11 import HTTP11Connection
@@ -24,7 +24,7 @@ from .http11 import HTTP11Connection
 ReleaseCallback = typing.Callable[["HTTPConnection"], typing.Awaitable[None]]
 
 
-class HTTPConnection(Dispatcher):
+class HTTPConnection(AsyncDispatcher):
     def __init__(
         self,
         origin: typing.Union[str, Origin],

--- a/httpcore/dispatch/connection_pool.py
+++ b/httpcore/dispatch/connection_pool.py
@@ -12,7 +12,7 @@ from ..config import (
 )
 from ..decoders import ACCEPT_ENCODING
 from ..exceptions import PoolTimeout
-from ..interfaces import ConcurrencyBackend, Dispatcher
+from ..interfaces import AsyncDispatcher, ConcurrencyBackend
 from ..models import Origin, Request, Response
 from .connection import HTTPConnection
 
@@ -77,7 +77,7 @@ class ConnectionStore:
         return len(self.all)
 
 
-class ConnectionPool(Dispatcher):
+class ConnectionPool(AsyncDispatcher):
     def __init__(
         self,
         *,

--- a/httpcore/dispatch/http11.py
+++ b/httpcore/dispatch/http11.py
@@ -4,7 +4,7 @@ import h11
 
 from ..config import DEFAULT_TIMEOUT_CONFIG, TimeoutConfig, TimeoutTypes
 from ..exceptions import ConnectTimeout, ReadTimeout
-from ..interfaces import BaseReader, BaseWriter, Dispatcher
+from ..interfaces import BaseReader, BaseWriter
 from ..models import Request, Response
 
 H11Event = typing.Union[

--- a/httpcore/dispatch/http2.py
+++ b/httpcore/dispatch/http2.py
@@ -6,7 +6,7 @@ import h2.events
 
 from ..config import DEFAULT_TIMEOUT_CONFIG, TimeoutConfig, TimeoutTypes
 from ..exceptions import ConnectTimeout, ReadTimeout
-from ..interfaces import BaseReader, BaseWriter, Dispatcher
+from ..interfaces import BaseReader, BaseWriter
 from ..models import Request, Response
 
 

--- a/httpcore/interfaces.py
+++ b/httpcore/interfaces.py
@@ -6,6 +6,7 @@ from types import TracebackType
 from .config import CertTypes, PoolLimits, TimeoutConfig, TimeoutTypes, VerifyTypes
 from .models import (
     URL,
+    AsyncRequestData,
     Headers,
     HeaderTypes,
     QueryParamTypes,
@@ -35,7 +36,7 @@ class AsyncDispatcher:
         method: str,
         url: URLTypes,
         *,
-        data: RequestData = b"",
+        data: AsyncRequestData = b"",
         params: QueryParamTypes = None,
         headers: HeaderTypes = None,
         stream: bool = False,
@@ -180,7 +181,7 @@ class ConcurrencyBackend:
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         raise NotImplementedError()  # pragma: no cover
 
-    def run_in_threadpool(
+    async def run_in_threadpool(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover

--- a/httpcore/interfaces.py
+++ b/httpcore/interfaces.py
@@ -184,3 +184,8 @@ class ConcurrencyBackend:
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover
+
+    def run(
+        self, coroutine: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover

--- a/httpcore/interfaces.py
+++ b/httpcore/interfaces.py
@@ -21,9 +21,9 @@ class Protocol(str, enum.Enum):
     HTTP_2 = "HTTP/2"
 
 
-class Dispatcher:
+class AsyncDispatcher:
     """
-    Base class for dispatcher classes, that handle sending the request.
+    Base class for async dispatcher classes, that handle sending the request.
 
     Stubs out the interface, as well as providing a `.request()` convienence
     implementation, to make it easy to use or test stand-alone dispatchers,
@@ -44,10 +44,9 @@ class Dispatcher:
         timeout: TimeoutTypes = None
     ) -> Response:
         request = Request(method, url, data=data, params=params, headers=headers)
-        response = await self.send(
+        return await self.send(
             request, stream=stream, verify=verify, cert=cert, timeout=timeout
         )
-        return response
 
     async def send(
         self,
@@ -62,7 +61,7 @@ class Dispatcher:
     async def close(self) -> None:
         pass  # pragma: nocover
 
-    async def __aenter__(self) -> "Dispatcher":
+    async def __aenter__(self) -> "AsyncDispatcher":
         return self
 
     async def __aexit__(
@@ -72,6 +71,58 @@ class Dispatcher:
         traceback: TracebackType = None,
     ) -> None:
         await self.close()
+
+
+class Dispatcher:
+    """
+    Base class for syncronous dispatcher classes, that handle sending the request.
+
+    Stubs out the interface, as well as providing a `.request()` convienence
+    implementation, to make it easy to use or test stand-alone dispatchers,
+    without requiring a complete `Client` instance.
+    """
+
+    def request(
+        self,
+        method: str,
+        url: URLTypes,
+        *,
+        data: RequestData = b"",
+        params: QueryParamTypes = None,
+        headers: HeaderTypes = None,
+        stream: bool = False,
+        verify: VerifyTypes = None,
+        cert: CertTypes = None,
+        timeout: TimeoutTypes = None
+    ) -> Response:
+        request = Request(method, url, data=data, params=params, headers=headers)
+        return self.send(
+            request, stream=stream, verify=verify, cert=cert, timeout=timeout
+        )
+
+    def send(
+        self,
+        request: Request,
+        stream: bool = False,
+        verify: VerifyTypes = None,
+        cert: CertTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> Response:
+        raise NotImplementedError()  # pragma: nocover
+
+    def close(self) -> None:
+        pass  # pragma: nocover
+
+    def __enter__(self) -> "Dispatcher":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        self.close()
 
 
 class BaseReader:
@@ -127,4 +178,9 @@ class ConcurrencyBackend:
         raise NotImplementedError()  # pragma: no cover
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
+        raise NotImplementedError()  # pragma: no cover
+
+    def run_in_threadpool(
+        self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover

--- a/httpcore/models.py
+++ b/httpcore/models.py
@@ -50,7 +50,9 @@ AuthTypes = typing.Union[
     typing.Callable[["Request"], "Request"],
 ]
 
-RequestData = typing.Union[dict, bytes, typing.AsyncIterator[bytes]]
+AsyncRequestData = typing.Union[dict, bytes, typing.AsyncIterator[bytes]]
+
+RequestData = typing.Union[dict, bytes, typing.Iterator[bytes]]
 
 ResponseContent = typing.Union[bytes, typing.AsyncIterator[bytes]]
 
@@ -474,7 +476,7 @@ class Request:
         method: str,
         url: typing.Union[str, URL],
         *,
-        data: RequestData = b"",
+        data: AsyncRequestData = b"",
         json: typing.Any = None,
         params: QueryParamTypes = None,
         headers: HeaderTypes = None,
@@ -499,6 +501,7 @@ class Request:
             self.content = urlencode(data, doseq=True).encode("utf-8")
             self.headers["Content-Type"] = "application/x-www-form-urlencoded"
         else:
+            assert hasattr(data, "__aiter__")
             self.is_streaming = True
             self.content_aiter = data
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -4,9 +4,9 @@ import pytest
 
 from httpcore import (
     URL,
+    AsyncDispatcher,
     CertTypes,
     Client,
-    AsyncDispatcher,
     Request,
     Response,
     TimeoutTypes,

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -6,7 +6,7 @@ from httpcore import (
     URL,
     CertTypes,
     Client,
-    Dispatcher,
+    AsyncDispatcher,
     Request,
     Response,
     TimeoutTypes,
@@ -14,7 +14,7 @@ from httpcore import (
 )
 
 
-class MockDispatch(Dispatcher):
+class MockDispatch(AsyncDispatcher):
     async def send(
         self,
         request: Request,

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -5,10 +5,10 @@ import pytest
 
 from httpcore import (
     URL,
+    AsyncDispatcher,
     CertTypes,
     Client,
     Cookies,
-    AsyncDispatcher,
     Request,
     Response,
     TimeoutTypes,

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -8,7 +8,7 @@ from httpcore import (
     CertTypes,
     Client,
     Cookies,
-    Dispatcher,
+    AsyncDispatcher,
     Request,
     Response,
     TimeoutTypes,
@@ -16,7 +16,7 @@ from httpcore import (
 )
 
 
-class MockDispatch(Dispatcher):
+class MockDispatch(AsyncDispatcher):
     async def send(
         self,
         request: Request,

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -7,7 +7,7 @@ from httpcore import (
     URL,
     AsyncClient,
     CertTypes,
-    Dispatcher,
+    AsyncDispatcher,
     RedirectBodyUnavailable,
     RedirectLoop,
     Request,
@@ -19,7 +19,7 @@ from httpcore import (
 )
 
 
-class MockDispatch(Dispatcher):
+class MockDispatch(AsyncDispatcher):
     async def send(
         self,
         request: Request,

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -6,8 +6,8 @@ import pytest
 from httpcore import (
     URL,
     AsyncClient,
-    CertTypes,
     AsyncDispatcher,
+    CertTypes,
     RedirectBodyUnavailable,
     RedirectLoop,
     Request,

--- a/tests/dispatch/test_threaded.py
+++ b/tests/dispatch/test_threaded.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from httpcore import (
+    CertTypes,
+    Client,
+    Dispatcher,
+    Request,
+    Response,
+    TimeoutTypes,
+    VerifyTypes,
+)
+
+
+class MockDispatch(Dispatcher):
+    def send(
+        self,
+        request: Request,
+        stream: bool = False,
+        verify: VerifyTypes = None,
+        cert: CertTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> Response:
+        body = json.dumps({"hello": "world"}).encode()
+        return Response(200, content=body, request=request)
+
+
+def test_threaded_dispatch():
+    """
+    Use a syncronous 'Dispatcher' class with the client.
+    Calls to the dispatcher will end up running within a thread pool.
+    """
+    url = "https://example.org/"
+    with Client(dispatch=MockDispatch()) as client:
+        response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+
+def test_dispatch_class():
+    """
+    Use a syncronous 'Dispatcher' class directly.
+    """
+    url = "https://example.org/"
+    with MockDispatch() as dispatcher:
+        response = dispatcher.request("GET", url)
+
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,16 +38,16 @@ def test_post(server):
     assert response.reason_phrase == "OK"
 
 
-# @threadpool
-# def test_post_byte_iterator(server):
-#     def data():
-#         yield b"Hello"
-#         yield b", "
-#         yield b"world!"
-#
-#     response = httpcore.post("http://127.0.0.1:8000/", data=data())
-#     assert response.status_code == 200
-#     assert response.reason_phrase == "OK"
+@threadpool
+def test_post_byte_iterator(server):
+    def data():
+        yield b"Hello"
+        yield b", "
+        yield b"world!"
+
+    response = httpcore.post("http://127.0.0.1:8000/", data=data())
+    assert response.status_code == 200
+    assert response.reason_phrase == "OK"
 
 
 @threadpool

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,14 @@ def test_post(server):
     assert response.reason_phrase == "OK"
 
 
+# @threadpool
+# def test_post_byte_iterator(server):
+#     data = (i for i in [b"Hello", b", ", b"world!"])
+#     response = httpcore.post("http://127.0.0.1:8000/", data=data)
+#     assert response.status_code == 200
+#     assert response.reason_phrase == "OK"
+
+
 @threadpool
 def test_options(server):
     response = httpcore.options("http://127.0.0.1:8000/")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,8 +40,12 @@ def test_post(server):
 
 # @threadpool
 # def test_post_byte_iterator(server):
-#     data = (i for i in [b"Hello", b", ", b"world!"])
-#     response = httpcore.post("http://127.0.0.1:8000/", data=data)
+#     def data():
+#         yield b"Hello"
+#         yield b", "
+#         yield b"world!"
+#
+#     response = httpcore.post("http://127.0.0.1:8000/", data=data())
 #     assert response.status_code == 200
 #     assert response.reason_phrase == "OK"
 


### PR DESCRIPTION
This PR means that we now have two styles of dispatch class which can be used...

* `Dispatcher` - A standard sync dispatch interface.
* `AsyncDispatcher` - An async dispatch interface.

Either style can be passed to the client. The sync version ends up being run within a thread pool.

### What this will give us

* The ability to write a WSGI dispatcher.
* The ability to write a `urllib3` based dispatcher.

### What's not quite done

I've not quite figured out how to handle the bridging for the request and response classes.

* We currently only have a `Request` class. We'll actually want an `AsyncRequest` and `Request` class, and have a sync method for reading the request body on the `Request` class.
* We currently have both async and sync variants of Response, but we only ever return the async case. We'll need to allow returning a sync response (ie. allow a sync generator for the body)