### PR TITLE
Drop request_finished on http connections

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -42,12 +42,10 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
         origin: Tuple[bytes, bytes, int],
         socket: AsyncSocketStream = None,
         ssl_context: SSLContext = None,
-        request_finished: Callable[["AsyncHTTP11Connection"], Awaitable[None]] = None,
     ):
         self.origin = origin
         self.socket = socket
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
-        self.request_finished = request_finished
 
         self.backend = AutoBackend()
         self.h11_state = h11.Connection(our_role=h11.CLIENT)
@@ -182,9 +180,6 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
             self.state = ConnectionState.IDLE
         else:
             await self.close()
-
-        if self.request_finished is not None:
-            await self.request_finished(self)
 
     async def close(self) -> None:
         if self.state != ConnectionState.CLOSED:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -42,12 +42,10 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         origin: Tuple[bytes, bytes, int],
         socket: SyncSocketStream = None,
         ssl_context: SSLContext = None,
-        request_finished: Callable[["SyncHTTP11Connection"], Awaitable[None]] = None,
     ):
         self.origin = origin
         self.socket = socket
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
-        self.request_finished = request_finished
 
         self.backend = SyncBackend()
         self.h11_state = h11.Connection(our_role=h11.CLIENT)
@@ -182,9 +180,6 @@ class SyncHTTP11Connection(SyncHTTPTransport):
             self.state = ConnectionState.IDLE
         else:
             self.close()
-
-        if self.request_finished is not None:
-            self.request_finished(self)
 
     def close(self) -> None:
         if self.state != ConnectionState.CLOSED:


### PR DESCRIPTION
Changes the mechanism by which `stream.close()` ends up either closing connections or releasing them back to the pool.

The change is more code, but it simplifies the flow of execution, since there's no longer any call back from the connection to the connection pool.

Instead we make sure that the connection pool wraps up the returned stream object in a class that calls into `AsyncConnectionPool._request_closed` when the client releases the stream.
