### PR TITLE
Add `ConnectionState.CLOSED`

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -18,9 +18,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self, ssl_context: SSLContext = None,
     ):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
-        self.connections = (
-            {}
-        )  # type: Dict[Tuple[bytes, bytes, int], Set[AsyncHTTP11Connection]]
+        self.connections: Dict[
+            Tuple[bytes, bytes, int], Set[AsyncHTTP11Connection]
+        ] = {}
 
     async def request(
         self,
@@ -31,9 +31,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         origin = url[:3]
-        connections = self.connections.get(
-            origin, set()
-        )  # type: Set[AsyncHTTP11Connection]
+        connections: Set[AsyncHTTP11Connection] = self.connections.get(origin, set())
 
         # Determine expired keep alive connections on this origin.
         reuse_connection = None

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -15,8 +15,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     """
 
     def __init__(
-        self,
-        ssl_context: SSLContext = None,
+        self, ssl_context: SSLContext = None,
     ):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.connections = (
@@ -68,7 +67,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         )
 
     async def request_finished(self, connection: AsyncHTTP11Connection):
-        if connection.socket is None:
+        if connection.state == ConnectionState.CLOSED:
             self.connections[connection.origin].remove(connection)
             if not self.connections[connection.origin]:
                 self.connections.pop(connection.origin)

--- a/httpcore/_backends/auto.py
+++ b/httpcore/_backends/auto.py
@@ -16,7 +16,7 @@ class AutoBackend(AsyncBackend):
             if backend == "asyncio":
                 from .asyncio import AsyncioBackend
 
-                self._backend_implementation = AsyncioBackend()  # type: AsyncBackend
+                self._backend_implementation: AsyncBackend = AsyncioBackend()
             elif backend == "trio":
                 from .trio import TrioBackend
 

--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -19,6 +19,7 @@ class ProtocolError(Exception):
 
 # Timeout errors
 
+
 class ConnectTimeout(Exception):
     pass
 
@@ -32,6 +33,7 @@ class WriteTimeout(Exception):
 
 
 # Network errors
+
 
 class NetworkError(Exception):
     pass

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -15,8 +15,7 @@ class SyncConnectionPool(SyncHTTPTransport):
     """
 
     def __init__(
-        self,
-        ssl_context: SSLContext = None,
+        self, ssl_context: SSLContext = None,
     ):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.connections = (
@@ -68,7 +67,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         )
 
     def request_finished(self, connection: SyncHTTP11Connection):
-        if connection.socket is None:
+        if connection.state == ConnectionState.CLOSED:
             self.connections[connection.origin].remove(connection)
             if not self.connections[connection.origin]:
                 self.connections.pop(connection.origin)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -18,9 +18,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         self, ssl_context: SSLContext = None,
     ):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
-        self.connections = (
-            {}
-        )  # type: Dict[Tuple[bytes, bytes, int], Set[SyncHTTP11Connection]]
+        self.connections: Dict[
+            Tuple[bytes, bytes, int], Set[SyncHTTP11Connection]
+        ] = {}
 
     def request(
         self,
@@ -31,9 +31,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         timeout: Dict[str, Optional[float]] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         origin = url[:3]
-        connections = self.connections.get(
-            origin, set()
-        )  # type: Set[SyncHTTP11Connection]
+        connections: Set[SyncHTTP11Connection] = self.connections.get(origin, set())
 
         # Determine expired keep alive connections on this origin.
         reuse_connection = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,5 +1,4 @@
 import enum
-import time
 from ssl import SSLContext
 from typing import (
     Iterator,
@@ -15,7 +14,7 @@ from typing import (
 import h11
 
 from .._backends.auto import SyncSocketStream, SyncBackend
-from .._exceptions import map_exceptions, ProtocolError
+from .._exceptions import ProtocolError, map_exceptions
 from .base import SyncByteStream, SyncHTTPTransport
 
 H11Event = Union[
@@ -29,9 +28,10 @@ H11Event = Union[
 
 
 class ConnectionState(enum.IntEnum):
-    IDLE = 0
-    PENDING = 1
-    ACTIVE = 2
+    PENDING = 0
+    ACTIVE = 1
+    IDLE = 2
+    CLOSED = 3
 
 
 class SyncHTTP11Connection(SyncHTTPTransport):
@@ -190,13 +190,15 @@ class SyncHTTP11Connection(SyncHTTPTransport):
             self.request_finished(self)
 
     def close(self) -> None:
-        if self.h11_state.our_state is h11.MUST_CLOSE:
-            event = h11.ConnectionClosed()
-            self.h11_state.send(event)
+        if self.state != ConnectionState.CLOSED:
+            self.state = ConnectionState.CLOSED
 
-        if self.socket is not None:
-            self.socket.close()
-            self.socket = None
+            if self.h11_state.our_state is h11.MUST_CLOSE:
+                event = h11.ConnectionClosed()
+                self.h11_state.send(event)
+
+            if self.socket is not None:
+                self.socket.close()
 
     def is_connection_dropped(self) -> bool:
         return self.socket is not None and self.socket.is_connection_dropped()

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -169,14 +169,11 @@ class SyncHTTP11Connection(SyncHTTPTransport):
                 event = self.h11_state.next_event()
 
             if event is h11.NEED_DATA:
-                try:
-                    data = self.socket.read(self.READ_NUM_BYTES, timeout)
-                except OSError:  # pragma: nocover
-                    data = b""
+                data = self.socket.read(self.READ_NUM_BYTES, timeout)
                 self.h11_state.receive_data(data)
             else:
                 assert event is not h11.NEED_DATA
-                break  # pragma: no cover
+                break
         return event
 
     def _response_closed(self) -> None:


### PR DESCRIPTION
A little bit of tidying up.

To follow up on this we might want to make all attributes private on `AsyncHTTP11Connection`, except for `.state` and `.origin`.