### PR TITLE
Timeout as dict

### DIFF
--- a/httpcore/_async/dispatch.py
+++ b/httpcore/_async/dispatch.py
@@ -1,6 +1,6 @@
 from ssl import SSLContext
 from types import TracebackType
-from typing import AsyncIterator, List, Optional, Tuple, Type
+from typing import AsyncIterator, Dict, List, Tuple, Type
 
 
 class AsyncByteStream:
@@ -37,30 +37,28 @@ class AsyncHTTPTransport:
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         """
         The interface for sending a single HTTP request, and returning a response.
 
         **Parameters:**
 
-        * **method** - *bytes* - The HTTP method, such as `b'GET'`.
-        * **url** - *(bytes, bytes, int, bytes)* - The URL as a 4-tuple of (scheme, host, port, path).
-        * **headers** - *list of (bytes, bytes), optional* - Any HTTP headers to send with the request.
-        * **stream** - *bytes async iterator, optional* - The body of the HTTP request.
-        * **timeout** - *(float, float, float, float), all optional.* - A tuple of timeout values for (read, write, connect, pool acquiry) operations.
+        * **method** - `bytes` - The HTTP method, such as `b'GET'`.
+        * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of (scheme, host, port, path).
+        * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers to send with the request.
+        * **stream** - `Optional[AsyncByteStream]` - The body of the HTTP request.
+        * **timeout** - `Optional[Dict[str, float]]` - A dictionary of timeout values for I/O operations.
 
         ** Returns:**
 
         A five-tuple of:
 
-        * **http_version** - *bytes* - The HTTP version used by the server, such as `b'HTTP/1.1'`.
-        * **status_code** - *int* - The HTTP status code, such as `200`.
-        * **reason_phrase** - *bytes* - Any HTTP reason phrase, such as `b'OK'`.
-        * **headers** - *list of (bytes, bytes)* - Any HTTP headers included on the response.
-        * **stream** - *bytes async iterator* - The body of the HTTP response.
+        * **http_version** - `bytes` - The HTTP version used by the server, such as `b'HTTP/1.1'`.
+        * **status_code** - `int` - The HTTP status code, such as `200`.
+        * **reason_phrase** - `bytes` - Any HTTP reason phrase, such as `b'OK'`.
+        * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included on the response.
+        * **stream** - `AsyncByteStream` - The body of the HTTP response.
         """
         raise NotImplementedError()
 
@@ -88,9 +86,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
 
     **Parameters:**
 
