### PR TITLE
Cause `unasync --check` failure

### DIFF
--- a/httpcore/_sync/dispatch.py
+++ b/httpcore/_sync/dispatch.py
@@ -15,7 +15,7 @@ class SyncByteStream:
         """
         Yield bytes representing the request or response body.
         """
-        yield b""
+        yield b""  # Changed sync only. Should cause 'unasync --check' to fail.
 
     def close(self) -> None:
         """


### PR DESCRIPTION
This PR makes a change in one of the sync modules, rather than making a change in the unasync modules and running `scripts/lint` to perform linting and unasync'ing.

It should fail the CI check stage.