### PR TITLE
WIP: SOCKS proxy support

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -36,5 +36,7 @@ __all__ = [
     "ReadError",
     "WriteError",
     "CloseError",
+    "ProtocolError",
+    "ProxyError",
 ]
 __version__ = "0.7.0"

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -115,9 +115,9 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
         origin: Tuple[bytes, bytes, int],
         proxy_origin: Tuple[bytes, bytes, int],
         socks_version: str,
-        user_id: str = b"httpcore",
+        user_id: bytes = b"httpcore",
         ssl_context: SSLContext = None,
-    ):
+    ) -> None:
         self.origin = origin
         self.proxy_origin = proxy_origin
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
@@ -131,7 +131,7 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
         self.user_id = user_id
         self.socks_connection = self._get_socks_connection(socks_version)
 
-    def _get_socks_connection(self, socks_version: str):
+    def _get_socks_connection(self, socks_version: str) -> socks4.SOCKS4Connection:
         if socks_version == "SOCKS4":
             return socks4.SOCKS4Connection(user_id=self.user_id)
         else:
@@ -139,7 +139,7 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
 
     async def _connect(
         self, timeout: Dict[str, Optional[float]] = None,
-    ):
+    ) -> None:
         """SOCKS4 negotiation prior to creating an HTTP/1.1 connection."""
         _, hostname, port = self.proxy_origin
         timeout = {} if timeout is None else timeout

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple, Union
 from socksio import socks4
 
 from .._backends.auto import AsyncLock, AutoBackend
+from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -12,15 +13,11 @@ from .base import (
 )
 from .http2 import AsyncHTTP2Connection
 from .http11 import AsyncHTTP11Connection
-from .._types import URL, Origin, Headers, TimeoutDict
 
 
 class AsyncHTTPConnection(AsyncHTTPTransport):
     def __init__(
-        self,
-        origin: Origin,
-        http2: bool = False,
-        ssl_context: SSLContext = None,
+        self, origin: Origin, http2: bool = False, ssl_context: SSLContext = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -138,9 +135,7 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
         else:
             raise NotImplementedError
 
-    async def _connect(
-        self, timeout: Optional[TimeoutDict] = None,
-    ) -> None:
+    async def _connect(self, timeout: Optional[TimeoutDict] = None,) -> None:
         """SOCKS4 negotiation prior to creating an HTTP/1.1 connection."""
         # First setup the socket to talk to the proxy server
         _, hostname, port = self.proxy_origin
@@ -171,4 +166,6 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
             )
 
         # Otherwise use the socket as usual
-        self.connection = AsyncHTTP11Connection(socket=socket)
+        self.connection = AsyncHTTP11Connection(
+            socket=socket, ssl_context=self.ssl_context
+        )

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple, Union
 from socksio import socks4
 
 from .._backends.auto import AsyncLock, AutoBackend
+from .._exceptions import ProxyError
 from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     AsyncByteStream,
@@ -159,7 +160,7 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
 
         # Bail if rejected
         if event.reply_code != socks4.SOCKS4ReplyCode.REQUEST_GRANTED:
