### PR TITLE
Drop Host header for HTTP/2

### DIFF
--- a/httpcore/dispatch/http11.py
+++ b/httpcore/dispatch/http11.py
@@ -46,6 +46,9 @@ class HTTP11Connection:
         method = request.method.encode("ascii")
         target = request.url.full_path.encode("ascii")
         headers = request.headers.raw
+        if 'Host' not in request.headers:
+            host = request.url.authority.encode("ascii")
+            headers = [(b"host", host)] + headers
         event = h11.Request(method=method, target=target, headers=headers)
         await self._send_event(event, timeout)
 

--- a/httpcore/models.py
+++ b/httpcore/models.py
@@ -523,14 +523,11 @@ class Request:
     def prepare(self) -> None:
         auto_headers = []  # type: typing.List[typing.Tuple[bytes, bytes]]
 
-        has_host = "host" in self.headers
         has_content_length = (
             "content-length" in self.headers or "transfer-encoding" in self.headers
         )
         has_accept_encoding = "accept-encoding" in self.headers
 
-        if not has_host and self.url.authority:
-            auto_headers.append((b"host", self.url.authority.encode("ascii")))
         if not has_content_length:
             if self.is_streaming:
                 auto_headers.append((b"transfer-encoding", b"chunked"))

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -8,11 +8,11 @@ def test_request_repr():
     assert repr(request) == "<Request('GET', 'http://example.org')>"
 
 
-def test_host_header():
+def test_no_content():
     request = httpcore.Request("GET", "http://example.org")
     request.prepare()
     assert request.headers == httpcore.Headers(
-        [(b"host", b"example.org"), (b"accept-encoding", b"deflate, gzip, br")]
+        [(b"accept-encoding", b"deflate, gzip, br")]
     )
 
 
@@ -21,7 +21,6 @@ def test_content_length_header():
     request.prepare()
     assert request.headers == httpcore.Headers(
         [
-            (b"host", b"example.org"),
             (b"content-length", b"8"),
             (b"accept-encoding", b"deflate, gzip, br"),
         ]
@@ -33,7 +32,6 @@ def test_url_encoded_data():
     request.prepare()
     assert request.headers == httpcore.Headers(
         [
-            (b"host", b"example.org"),
             (b"content-length", b"8"),
             (b"accept-encoding", b"deflate, gzip, br"),
             (b"content-type", b"application/x-www-form-urlencoded"),
@@ -52,7 +50,6 @@ def test_transfer_encoding_header():
     request.prepare()
     assert request.headers == httpcore.Headers(
         [
-            (b"host", b"example.org"),
             (b"transfer-encoding", b"chunked"),
             (b"accept-encoding", b"deflate, gzip, br"),
         ]
@@ -75,7 +72,7 @@ def test_override_accept_encoding_header():
     request = httpcore.Request("GET", "http://example.org", headers=headers)
     request.prepare()
     assert request.headers == httpcore.Headers(
-        [(b"host", b"example.org"), (b"accept-encoding", b"identity")]
+        [(b"accept-encoding", b"identity")]
     )
 
 
@@ -90,7 +87,6 @@ def test_override_content_length_header():
     request.prepare()
     assert request.headers == httpcore.Headers(
         [
-            (b"host", b"example.org"),
             (b"accept-encoding", b"deflate, gzip, br"),
             (b"content-length", b"8"),
         ]


### PR DESCRIPTION
Don't setup a 'Host' header automatically under `prepare_request`.
Only send the header with HTTP/1.1

Closes #80