-    * **ssl_context** - *SSLContext, optional* - An SSL context to use for verifying connections.
-    * **max_keepalive** - *int, optional* - The maximum number of keep alive connections to maintain in the pool.
-    * **max_connections** - *int, optional* - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
+    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for verifying connections.
+    * **max_keepalive** - `Optional[int]` - The maximum number of keep alive connections to maintain in the pool.
+    * **max_connections** - `Optional[int]` - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
     """
 
     def __init__(
@@ -107,9 +105,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         raise NotImplementedError()
 
@@ -123,12 +119,12 @@ class AsyncHTTPProxy(AsyncHTTPTransport):
 
     **Parameters:**
 
-    * **proxy_url** - *(bytes, bytes, int, bytes)* - The URL of the proxy service as a 4-tuple of (scheme, host, port, path).
-    * **proxy_headers** - *list of (bytes, bytes), optional* - An SSL context to use for verifying connections.
-    * **proxy_mode** - *str, optional* - A proxy mode to operate in. May be "DEFAULT", "FORWARD_ONLY", or "TUNNEL_ONLY".
-    * **ssl_context** - *SSLContext, optional* - An SSL context to use for verifying connections.
-    * **max_keepalive** - *int, optional* - The maximum number of keep alive connections to maintain in the pool.
-    * **max_connections** - *int, optional* - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
+    * **proxy_url** - `Tuple[bytes, bytes, int, bytes]` - The URL of the proxy service as a 4-tuple of (scheme, host, port, path).
+    * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of proxy headers to include.
+    * **proxy_mode** - `Optional[str]` - A proxy mode to operate in. May be "DEFAULT", "FORWARD_ONLY", or "TUNNEL_ONLY".
+    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for verifying connections.
+    * **max_keepalive** - `Optional[int]` - The maximum number of keep alive connections to maintain in the pool.
+    * **max_connections** - `Optional[int]` - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
     """
 
     def __init__(
@@ -148,9 +144,7 @@ class AsyncHTTPProxy(AsyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         raise NotImplementedError()
 

--- a/httpcore/_async/dispatch.py
+++ b/httpcore/_async/dispatch.py
@@ -1,6 +1,6 @@
 from ssl import SSLContext
 from types import TracebackType
-from typing import AsyncIterator, Dict, List, Tuple, Type
+from typing import AsyncIterator, Dict, List, Optional, Tuple, Type
 
 
 class AsyncByteStream:

--- a/httpcore/_async/dispatch.py
+++ b/httpcore/_async/dispatch.py
@@ -37,7 +37,7 @@ class AsyncHTTPTransport:
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         """
         The interface for sending a single HTTP request, and returning a response.
@@ -48,7 +48,7 @@ class AsyncHTTPTransport:
         * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers to send with the request.
         * **stream** - `Optional[AsyncByteStream]` - The body of the HTTP request.
-        * **timeout** - `Optional[Dict[str, float]]` - A dictionary of timeout values for I/O operations.
+        * **timeout** - `Optional[Dict[str, Optional[float]]]` - A dictionary of timeout values for I/O operations.
 
         ** Returns:**
 
@@ -105,7 +105,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         raise NotImplementedError()
 
@@ -144,7 +144,7 @@ class AsyncHTTPProxy(AsyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: AsyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         raise NotImplementedError()
 

--- a/httpcore/_sync/dispatch.py
+++ b/httpcore/_sync/dispatch.py
@@ -37,7 +37,7 @@ class SyncHTTPTransport:
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         """
         The interface for sending a single HTTP request, and returning a response.
@@ -48,7 +48,7 @@ class SyncHTTPTransport:
         * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers to send with the request.
         * **stream** - `Optional[SyncByteStream]` - The body of the HTTP request.
-        * **timeout** - `Optional[Dict[str, float]]` - A dictionary of timeout values for I/O operations.
+        * **timeout** - `Optional[Dict[str, Optional[float]]]` - A dictionary of timeout values for I/O operations.
 
         ** Returns:**
 
@@ -105,7 +105,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         raise NotImplementedError()
 
@@ -144,7 +144,7 @@ class SyncHTTPProxy(SyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Dict[str, float] = None,
+        timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         raise NotImplementedError()
 

--- a/httpcore/_sync/dispatch.py
+++ b/httpcore/_sync/dispatch.py
@@ -1,6 +1,6 @@
 from ssl import SSLContext
 from types import TracebackType
-from typing import Iterator, Dict, List, Tuple, Type
+from typing import Iterator, Dict, List, Optional, Tuple, Type
 
 
 class SyncByteStream:

--- a/httpcore/_sync/dispatch.py
+++ b/httpcore/_sync/dispatch.py
@@ -15,7 +15,7 @@ class SyncByteStream:
         """
         Yield bytes representing the request or response body.
         """
-        yield b""
+        yield b""  # Changed sync only. Should cause 'unasync --check' to fail.
 
     def close(self) -> None:
         """

--- a/httpcore/_sync/dispatch.py
+++ b/httpcore/_sync/dispatch.py
@@ -1,6 +1,6 @@
 from ssl import SSLContext
 from types import TracebackType
-from typing import Iterator, List, Optional, Tuple, Type
+from typing import Iterator, Dict, List, Tuple, Type
 
 
 class SyncByteStream:
@@ -15,7 +15,7 @@ class SyncByteStream:
         """
         Yield bytes representing the request or response body.
         """
-        yield b""  # Changed sync only. Should cause 'unasync --check' to fail.
+        yield b""
 
     def close(self) -> None:
         """
@@ -37,30 +37,28 @@ class SyncHTTPTransport:
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         """
         The interface for sending a single HTTP request, and returning a response.
 
         **Parameters:**
 
-        * **method** - *bytes* - The HTTP method, such as `b'GET'`.
-        * **url** - *(bytes, bytes, int, bytes)* - The URL as a 4-tuple of (scheme, host, port, path).
-        * **headers** - *list of (bytes, bytes), optional* - Any HTTP headers to send with the request.
-        * **stream** - *bytes async iterator, optional* - The body of the HTTP request.
-        * **timeout** - *(float, float, float, float), all optional.* - A tuple of timeout values for (read, write, connect, pool acquiry) operations.
+        * **method** - `bytes` - The HTTP method, such as `b'GET'`.
+        * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of (scheme, host, port, path).
+        * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers to send with the request.
+        * **stream** - `Optional[SyncByteStream]` - The body of the HTTP request.
+        * **timeout** - `Optional[Dict[str, float]]` - A dictionary of timeout values for I/O operations.
 
         ** Returns:**
 
         A five-tuple of:
 
-        * **http_version** - *bytes* - The HTTP version used by the server, such as `b'HTTP/1.1'`.
-        * **status_code** - *int* - The HTTP status code, such as `200`.
-        * **reason_phrase** - *bytes* - Any HTTP reason phrase, such as `b'OK'`.
-        * **headers** - *list of (bytes, bytes)* - Any HTTP headers included on the response.
-        * **stream** - *bytes async iterator* - The body of the HTTP response.
+        * **http_version** - `bytes` - The HTTP version used by the server, such as `b'HTTP/1.1'`.
+        * **status_code** - `int` - The HTTP status code, such as `200`.
+        * **reason_phrase** - `bytes` - Any HTTP reason phrase, such as `b'OK'`.
+        * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included on the response.
+        * **stream** - `SyncByteStream` - The body of the HTTP response.
         """
         raise NotImplementedError()
 
@@ -88,9 +86,9 @@ class SyncConnectionPool(SyncHTTPTransport):
 
     **Parameters:**
 
-    * **ssl_context** - *SSLContext, optional* - An SSL context to use for verifying connections.
-    * **max_keepalive** - *int, optional* - The maximum number of keep alive connections to maintain in the pool.
-    * **max_connections** - *int, optional* - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
+    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for verifying connections.
+    * **max_keepalive** - `Optional[int]` - The maximum number of keep alive connections to maintain in the pool.
+    * **max_connections** - `Optional[int]` - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
     """
 
     def __init__(
@@ -107,9 +105,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         raise NotImplementedError()
 
@@ -123,12 +119,12 @@ class SyncHTTPProxy(SyncHTTPTransport):
 
     **Parameters:**
 
-    * **proxy_url** - *(bytes, bytes, int, bytes)* - The URL of the proxy service as a 4-tuple of (scheme, host, port, path).
-    * **proxy_headers** - *list of (bytes, bytes), optional* - An SSL context to use for verifying connections.
-    * **proxy_mode** - *str, optional* - A proxy mode to operate in. May be "DEFAULT", "FORWARD_ONLY", or "TUNNEL_ONLY".
-    * **ssl_context** - *SSLContext, optional* - An SSL context to use for verifying connections.
-    * **max_keepalive** - *int, optional* - The maximum number of keep alive connections to maintain in the pool.
-    * **max_connections** - *int, optional* - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
+    * **proxy_url** - `Tuple[bytes, bytes, int, bytes]` - The URL of the proxy service as a 4-tuple of (scheme, host, port, path).
+    * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of proxy headers to include.
+    * **proxy_mode** - `Optional[str]` - A proxy mode to operate in. May be "DEFAULT", "FORWARD_ONLY", or "TUNNEL_ONLY".
+    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for verifying connections.
+    * **max_keepalive** - `Optional[int]` - The maximum number of keep alive connections to maintain in the pool.
+    * **max_connections** - `Optional[int]` - The maximum number of HTTP connections to allow. Attempting to establish a connection beyond this limit will block for the duration specified in the pool acquiry timeout.
     """
 
     def __init__(
@@ -148,9 +144,7 @@ class SyncHTTPProxy(SyncHTTPTransport):
         url: Tuple[bytes, bytes, int, bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: SyncByteStream = None,
-        timeout: Tuple[
-            Optional[float], Optional[float], Optional[float], Optional[float]
-        ] = None,
+        timeout: Dict[str, float] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         raise NotImplementedError()
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: HTTP Core
 site_description: Do one thing, and do it well.
-site_url: https://www.encode.org/httpcore
+site_url: https://www.encode.io/httpcore
 
 theme:
     name: 'material'


### PR DESCRIPTION
* Timeouts as `Dict[str, Optional[float]]`.
* Tweak docstring style.

I've used `Optional[float]` here. We could have just used `float`, and mandate that any missing key should be treated as `None`, but:

1. That's a bit awkward for user-code to build up the dict, given a config model.
2. It's nicer if we can have `None` as an explicit "Off". (Eg. allows us to provide non-off defaults if we want to.)