-            raise Exception(
+            raise ProxyError(
                 "Proxy server could not connect to remote host: {}".format(
                     event.reply_code
                 )

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,5 +1,5 @@
 from ssl import SSLContext
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from socksio import socks4
 
@@ -12,12 +12,13 @@ from .base import (
 )
 from .http2 import AsyncHTTP2Connection
 from .http11 import AsyncHTTP11Connection
+from .._types import URL, Origin, Headers, TimeoutDict
 
 
 class AsyncHTTPConnection(AsyncHTTPTransport):
     def __init__(
         self,
-        origin: Tuple[bytes, bytes, int],
+        origin: Origin,
         http2: bool = False,
         ssl_context: SSLContext = None,
     ):
@@ -46,10 +47,10 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
-        url: Tuple[bytes, bytes, int, bytes],
-        headers: List[Tuple[bytes, bytes]] = None,
+        url: URL,
+        headers: Optional[Headers] = None,
         stream: AsyncByteStream = None,
-        timeout: Dict[str, Optional[float]] = None,
+        timeout: Optional[TimeoutDict] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         assert url[:3] == self.origin
 
@@ -70,7 +71,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         assert self.connection is not None
         return await self.connection.request(method, url, headers, stream, timeout)
 
-    async def _connect(self, timeout: Dict[str, Optional[float]] = None) -> None:
+    async def _connect(self, timeout: TimeoutDict = None) -> None:
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
@@ -101,7 +102,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
             self.connection.mark_as_ready()
 
     async def start_tls(
-        self, hostname: bytes, timeout: Dict[str, Optional[float]] = None
+        self, hostname: bytes, timeout: Optional[TimeoutDict] = None
     ) -> None:
         if self.connection is not None:
             await self.connection.start_tls(hostname, timeout)
@@ -112,11 +113,11 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
 
     def __init__(
         self,
-        origin: Tuple[bytes, bytes, int],
-        proxy_origin: Tuple[bytes, bytes, int],
+        origin: Origin,
+        proxy_origin: Origin,
         socks_version: str,
         user_id: bytes = b"httpcore",
-        ssl_context: SSLContext = None,
+        ssl_context: Optional[SSLContext] = None,
     ) -> None:
         self.origin = origin
         self.proxy_origin = proxy_origin
@@ -138,7 +139,7 @@ class AsyncSOCKSConnection(AsyncHTTPConnection):
             raise NotImplementedError
 
     async def _connect(
-        self, timeout: Dict[str, Optional[float]] = None,
+        self, timeout: Optional[TimeoutDict] = None,
     ) -> None:
         """SOCKS4 negotiation prior to creating an HTTP/1.1 connection."""
         _, hostname, port = self.proxy_origin

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -35,12 +35,18 @@ class AsyncHTTPProxy(AsyncConnectionPool):
 
     **Parameters:**
 
-    * **proxy_origin** - `Tuple[bytes, bytes, int]` - The address of the proxy service as a 3-tuple of (scheme, host, port).
-    * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of proxy headers to include.
-    * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT", "FORWARD_ONLY", or "TUNNEL_ONLY".
-    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for verifying connections.
-    * **max_connections** - `Optional[int]` - The maximum number of concurrent connections to allow.
-    * **max_keepalive** - `Optional[int]` - The maximum number of connections to allow before closing keep-alive connections.
+    * **proxy_origin** - `Tuple[bytes, bytes, int]` - The address of the proxy
+    service as a 3-tuple of (scheme, host, port).
+    * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
+    proxy headers to include.
+    * **proxy_mode** - `str` - A proxy mode to operate in. One of "DEFAULT",
+    "FORWARD_ONLY", or "TUNNEL_ONLY".
+    * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
+    verifying connections.
+    * **max_connections** - `Optional[int]` - The maximum number of concurrent
+    connections to allow.
+    * **max_keepalive** - `Optional[int]` - The maximum number of connections
+    to allow before closing keep-alive connections.
     * **http2** - `bool` - Enable HTTP/2 support.
     """
 

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -1,16 +1,12 @@
 from enum import Enum
 from ssl import SSLContext
-from typing import Dict, List, Optional, Tuple
+from typing import Tuple
 
 from .._exceptions import ProxyError
+from .._types import URL, Headers, Origin, TimeoutDict
 from .base import AsyncByteStream
 from .connection import AsyncHTTPConnection, AsyncSOCKSConnection
 from .connection_pool import AsyncConnectionPool, ResponseByteStream
-
-Origin = Tuple[bytes, bytes, int]
-URL = Tuple[bytes, bytes, int, bytes]
-Headers = List[Tuple[bytes, bytes]]
-TimeoutDict = Dict[str, Optional[float]]
 
 
 async def read_body(stream: AsyncByteStream) -> bytes:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,7 +1,10 @@
 from ssl import SSLContext
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
+
+from socksio import socks4
 
 from .._backends.auto import SyncLock, SyncBackend
+from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,
@@ -14,10 +17,7 @@ from .http11 import SyncHTTP11Connection
 
 class SyncHTTPConnection(SyncHTTPTransport):
     def __init__(
-        self,
-        origin: Tuple[bytes, bytes, int],
-        http2: bool = False,
-        ssl_context: SSLContext = None,
+        self, origin: Origin, http2: bool = False, ssl_context: SSLContext = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -44,10 +44,10 @@ class SyncHTTPConnection(SyncHTTPTransport):
     def request(
         self,
         method: bytes,
-        url: Tuple[bytes, bytes, int, bytes],
-        headers: List[Tuple[bytes, bytes]] = None,
+        url: URL,
+        headers: Optional[Headers] = None,
         stream: SyncByteStream = None,
-        timeout: Dict[str, Optional[float]] = None,
+        timeout: Optional[TimeoutDict] = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         assert url[:3] == self.origin
 
@@ -68,7 +68,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         assert self.connection is not None
         return self.connection.request(method, url, headers, stream, timeout)
 
-    def _connect(self, timeout: Dict[str, Optional[float]] = None) -> None:
+    def _connect(self, timeout: TimeoutDict = None) -> None:
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
@@ -99,7 +99,73 @@ class SyncHTTPConnection(SyncHTTPTransport):
             self.connection.mark_as_ready()
 
     def start_tls(
-        self, hostname: bytes, timeout: Dict[str, Optional[float]] = None
+        self, hostname: bytes, timeout: Optional[TimeoutDict] = None
     ) -> None:
         if self.connection is not None:
             self.connection.start_tls(hostname, timeout)
+
+
+class SyncSOCKSConnection(SyncHTTPConnection):
+    """An HTTP/1.1 connection with SOCKS proxy negotiation."""
+
+    def __init__(
+        self,
+        origin: Origin,
+        proxy_origin: Origin,
+        socks_version: str,
+        user_id: bytes = b"httpcore",
+        ssl_context: Optional[SSLContext] = None,
+    ) -> None:
+        self.origin = origin
+        self.proxy_origin = proxy_origin
+        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.connection: Union[None, SyncHTTP11Connection] = None
+        self.is_http11 = True
+        self.is_http2 = False
+        self.connect_failed = False
+        self.expires_at: Optional[float] = None
+        self.backend = SyncBackend()
+
+        self.user_id = user_id
+        self.socks_connection = self._get_socks_connection(socks_version)
+
+    def _get_socks_connection(self, socks_version: str) -> socks4.SOCKS4Connection:
+        if socks_version == "SOCKS4":
+            return socks4.SOCKS4Connection(user_id=self.user_id)
+        else:
+            raise NotImplementedError
+
+    def _connect(self, timeout: Optional[TimeoutDict] = None,) -> None:
+        """SOCKS4 negotiation prior to creating an HTTP/1.1 connection."""
+        # First setup the socket to talk to the proxy server
+        _, hostname, port = self.proxy_origin
+        timeout = {} if timeout is None else timeout
+        ssl_context = None
+        socket = self.backend.open_tcp_stream(
+            hostname, port, ssl_context, timeout
+        )
+
+        # Use socksio to negotiate the connection with the remote host
+        request = socks4.SOCKS4Request.from_address(
+            socks4.SOCKS4Command.CONNECT, (self.origin[1].decode(), self.origin[2])
+        )
+        self.socks_connection.send(request)
+        bytes_to_send = self.socks_connection.data_to_send()
+        socket.write(bytes_to_send, timeout)
+
+        # Read the response from the proxy
+        data = socket.read(1024, timeout)
+        event = self.socks_connection.receive_data(data)
+
+        # Bail if rejected
+        if event.reply_code != socks4.SOCKS4ReplyCode.REQUEST_GRANTED:
+            raise Exception(
+                "Proxy server could not connect to remote host: {}".format(
+                    event.reply_code
+                )
+            )
+
+        # Otherwise use the socket as usual
+        self.connection = SyncHTTP11Connection(
+            socket=socket, ssl_context=self.ssl_context
+        )

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -1,16 +1,12 @@
 from enum import Enum
 from ssl import SSLContext
-from typing import Dict, List, Optional, Tuple
+from typing import Tuple
 
 from .._exceptions import ProxyError
+from .._types import URL, Headers, Origin, TimeoutDict
 from .base import SyncByteStream
 from .connection import SyncHTTPConnection, SyncSOCKSConnection
 from .connection_pool import SyncConnectionPool, ResponseByteStream
-
-Origin = Tuple[bytes, bytes, int]
-URL = Tuple[bytes, bytes, int, bytes]
-Headers = List[Tuple[bytes, bytes]]
-TimeoutDict = Dict[str, Optional[float]]
 
 
 def read_body(stream: SyncByteStream) -> bytes:

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "h11>=0.8,<0.10",
         "h2==3.*",
         "sniffio==1.*",
+        "socksio>=0.2.0",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -22,7 +22,7 @@ async def test_http_request():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -39,7 +39,7 @@ async def test_https_request():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -56,7 +56,7 @@ async def test_http2_request():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/2"
         assert status_code == 200
@@ -73,7 +73,7 @@ async def test_closing_http_request():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -90,7 +90,7 @@ async def test_http_request_reuse_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -103,7 +103,7 @@ async def test_http_request_reuse_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -120,7 +120,7 @@ async def test_https_request_reuse_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -133,7 +133,7 @@ async def test_https_request_reuse_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -150,7 +150,7 @@ async def test_http_request_cannot_reuse_dropped_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -167,7 +167,7 @@ async def test_http_request_cannot_reuse_dropped_connection():
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -185,7 +185,7 @@ async def test_http_proxy(proxy_server, proxy_mode):
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import threading
 import typing
 
 import pytest
-from mitmproxy import master, options, proxy
+from mitmproxy import options, proxy
 from mitmproxy.tools.dump import DumpMaster
 
 PROXY_HOST = "127.0.0.1"
@@ -69,7 +69,7 @@ class ProxyWrapper(threading.Thread):
         self.master.addons.add(self.notify)
         self.master.run()
 
-    def join(self) -> None:
+    def join(self, timeout: typing.Optional[float] = None) -> None:
         self.master.shutdown()
         super().join()
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -22,7 +22,7 @@ def test_http_request():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -39,7 +39,7 @@ def test_https_request():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -56,7 +56,7 @@ def test_http2_request():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/2"
         assert status_code == 200
@@ -73,7 +73,7 @@ def test_closing_http_request():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -90,7 +90,7 @@ def test_http_request_reuse_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -103,7 +103,7 @@ def test_http_request_reuse_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -120,7 +120,7 @@ def test_https_request_reuse_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -133,7 +133,7 @@ def test_https_request_reuse_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -150,7 +150,7 @@ def test_http_request_cannot_reuse_dropped_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -167,7 +167,7 @@ def test_http_request_cannot_reuse_dropped_connection():
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -185,7 +185,7 @@ def test_http_proxy(proxy_server, proxy_mode):
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200


### PR DESCRIPTION
Adds SOCKS4 proxy support via socksio 🎉 

You can test this either locally using Dante via Docker as [we do in socksio](https://github.com/sethmlarson/socksio/tree/master/docker) or simply running an `ssh -vND <PORT> <OTHER_MACHINE>`, then running the following script, assuming the proxy is running in `localhost:1080`:

```python
import asyncio
import httpcore

async def read_body(stream):
    try:
        body = []
        async for chunk in stream:
            body.append(chunk)
        return b"".join(body)
    finally:
        await stream.aclose()

async def socks_proxy(proxy_server, proxy_mode):
    async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
        method = b"GET"
        url = (b"http", b"93.184.216.34", 80, b"/")
        headers = [(b"host", b"example.org")]
        http_version, status_code, reason, headers, stream = await http.request(
            method, url, headers
        )
        body = await read_body(stream)
        print(body)

        assert http_version == b"HTTP/1.1"
        assert status_code == 200
        assert reason == b"OK"

def main():
    proxy_server = (b'http', b'localhost', 1080)
    proxy_mode = 'SOCKS4'
    asyncio.run(socks_proxy(proxy_server, proxy_mode))

if __name__ == '__main__':
    main()
```

Before I carry on with SOCKS4A and SOCKS5 (or possibly I should open a different PR?) I'd like some feedback.