### PR TITLE
Add TUNNEL_ONLY to http_proxy test parametrization

### DIFF
--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -175,7 +175,7 @@ async def test_http_request_cannot_reuse_dropped_connection():
         assert len(http._connections[url[:3]]) == 1
 
 
-@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY"])
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.usefixtures("async_environment")
 async def test_http_proxy(proxy_server, proxy_mode):
     async with httpcore.AsyncHTTPProxy(proxy_server) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -175,7 +175,7 @@ def test_http_request_cannot_reuse_dropped_connection():
         assert len(http._connections[url[:3]]) == 1
 
 
-@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY"])
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 
 def test_http_proxy(proxy_server, proxy_mode):
     with httpcore.SyncHTTPProxy(proxy_server) as http:


### PR DESCRIPTION
For some reason TUNNEL_ONLY was failing for me while working on https://github.com/encode/httpcore/pull/48, but it seems to work fine now, probably missed something.