### PR TITLE
Async close rename

### DIFF
--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -55,7 +55,7 @@ class AsyncByteStream:
         async for chunk in self.iterator:
             yield chunk
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         """
         Must be called by the client to indicate that the stream has been closed.
         """
@@ -102,7 +102,7 @@ class AsyncHTTPTransport:
         """
         raise NotImplementedError()  # pragma: nocover
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         """
         Close the implementation, which should close any outstanding response streams,
         and any keep alive connections.
@@ -117,4 +117,4 @@ class AsyncHTTPTransport:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        await self.close()
+        await self.aclose()

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -163,9 +163,9 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
             self.h11_state.start_next_cycle()
             self.state = ConnectionState.IDLE
         else:
-            await self.close()
+            await self.aclose()
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         if self.state != ConnectionState.CLOSED:
             self.state = ConnectionState.CLOSED
 
@@ -173,7 +173,7 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
                 event = h11.ConnectionClosed()
                 self.h11_state.send(event)
 
-            await self.socket.close()
+            await self.socket.aclose()
 
     def is_connection_dropped(self) -> bool:
         return self.socket.is_connection_dropped()

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -150,11 +150,11 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
     def is_connection_dropped(self) -> bool:
         return self.socket.is_connection_dropped()
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         if self.state != ConnectionState.CLOSED:
             self.state = ConnectionState.CLOSED
 
-            await self.socket.close()
+            await self.socket.aclose()
 
     async def wait_for_outgoing_flow(
         self, stream_id: int, timeout: Dict[str, Optional[float]]
@@ -247,7 +247,7 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
             if self.state == ConnectionState.ACTIVE:
                 self.state = ConnectionState.IDLE
             elif self.state == ConnectionState.FULL:
-                await self.close()
+                await self.aclose()
 
 
 class AsyncHTTP2Stream:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -16,7 +16,7 @@ async def read_body(stream: AsyncByteStream) -> bytes:
     try:
         return b"".join([chunk async for chunk in stream])
     finally:
-        await stream.close()
+        await stream.aclose()
 
 
 class AsyncHTTPProxy(AsyncConnectionPool):

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -149,12 +149,12 @@ class SocketStream(AsyncSocketStream):
                     self.stream_writer.drain(), timeout.get("write")
                 )
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         # NOTE: StreamWriter instances expose a '.wait_closed()' coroutine function,
         # but using it has caused compatibility issues with certain sites in
         # the past (see https://github.com/encode/httpx/issues/634), which is
         # why we don't call it here.
-        # This is fine, though, because '.close()' schedules the actual closing of the
+        # This is fine, though, because '.aclose()' schedules the actual closing of the
         # stream, meaning that at best it will happen during the next event loop
         # iteration, and at worst asyncio will take care of it on program exit.
         async with self.write_lock:

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -27,7 +27,7 @@ class AsyncSocketStream:
     async def write(self, data: bytes, timeout: Dict[str, Optional[float]]) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
     def is_connection_dropped(self) -> bool:

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -77,7 +77,7 @@ class SocketStream(AsyncSocketStream):
                 with trio.fail_after(write_timeout):
                     return await self.stream.send_all(data)
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         async with self.write_lock:
             with map_exceptions({trio.BrokenResourceError: CloseError}):
                 await self.stream.aclose()

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -10,7 +10,7 @@ async def read_body(stream):
             body.append(chunk)
         return b"".join(body)
     finally:
-        await stream.close()
+        await stream.aclose()
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/unasync.py
+++ b/unasync.py
@@ -11,6 +11,7 @@ SUBS = [
     ('async with', 'with'),
     ('async for', 'for'),
     ('await ', ''),
+    ('aclose', 'close'),
     ('__aenter__', '__enter__'),
     ('__aexit__', '__exit__'),
     ('__aiter__', '__iter__'),


### PR DESCRIPTION
PR to solve #9

- Updated `async close` methods to `async aclose`
- Updated `unasync.py` to map `aclose` -> `close`
- Updates async tests