### PR TITLE
Fix tunnel proxy and support HTTPS

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple, Union
 
-from .._backends.auto import AsyncLock, AutoBackend
+from .._backends.auto import AsyncLock, AutoBackend, AsyncSocketStream
 from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     AsyncByteStream,
@@ -15,7 +15,11 @@ from .http11 import AsyncHTTP11Connection
 
 class AsyncHTTPConnection(AsyncHTTPTransport):
     def __init__(
-        self, origin: Origin, http2: bool = False, ssl_context: SSLContext = None,
+        self,
+        origin: Origin,
+        http2: bool = False,
+        ssl_context: SSLContext = None,
+        socket: AsyncSocketStream = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -30,6 +34,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = AutoBackend()
+        self.socket = socket
 
     @property
     def request_lock(self) -> AsyncLock:
@@ -48,14 +53,16 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         assert url[:3] == self.origin
-
         async with self.request_lock:
             if self.state == ConnectionState.PENDING:
-                try:
-                    await self._connect(timeout)
-                except Exception:
-                    self.connect_failed = True
-                    raise
+                if self.socket:
+                    self._create_connection(self.socket)
+                else:
+                    try:
+                        await self._connect(timeout)
+                    except Exception:
+                        self.connect_failed = True
+                        raise
             elif self.state in (ConnectionState.READY, ConnectionState.IDLE):
                 pass
             elif self.state == ConnectionState.ACTIVE and self.is_http2:
@@ -70,9 +77,12 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
-        socket = await self.backend.open_tcp_stream(
+        self.socket = await self.backend.open_tcp_stream(
             hostname, port, ssl_context, timeout
         )
+        self._create_connection(self.socket)
+
+    def _create_connection(self, socket: AsyncSocketStream) -> None:
         http_version = socket.get_http_version()
         if http_version == "HTTP/2":
             self.is_http2 = True

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple, Union
 
-from .._backends.auto import AsyncLock, AutoBackend, AsyncSocketStream
+from .._backends.auto import AsyncLock, AsyncSocketStream, AutoBackend
 from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     AsyncByteStream,

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -86,10 +86,14 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         http_version = socket.get_http_version()
         if http_version == "HTTP/2":
             self.is_http2 = True
-            self.connection = AsyncHTTP2Connection(socket=socket, backend=self.backend)
+            self.connection = AsyncHTTP2Connection(
+                socket=socket, backend=self.backend, ssl_context=self.ssl_context
+            )
         else:
             self.is_http11 = True
-            self.connection = AsyncHTTP11Connection(socket=socket)
+            self.connection = AsyncHTTP11Connection(
+                socket=socket, ssl_context=self.ssl_context
+            )
 
     @property
     def state(self) -> ConnectionState:

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -109,3 +109,4 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
     async def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
         if self.connection is not None:
             await self.connection.start_tls(hostname, timeout)
+            self.socket = self.connection.socket

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -123,7 +123,7 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
             event = await self._receive_event(timeout)
             if isinstance(event, h11.Data):
                 yield bytes(event.data)
-            elif isinstance(event, h11.EndOfMessage):
+            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
     async def _receive_event(self, timeout: TimeoutDict) -> H11Event:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -170,9 +170,10 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Upgrade to TLS.
-            # TODO: upgrade only on HTTPS targets?
-            # await proxy_connection.start_tls(target, timeout)
+            # Upgrade to TLS if required
+            # We assume the target speaks TLS on the specified port
+            if url[0] == b"https":
+                await proxy_connection.start_tls(target, timeout)
 
             # Create a new connection to the target
             connection = AsyncHTTPConnection(

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -140,6 +140,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         connection = await self._get_connection_from_pool(origin)
 
         if connection is None:
+            # First, create a connection to the proxy server
             proxy_connection = AsyncHTTPConnection(
                 origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
@@ -147,7 +148,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 self._connections.setdefault(origin, set())
                 self._connections[origin].add(proxy_connection)
 
-            # Establish the connection by issuing a CONNECT request...
+            # Issue a CONNECT request...
 
             # CONNECT www.example.org:80 HTTP/1.1
             # [proxy-headers]
@@ -173,7 +174,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # Upgrade to TLS if required
             # We assume the target speaks TLS on the specified port
             if url[0] == b"https":
-                await proxy_connection.start_tls(target, timeout)
+                await proxy_connection.start_tls(url[1], timeout)
 
             # Create a new connection to the target
             connection = AsyncHTTPConnection(

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -140,12 +140,12 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         connection = await self._get_connection_from_pool(origin)
 
         if connection is None:
-            connection = AsyncHTTPConnection(
-                origin=origin, http2=False, ssl_context=self._ssl_context,
+            proxy_connection = AsyncHTTPConnection(
+                origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
             async with self._thread_lock:
                 self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+                self._connections[origin].add(proxy_connection)
 
             # Establish the connection by issuing a CONNECT request...
 
@@ -153,34 +153,42 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers
-            proxy_response = await connection.request(
+            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            proxy_response = await proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
             proxy_stream = proxy_response[4]
 
-            # Ingest any request body.
-            await read_body(proxy_stream)
+            # Read the response data without closing the socket
+            _ = b"".join([chunk async for chunk in proxy_stream])
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.
             if proxy_status_code < 200 or proxy_status_code > 299:
-                async with self._thread_lock:
-                    self._connections[connection.origin].remove(connection)
-                    if not self._connections[connection.origin]:
-                        del self._connections[connection.origin]
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
             # Upgrade to TLS.
-            await connection.start_tls(target, timeout)
+            # TODO: upgrade only on HTTPS targets?
+            # await proxy_connection.start_tls(target, timeout)
+
+            # Create a new connection to the target
+            connection = AsyncHTTPConnection(
+                origin=origin,
+                http2=False,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            async with self._thread_lock:
+                self._connections[origin].remove(proxy_connection)
+                self._connections[origin].add(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.
         response = await connection.request(
-            method, url, headers=headers, stream=stream, timeout=timeout
+            method, url, headers=headers, stream=stream, timeout=timeout,
         )
         wrapped_stream = ResponseByteStream(
             response[4], connection=connection, callback=self._response_closed

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -107,9 +107,9 @@ class SocketStream(AsyncSocketStream):
 
         transport = await asyncio.wait_for(
             loop_start_tls(
-                transport=transport,
-                protocol=protocol,
-                sslcontext=ssl_context,
+                transport,
+                protocol,
+                ssl_context,
                 server_hostname=hostname.decode("ascii"),
             ),
             timeout=timeout.get("connect"),

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -86,10 +86,14 @@ class SyncHTTPConnection(SyncHTTPTransport):
         http_version = socket.get_http_version()
         if http_version == "HTTP/2":
             self.is_http2 = True
-            self.connection = SyncHTTP2Connection(socket=socket, backend=self.backend)
+            self.connection = SyncHTTP2Connection(
+                socket=socket, backend=self.backend, ssl_context=self.ssl_context
+            )
         else:
             self.is_http11 = True
-            self.connection = SyncHTTP11Connection(socket=socket)
+            self.connection = SyncHTTP11Connection(
+                socket=socket, ssl_context=self.ssl_context
+            )
 
     @property
     def state(self) -> ConnectionState:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -51,12 +51,9 @@ class SyncHTTP11Connection(SyncHTTPTransport):
 
         self._send_request(method, url, headers, timeout)
         self._send_request_body(stream, timeout)
-        (
-            http_version,
-            status_code,
-            reason_phrase,
-            headers,
-        ) = self._receive_response(timeout)
+        (http_version, status_code, reason_phrase, headers,) = self._receive_response(
+            timeout
+        )
         stream = SyncByteStream(
             iterator=self._receive_response_data(timeout),
             close_func=self._response_closed,
@@ -77,9 +74,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         event = h11.Request(method=method, target=target, headers=headers)
         self._send_event(event, timeout)
 
-    def _send_request_body(
-        self, stream: SyncByteStream, timeout: TimeoutDict
-    ) -> None:
+    def _send_request_body(self, stream: SyncByteStream, timeout: TimeoutDict) -> None:
         """
         Send the request body.
         """
@@ -113,9 +108,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         http_version = b"HTTP/" + event.http_version
         return http_version, event.status_code, event.reason, event.headers
 
-    def _receive_response_data(
-        self, timeout: TimeoutDict
-    ) -> Iterator[bytes]:
+    def _receive_response_data(self, timeout: TimeoutDict) -> Iterator[bytes]:
         """
         Read the response data from the network.
         """

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -51,9 +51,12 @@ class SyncHTTP11Connection(SyncHTTPTransport):
 
         self._send_request(method, url, headers, timeout)
         self._send_request_body(stream, timeout)
-        (http_version, status_code, reason_phrase, headers,) = self._receive_response(
-            timeout
-        )
+        (
+            http_version,
+            status_code,
+            reason_phrase,
+            headers,
+        ) = self._receive_response(timeout)
         stream = SyncByteStream(
             iterator=self._receive_response_data(timeout),
             close_func=self._response_closed,
@@ -74,7 +77,9 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         event = h11.Request(method=method, target=target, headers=headers)
         self._send_event(event, timeout)
 
-    def _send_request_body(self, stream: SyncByteStream, timeout: TimeoutDict) -> None:
+    def _send_request_body(
+        self, stream: SyncByteStream, timeout: TimeoutDict
+    ) -> None:
         """
         Send the request body.
         """
@@ -108,7 +113,9 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         http_version = b"HTTP/" + event.http_version
         return http_version, event.status_code, event.reason, event.headers
 
-    def _receive_response_data(self, timeout: TimeoutDict) -> Iterator[bytes]:
+    def _receive_response_data(
+        self, timeout: TimeoutDict
+    ) -> Iterator[bytes]:
         """
         Read the response data from the network.
         """
@@ -116,7 +123,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
             event = self._receive_event(timeout)
             if isinstance(event, h11.Data):
                 yield bytes(event.data)
-            elif isinstance(event, h11.EndOfMessage):
+            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
     def _receive_event(self, timeout: TimeoutDict) -> H11Event:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -140,12 +140,12 @@ class SyncHTTPProxy(SyncConnectionPool):
         connection = self._get_connection_from_pool(origin)
 
         if connection is None:
-            connection = SyncHTTPConnection(
-                origin=origin, http2=False, ssl_context=self._ssl_context,
+            proxy_connection = SyncHTTPConnection(
+                origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
             with self._thread_lock:
                 self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+                self._connections[origin].add(proxy_connection)
 
             # Establish the connection by issuing a CONNECT request...
 
@@ -153,34 +153,43 @@ class SyncHTTPProxy(SyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers
-            proxy_response = connection.request(
+            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            proxy_response = proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
             proxy_stream = proxy_response[4]
 
-            # Ingest any request body.
-            read_body(proxy_stream)
+            # Read the response data without closing the socket
+            _ = b"".join([chunk for chunk in proxy_stream])
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.
             if proxy_status_code < 200 or proxy_status_code > 299:
-                with self._thread_lock:
-                    self._connections[connection.origin].remove(connection)
-                    if not self._connections[connection.origin]:
-                        del self._connections[connection.origin]
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Upgrade to TLS.
-            connection.start_tls(target, timeout)
+            # Upgrade to TLS if required
+            # We assume the target speaks TLS on the specified port
+            if url[0] == b"https":
+                proxy_connection.start_tls(target, timeout)
+
+            # Create a new connection to the target
+            connection = SyncHTTPConnection(
+                origin=origin,
+                http2=False,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            with self._thread_lock:
+                self._connections[origin].remove(proxy_connection)
+                self._connections[origin].add(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.
         response = connection.request(
-            method, url, headers=headers, stream=stream, timeout=timeout
+            method, url, headers=headers, stream=stream, timeout=timeout,
         )
         wrapped_stream = ResponseByteStream(
             response[4], connection=connection, callback=self._response_closed

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -140,6 +140,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         connection = self._get_connection_from_pool(origin)
 
         if connection is None:
+            # First, create a connection to the proxy server
             proxy_connection = SyncHTTPConnection(
                 origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
@@ -147,7 +148,7 @@ class SyncHTTPProxy(SyncConnectionPool):
                 self._connections.setdefault(origin, set())
                 self._connections[origin].add(proxy_connection)
 
-            # Establish the connection by issuing a CONNECT request...
+            # Issue a CONNECT request...
 
             # CONNECT www.example.org:80 HTTP/1.1
             # [proxy-headers]
@@ -173,7 +174,7 @@ class SyncHTTPProxy(SyncConnectionPool):
             # Upgrade to TLS if required
             # We assume the target speaks TLS on the specified port
             if url[0] == b"https":
-                proxy_connection.start_tls(target, timeout)
+                proxy_connection.start_tls(url[1], timeout)
 
             # Create a new connection to the target
             connection = SyncHTTPConnection(

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ autoflake
 mypy
 isort
 mitmproxy
+trustme

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -197,13 +197,12 @@ async def test_http_proxy(
         assert reason == b"OK"
 
 
-@pytest.mark.parametrize("proxy_mode", ["TUNNEL_ONLY"])
 @pytest.mark.usefixtures("async_environment")
-async def test_https_proxy(
-    https_proxy_server: typing.Tuple[bytes, bytes, int],
-    ca_ssl_context: ssl.SSLContext,
-    proxy_mode: str,
+async def test_proxy_https_requests(
+    https_proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
 ) -> None:
+    # mitmproxy does not support forwarding HTTPS requests
+    proxy_mode = "TUNNEL_ONLY"
     async with httpcore.AsyncHTTPProxy(
         https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
     ) as http:

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -24,7 +24,7 @@ async def test_http_request() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -41,7 +41,7 @@ async def test_https_request() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -58,7 +58,7 @@ async def test_http2_request() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/2"
         assert status_code == 200
@@ -75,7 +75,7 @@ async def test_closing_http_request() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -92,7 +92,7 @@ async def test_http_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -105,7 +105,7 @@ async def test_http_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -122,7 +122,7 @@ async def test_https_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -135,7 +135,7 @@ async def test_https_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -152,7 +152,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -169,7 +169,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -189,7 +189,7 @@ async def test_http_proxy(
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
         )
-        body = await read_body(stream)
+        _ = await read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -199,12 +199,12 @@ async def test_http_proxy(
 
 @pytest.mark.usefixtures("async_environment")
 async def test_proxy_https_requests(
-    https_proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
+    proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
 ) -> None:
     # mitmproxy does not support forwarding HTTPS requests
     proxy_mode = "TUNNEL_ONLY"
     async with httpcore.AsyncHTTPProxy(
-        https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
+        proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
     ) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -182,7 +182,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
 async def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
-    async with httpcore.AsyncHTTPProxy(proxy_server) as http:
+    async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,3 +1,4 @@
+import ssl
 import typing
 
 import pytest
@@ -185,6 +186,29 @@ async def test_http_proxy(
     async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = await http.request(
+            method, url, headers
+        )
+        _ = await read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"
+
+
+@pytest.mark.parametrize("proxy_mode", ["TUNNEL_ONLY"])
+@pytest.mark.usefixtures("async_environment")
+async def test_https_proxy(
+    https_proxy_server: typing.Tuple[bytes, bytes, int],
+    ca_ssl_context: ssl.SSLContext,
+    proxy_mode: str,
+) -> None:
+    async with httpcore.AsyncHTTPProxy(
+        https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
+    ) as http:
+        method = b"GET"
+        url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def cert_authority() -> trustme.CA:
 
 @pytest.fixture(scope="session")
 def ca_ssl_context(cert_authority: trustme.CA) -> ssl.SSLContext:
-    ctx = ssl.SSLContext()
+    ctx = ssl.create_default_context()
     cert_authority.configure_trust(ctx)
     return ctx
 
@@ -114,11 +114,7 @@ def proxy_server(
     intregrate in our tests.
     """
     try:
-        # TODO: the ssl_insecure flag prevents an error raised from mitmproxy:
-        # TlsException("Cannot validate certificate hostname without SNI")
-        thread = ProxyWrapper(
-            PROXY_HOST, PROXY_PORT, ssl_insecure=True, certs=[example_org_cert_path]
-        )
+        thread = ProxyWrapper(PROXY_HOST, PROXY_PORT, certs=[example_org_cert_path])
         thread.start()
         thread.notify.started.wait()
         yield (b"http", PROXY_HOST.encode(), PROXY_PORT)

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,3 +1,4 @@
+import ssl
 import typing
 
 import pytest
@@ -185,6 +186,29 @@ def test_http_proxy(
     with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = http.request(
+            method, url, headers
+        )
+        _ = read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"
+
+
+@pytest.mark.parametrize("proxy_mode", ["TUNNEL_ONLY"])
+
+def test_https_proxy(
+    https_proxy_server: typing.Tuple[bytes, bytes, int],
+    ca_ssl_context: ssl.SSLContext,
+    proxy_mode: str,
+) -> None:
+    with httpcore.SyncHTTPProxy(
+        https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
+    ) as http:
+        method = b"GET"
+        url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -197,13 +197,12 @@ def test_http_proxy(
         assert reason == b"OK"
 
 
-@pytest.mark.parametrize("proxy_mode", ["TUNNEL_ONLY"])
 
-def test_https_proxy(
-    https_proxy_server: typing.Tuple[bytes, bytes, int],
-    ca_ssl_context: ssl.SSLContext,
-    proxy_mode: str,
+def test_proxy_https_requests(
+    https_proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
 ) -> None:
+    # mitmproxy does not support forwarding HTTPS requests
+    proxy_mode = "TUNNEL_ONLY"
     with httpcore.SyncHTTPProxy(
         https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
     ) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -199,12 +199,12 @@ def test_http_proxy(
 
 
 def test_proxy_https_requests(
-    https_proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
+    proxy_server: typing.Tuple[bytes, bytes, int], ca_ssl_context: ssl.SSLContext,
 ) -> None:
     # mitmproxy does not support forwarding HTTPS requests
     proxy_mode = "TUNNEL_ONLY"
     with httpcore.SyncHTTPProxy(
-        https_proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
+        proxy_server, proxy_mode=proxy_mode, ssl_context=ca_ssl_context
     ) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -24,7 +24,7 @@ def test_http_request() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -41,7 +41,7 @@ def test_https_request() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -58,7 +58,7 @@ def test_http2_request() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/2"
         assert status_code == 200
@@ -75,7 +75,7 @@ def test_closing_http_request() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -92,7 +92,7 @@ def test_http_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -105,7 +105,7 @@ def test_http_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -122,7 +122,7 @@ def test_https_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -135,7 +135,7 @@ def test_https_request_reuse_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -152,7 +152,7 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -169,7 +169,7 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
@@ -182,14 +182,14 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
 def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
-    with httpcore.SyncHTTPProxy(proxy_server) as http:
+    with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )
-        body = read_body(stream)
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200


### PR DESCRIPTION
Fixes https://github.com/encode/httpcore/issues/54

Probably helps with https://github.com/encode/httpx/issues/897

- First establish an HTTP connection to our proxy since `CONNECT` is an HTTP method handled by h11.
- Once successful discard the connection but prevent closing the socket.
- Upgrade to TLS if required.
- Allow passing a socket to the `AsyncHTTPConnection` and create a new h11 connection to the target.

Only HTTP is covered by the tests using mitmproxy, I couldn't quite get HTTPS requests to work using mitmproxy but it did work using Squid as @florimondmanca [outlined in the HTTPX issue](https://github.com/encode/httpx/issues/859#issuecomment-611206532) (thanks for that, it was very helpful 👍 )

These changes sit a bit at the edge of our abstractions since the socket is now exposed a few levels above what it used to. I'm keen to hear your thoughts on whether we need some refactoring.