### PR TITLE
Use mitmproxy as a fixture for proxy tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ black
 autoflake
 mypy
 isort
+mitmproxy

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -173,3 +173,20 @@ async def test_http_request_cannot_reuse_dropped_connection():
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1
+
+
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY"])
+@pytest.mark.usefixtures("async_environment")
+async def test_http_proxy(proxy_server, proxy_mode):
+    async with httpcore.AsyncHTTPProxy(proxy_server) as http:
+        method = b"GET"
+        url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = await http.request(
+            method, url, headers
+        )
+        body = await read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ import pytest
 from mitmproxy import master, options, proxy
 from mitmproxy.tools.dump import DumpMaster
 
+PROXY_HOST = "127.0.0.1"
+PROXY_PORT = 8080
+
 
 @pytest.fixture(
     params=[
@@ -32,31 +35,38 @@ def async_environment(request: typing.Any) -> str:
     return request.param
 
 
+class ProxyWrapper(threading.Thread):
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.options = kwargs
+        super().__init__()
+
+    def run(self):
+        # mitmproxy uses asyncio internally but the default loop policy
+        # will only create event loops for the main thread, create one
+        # as part of the thread startup
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        opts = options.Options(
+            listen_host=self.host, listen_port=self.port, **self.options
+        )
+        pconf = proxy.config.ProxyConfig(opts)
+
+        self.master = DumpMaster(opts)
+        self.master.server = proxy.server.ProxyServer(pconf)
+        self.master.run()
+
+    def join(self):
+        self.master.shutdown()
+        super().join()
+
+
 @pytest.fixture
 def proxy_server():
-    host, port = "127.0.0.1", 8080
-
-    class ProxyWrapper(threading.Thread):
-        def run(self):
-            # mitmproxy uses asyncio internally but the default loop policy
-            # will only create event loops for the main thread, create one
-            # as part of the thread startup
-            asyncio.set_event_loop(asyncio.new_event_loop())
-            opts = options.Options(listen_host=host, listen_port=port)
-            pconf = proxy.config.ProxyConfig(opts)
-
-            self.master = DumpMaster(opts)
-            self.master.server = proxy.server.ProxyServer(pconf)
-            self.master.run()
-
-        def join(self):
-            self.master.shutdown()
-            super().join()
-
     try:
-        thread = ProxyWrapper()
+        thread = ProxyWrapper(PROXY_HOST, PROXY_PORT)
         thread.start()
-        time.sleep(2)  # TODO: there's probably a better way to do this
-        yield (host, port)
+        time.sleep(1)  # TODO: there's probably a better way to do this
+        yield (PROXY_HOST, PROXY_PORT)
     finally:
         thread.join()

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -175,7 +175,8 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert len(http._connections[url[:3]]) == 1
 
 
-@pytest.mark.parametrize('proxy_mode', ['DEFAULT', 'FORWARD_ONLY'])
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY"])
+
 def test_http_proxy(proxy_server, proxy_mode):
     with httpcore.SyncHTTPProxy(proxy_server) as http:
         method = b"GET"

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -177,9 +177,7 @@ def test_http_request_cannot_reuse_dropped_connection():
 
 @pytest.mark.parametrize('proxy_mode', ['DEFAULT', 'FORWARD_ONLY'])
 def test_http_proxy(proxy_server, proxy_mode):
-    proxy_host, proxy_port = proxy_server
-    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
-    with httpcore.SyncHTTPProxy(proxy_origin) as http:
+    with httpcore.SyncHTTPProxy(proxy_server) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -173,38 +173,3 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1
-
-
-@pytest.mark.parametrize('proxy_mode', ['DEFAULT', 'FORWARD_ONLY'])
-def test_http_proxy(proxy_server, proxy_mode):
-    proxy_host, proxy_port = proxy_server
-    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
-    with httpcore.SyncHTTPProxy(proxy_origin, proxy_mode=proxy_mode) as http:
-        method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
-        http_version, status_code, reason, headers, stream = http.request(
-            method, url, headers
-        )
-        body = read_body(stream)
-
-        assert http_version == b"HTTP/1.1"
-        assert status_code == 200
-        assert reason == b"OK"
-
-
-def test_http_tunnel_proxy(proxy_server):
-    proxy_host, proxy_port = proxy_server
-    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
-    with httpcore.SyncHTTPProxy(proxy_origin, proxy_mode='TUNNEL_ONLY') as http:
-        method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
-        http_version, status_code, reason, headers, stream = http.request(
-            method, url, headers
-        )
-        body = read_body(stream)
-
-        assert http_version == b"HTTP/1.1"
-        assert status_code == 200
-        assert reason == b"OK"

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -175,10 +175,28 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert len(http._connections[url[:3]]) == 1
 
 
-def test_http_proxy(proxy_server):
+@pytest.mark.parametrize('proxy_mode', ['DEFAULT', 'FORWARD_ONLY'])
+def test_http_proxy(proxy_server, proxy_mode):
     proxy_host, proxy_port = proxy_server
     proxy_origin = (b"http", proxy_host.encode(), proxy_port)
-    with httpcore.SyncHTTPProxy(proxy_origin) as http:
+    with httpcore.SyncHTTPProxy(proxy_origin, proxy_mode=proxy_mode) as http:
+        method = b"GET"
+        url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = http.request(
+            method, url, headers
+        )
+        body = read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"
+
+
+def test_http_tunnel_proxy(proxy_server):
+    proxy_host, proxy_port = proxy_server
+    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
+    with httpcore.SyncHTTPProxy(proxy_origin, proxy_mode='TUNNEL_ONLY') as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -173,3 +173,20 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1
+
+
+def test_http_proxy(proxy_server):
+    proxy_host, proxy_port = proxy_server
+    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
+    with httpcore.SyncHTTPProxy(proxy_origin) as http:
+        method = b"GET"
+        url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = http.request(
+            method, url, headers
+        )
+        body = read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -173,3 +173,21 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1
+
+
+@pytest.mark.parametrize('proxy_mode', ['DEFAULT', 'FORWARD_ONLY'])
+def test_http_proxy(proxy_server, proxy_mode):
+    proxy_host, proxy_port = proxy_server
+    proxy_origin = (b"http", proxy_host.encode(), proxy_port)
+    with httpcore.SyncHTTPProxy(proxy_origin) as http:
+        method = b"GET"
+        url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = http.request(
+            method, url, headers
+        )
+        body = read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"


### PR DESCRIPTION
Towards #42 

In [socksio](https://github.com/sethmlarson/socksio/) we use [Dante](https://www.inet.no/dante/) to spin up SOCKS 4 and 5 proxies for acceptance tests in Docker but I tend to use [mitmproxy](https://mitmproxy.org/) for debugging proxy issues, since it's written in Python I thought it might be a simple non-docker solution to run it as a thread in the background.

This is a POC only, but it show how we could go about doing that. The tunnel test is failing at an assertion in the connection, not quite sure why but the forwarding ones work well.
