### PR TITLE
[WIP] Add semaphore to wait for streams to become available.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -17,13 +17,8 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import (
-    AsyncLock,
-    AsyncSocketStream,
-    AutoBackend,
-    AsyncSemaphore
-)
-from .._exceptions import ProtocolError, PoolTimeout
+from .._backends.auto import AsyncLock, AsyncSemaphore, AsyncSocketStream, AutoBackend
+from .._exceptions import PoolTimeout, ProtocolError
 from .base import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -76,7 +71,7 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
         if not hasattr(self, "_read_lock"):
             self._read_lock = self.backend.create_lock()
         return self._read_lock
-    
+
     @property
     def streams_semaphore(self) -> AsyncSemaphore:
         # We do this lazily, to make sure backend autodetection always

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -17,13 +17,8 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import (
-    SyncLock,
-    SyncSocketStream,
-    SyncBackend,
-    SyncSemaphore
-)
-from .._exceptions import ProtocolError, PoolTimeout
+from .._backends.auto import SyncLock, SyncSemaphore, SyncSocketStream, SyncBackend
+from .._exceptions import PoolTimeout, ProtocolError
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -17,8 +17,13 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
-from .._exceptions import ProtocolError
+from .._backends.auto import (
+    SyncLock,
+    SyncSocketStream,
+    SyncBackend,
+    SyncSemaphore
+)
+from .._exceptions import ProtocolError, PoolTimeout
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,
@@ -72,6 +77,17 @@ class SyncHTTP2Connection(SyncHTTPTransport):
             self._read_lock = self.backend.create_lock()
         return self._read_lock
 
+    @property
+    def streams_semaphore(self) -> SyncSemaphore:
+        # We do this lazily, to make sure backend autodetection always
+        # runs within an async context.
+        if not hasattr(self, "_streams_semaphore"):
+            semaphore_count = self.h2_state.remote_settings.max_concurrent_streams
+            self._streams_semaphore = self.backend.create_semaphore(
+                semaphore_count, PoolTimeout
+            )
+        return self._streams_semaphore
+
     def start_tls(
         self, hostname: bytes, timeout: Dict[str, Optional[float]] = None
     ):
@@ -91,20 +107,24 @@ class SyncHTTP2Connection(SyncHTTPTransport):
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         timeout = {} if timeout is None else timeout
 
-        with self.init_lock:
-            if not self.sent_connection_init:
-                # The very first stream is responsible for initiating the connection.
-                self.state = ConnectionState.ACTIVE
-                self.send_connection_init(timeout)
-                self.sent_connection_init = True
+        self.streams_semaphore.acquire()
+        try:
+            with self.init_lock:
+                if not self.sent_connection_init:
+                    # The very first stream is responsible for initiating the connection.
+                    self.state = ConnectionState.ACTIVE
+                    self.send_connection_init(timeout)
+                    self.sent_connection_init = True
 
-            try:
-                stream_id = self.h2_state.get_next_available_stream_id()
-            except NoAvailableStreamIDError:
-                self.state = ConnectionState.FULL
-                raise NewConnectionRequired()
-            else:
-                self.state = ConnectionState.ACTIVE
+                try:
+                    stream_id = self.h2_state.get_next_available_stream_id()
+                except NoAvailableStreamIDError:
+                    self.state = ConnectionState.FULL
+                    raise NewConnectionRequired()
+                else:
+                    self.state = ConnectionState.ACTIVE
+        finally:
+            self.streams_semaphore.release()
 
         h2_stream = SyncHTTP2Stream(stream_id=stream_id, connection=self)
         self.streams[stream_id] = h2_stream


### PR DESCRIPTION
This PR adds a semaphore lock to prevent exceptions when the `MAX_CONCURRENT_STREAMS` limit is reached. It now instead waits for a stream to close instead of raising an exception.

This bug was [initially reported in httpx.](https://github.com/encode/httpx/issues/282)

### Some questions / comments:

#### What timeout should be used (if any)?
Both `AsyncSemaphore` and `SyncSemaphore` allow a timeout to be passed when acquiring. Should my code accept any sort of timeout?

#### Should semaphores support `with` statements?
The abstract semaphore interface doesn't implement any entry or exit functions, preventing the use of the `with` statement. I presume this is because this would ignore the timeout condition, and could lead to programming errors in the future.

Here are some possible ideas:
1. We don't add any entry or exit functions. This prevents using semaphores without timeouts when timeouts might be appropriate.
2. We add entry and exit functions that call acquire without timeouts.
3. We add the ability to pass a timeout when creating the semaphore, and use that timeout as the default when using entry and exit functions.

#### What exception should be thrown if a semaphore timeout is reached?
I'm currently using `PoolTimeout`, but it's a noop becuase without a timeout it's never going to be called anyway. Should I just pass `None`?