### PR TITLE
Fix tunnel proxy: HTTP requests only

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple, Union
 
-from .._backends.auto import AsyncLock, AutoBackend
+from .._backends.auto import AsyncLock, AsyncSocketStream, AutoBackend
 from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     AsyncByteStream,
@@ -15,7 +15,11 @@ from .http11 import AsyncHTTP11Connection
 
 class AsyncHTTPConnection(AsyncHTTPTransport):
     def __init__(
-        self, origin: Origin, http2: bool = False, ssl_context: SSLContext = None,
+        self,
+        origin: Origin,
+        http2: bool = False,
+        ssl_context: SSLContext = None,
+        socket: AsyncSocketStream = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -30,6 +34,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = AutoBackend()
+        self.socket = socket
 
     @property
     def request_lock(self) -> AsyncLock:
@@ -48,14 +53,16 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
         assert url[:3] == self.origin
-
         async with self.request_lock:
             if self.state == ConnectionState.PENDING:
-                try:
-                    await self._connect(timeout)
-                except Exception:
-                    self.connect_failed = True
-                    raise
+                if self.socket:
+                    self._create_connection(self.socket)
+                else:
+                    try:
+                        await self._connect(timeout)
+                    except Exception:
+                        self.connect_failed = True
+                        raise
             elif self.state in (ConnectionState.READY, ConnectionState.IDLE):
                 pass
             elif self.state == ConnectionState.ACTIVE and self.is_http2:
@@ -70,16 +77,23 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
-        socket = await self.backend.open_tcp_stream(
+        self.socket = await self.backend.open_tcp_stream(
             hostname, port, ssl_context, timeout
         )
+        self._create_connection(self.socket)
+
+    def _create_connection(self, socket: AsyncSocketStream) -> None:
         http_version = socket.get_http_version()
         if http_version == "HTTP/2":
             self.is_http2 = True
-            self.connection = AsyncHTTP2Connection(socket=socket, backend=self.backend)
+            self.connection = AsyncHTTP2Connection(
+                socket=socket, backend=self.backend, ssl_context=self.ssl_context
+            )
         else:
             self.is_http11 = True
-            self.connection = AsyncHTTP11Connection(socket=socket)
+            self.connection = AsyncHTTP11Connection(
+                socket=socket, ssl_context=self.ssl_context
+            )
 
     @property
     def state(self) -> ConnectionState:
@@ -99,3 +113,4 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
     async def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
         if self.connection is not None:
             await self.connection.start_tls(hostname, timeout)
+            self.socket = self.connection.socket

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -24,6 +24,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.origin = origin
         self.http2 = http2
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.socket = socket
 
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
@@ -34,7 +35,6 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = AutoBackend()
-        self.socket = socket
 
     @property
     def request_lock(self) -> AsyncLock:

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -123,7 +123,7 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
             event = await self._receive_event(timeout)
             if isinstance(event, h11.Data):
                 yield bytes(event.data)
-            elif isinstance(event, h11.EndOfMessage):
+            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
     async def _receive_event(self, timeout: TimeoutDict) -> H11Event:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -18,8 +18,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     service as a 3-tuple of (scheme, host, port).
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
-    * **proxy_mode** - `str` - A proxy mode to operate in. May be "FORWARD",
-    or "TUNNEL".
+    * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",
+    "FORWARD_ONLY", or "TUNNEL_ONLY". "DEFAULT" is identical to "FORWARD_ONLY"
+    but is kept for backward compatibility purposes.
     * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
@@ -40,7 +41,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         keepalive_expiry: float = None,
         http2: bool = False,
     ):
-        assert proxy_mode in ("FORWARD", "TUNNEL")
+        assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
         self.proxy_origin = proxy_origin
         self.proxy_headers = [] if proxy_headers is None else proxy_headers
@@ -64,7 +65,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         if self._keepalive_expiry is not None:
             await self._keepalive_sweep()
 
-        if self.proxy_mode == "FORWARD":
+        if self.proxy_mode == "FORWARD_ONLY":
             return await self._forward_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -8,13 +8,6 @@ from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool, ResponseByteStream
 
 
-async def read_body(stream: AsyncByteStream) -> bytes:
-    try:
-        return b"".join([chunk async for chunk in stream])
-    finally:
-        await stream.aclose()
-
-
 class AsyncHTTPProxy(AsyncConnectionPool):
     """
     A connection pool for making HTTP requests via an HTTP proxy.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -156,7 +156,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             proxy_stream = proxy_response[4]
 
             # Read the response data without closing the socket
-            _ = b"".join([chunk async for chunk in proxy_stream])
+            async for _ in proxy_stream:
+                pass
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -159,8 +159,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             async for _ in proxy_stream:
                 pass
 
-            # If the proxy responds with an error, then drop the connection
-            # from the pool, and raise an exception.
+            # See if the tunnel was successfully established.
             if proxy_status_code < 200 or proxy_status_code > 299:
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -137,9 +137,6 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             proxy_connection = AsyncHTTPConnection(
                 origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
-            async with self._thread_lock:
-                self._connections.setdefault(origin, set())
-                self._connections[origin].add(proxy_connection)
 
             # Issue a CONNECT request...
 
@@ -174,9 +171,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 ssl_context=self._ssl_context,
                 socket=proxy_connection.socket,
             )
-            async with self._thread_lock:
-                self._connections[origin].remove(proxy_connection)
-                self._connections[origin].add(connection)
+            await self._add_to_pool(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -65,11 +65,15 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         if self._keepalive_expiry is not None:
             await self._keepalive_sweep()
 
-        if self.proxy_mode == "FORWARD_ONLY":
+        if (
+            self.proxy_mode == "DEFAULT" and url[0] == b"http"
+        ) or self.proxy_mode == "FORWARD_ONLY":
+            # By default HTTP requests should be forwarded.
             return await self._forward_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )
         else:
+            # By default HTTPS should be tunnelled.
             return await self._tunnel_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -19,8 +19,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
     * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",
-    "FORWARD_ONLY", or "TUNNEL_ONLY". "DEFAULT" is identical to "FORWARD_ONLY"
-    but is kept for backward compatibility purposes.
+    "FORWARD_ONLY", or "TUNNEL_ONLY".
     * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
@@ -33,8 +32,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     def __init__(
         self,
         proxy_origin: Origin,
-        proxy_mode: str,
         proxy_headers: Headers = None,
+        proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
         max_connections: int = None,
         max_keepalive: int = None,

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -140,47 +140,52 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         connection = await self._get_connection_from_pool(origin)
 
         if connection is None:
-            connection = AsyncHTTPConnection(
-                origin=origin, http2=False, ssl_context=self._ssl_context,
+            # First, create a connection to the proxy server
+            proxy_connection = AsyncHTTPConnection(
+                origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
             async with self._thread_lock:
                 self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+                self._connections[origin].add(proxy_connection)
 
-            # Establish the connection by issuing a CONNECT request...
+            # Issue a CONNECT request...
 
             # CONNECT www.example.org:80 HTTP/1.1
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers
-            proxy_response = await connection.request(
+            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            proxy_response = await proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
             proxy_stream = proxy_response[4]
 
-            # Ingest any request body.
-            await read_body(proxy_stream)
+            # Read the response data without closing the socket
+            _ = b"".join([chunk async for chunk in proxy_stream])
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.
             if proxy_status_code < 200 or proxy_status_code > 299:
-                async with self._thread_lock:
-                    self._connections[connection.origin].remove(connection)
-                    if not self._connections[connection.origin]:
-                        del self._connections[connection.origin]
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Upgrade to TLS.
-            await connection.start_tls(target, timeout)
+            # Create a new connection to the target
+            connection = AsyncHTTPConnection(
+                origin=origin,
+                http2=False,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            async with self._thread_lock:
+                self._connections[origin].remove(proxy_connection)
+                self._connections[origin].add(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.
         response = await connection.request(
-            method, url, headers=headers, stream=stream, timeout=timeout
+            method, url, headers=headers, stream=stream, timeout=timeout,
         )
         wrapped_stream = ResponseByteStream(
             response[4], connection=connection, callback=self._response_closed

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -154,9 +154,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            headers = self.proxy_headers + ([] if headers is None else headers)
             proxy_response = await proxy_connection.request(
-                b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
+                b"CONNECT", connect_url, headers=headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -18,8 +18,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     service as a 3-tuple of (scheme, host, port).
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
-    * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",
-    "FORWARD_ONLY", or "TUNNEL_ONLY".
+    * **proxy_mode** - `str` - A proxy mode to operate in. May be "FORWARD",
+    or "TUNNEL".
     * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
@@ -32,15 +32,15 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     def __init__(
         self,
         proxy_origin: Origin,
+        proxy_mode: str,
         proxy_headers: Headers = None,
-        proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
         max_connections: int = None,
         max_keepalive: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
     ):
-        assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
+        assert proxy_mode in ("FORWARD", "TUNNEL")
 
         self.proxy_origin = proxy_origin
         self.proxy_headers = [] if proxy_headers is None else proxy_headers
@@ -64,15 +64,11 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         if self._keepalive_expiry is not None:
             await self._keepalive_sweep()
 
-        if (
-            self.proxy_mode == "DEFAULT" and url[0] == b"http"
-        ) or self.proxy_mode == "FORWARD_ONLY":
-            # By default HTTP requests should be forwarded.
+        if self.proxy_mode == "FORWARD":
             return await self._forward_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )
         else:
-            # By default HTTPS should be tunnelled.
             return await self._tunnel_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )
@@ -144,9 +140,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            proxy_headers = self._get_tunnel_proxy_headers(headers)
             proxy_response = await proxy_connection.request(
-                b"CONNECT", connect_url, headers=proxy_headers, timeout=timeout
+                b"CONNECT", connect_url, headers=self.proxy_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
@@ -182,34 +177,3 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             response[4], connection=connection, callback=self._response_closed
         )
         return response[0], response[1], response[2], response[3], wrapped_stream
-
-    def _get_tunnel_proxy_headers(self, request_headers: Headers = None) -> Headers:
-        """Returns the headers for the CONNECT request to the tunnel proxy.
-
-        These do not include _all_ the request headers, but we make sure Host
-        is present as it's required for any h11 connection. If not in the proxy
-        headers we try to pull it from the request headers.
-
-        We also attach `Accept: */*` if not present in the user's proxy headers.
-        """
-        proxy_headers = []
-        should_add_accept_header = True
-        should_add_host_header = True
-        for header in self.proxy_headers:
-            proxy_headers.append(header)
-            if header[0] == b"accept":
-                should_add_accept_header = False
-            if header[0] == b"host":
-                should_add_host_header = False
-
-        if should_add_accept_header:
-            proxy_headers.append((b"accept", b"*/*"))
-
-        if should_add_host_header and request_headers:
-            try:
-                host_header = next(h for h in request_headers if h[0] == b"host")
-                proxy_headers.append(host_header)
-            except StopIteration:
-                pass
-
-        return proxy_headers

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -165,7 +165,10 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Create a new connection to the target
+            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+            # This means the proxy connection is now unusable, and we must create
+            # a new one for regular requests, making sure to use the same socket to
+            # retain the tunnel.
             connection = AsyncHTTPConnection(
                 origin=origin,
                 http2=False,

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -107,9 +107,9 @@ class SocketStream(AsyncSocketStream):
 
         transport = await asyncio.wait_for(
             loop_start_tls(
-                transport=transport,
-                protocol=protocol,
-                sslcontext=ssl_context,
+                transport,
+                protocol,
+                ssl_context,
                 server_hostname=hostname.decode("ascii"),
             ),
             timeout=timeout.get("connect"),

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -24,6 +24,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.origin = origin
         self.http2 = http2
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.socket = socket
 
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
@@ -34,7 +35,6 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = SyncBackend()
-        self.socket = socket
 
     @property
     def request_lock(self) -> SyncLock:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple, Union
 
-from .._backends.auto import SyncLock, SyncBackend
+from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
 from .._types import URL, Headers, Origin, TimeoutDict
 from .base import (
     SyncByteStream,
@@ -15,7 +15,11 @@ from .http11 import SyncHTTP11Connection
 
 class SyncHTTPConnection(SyncHTTPTransport):
     def __init__(
-        self, origin: Origin, http2: bool = False, ssl_context: SSLContext = None,
+        self,
+        origin: Origin,
+        http2: bool = False,
+        ssl_context: SSLContext = None,
+        socket: SyncSocketStream = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -30,6 +34,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = SyncBackend()
+        self.socket = socket
 
     @property
     def request_lock(self) -> SyncLock:
@@ -48,14 +53,16 @@ class SyncHTTPConnection(SyncHTTPTransport):
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
         assert url[:3] == self.origin
-
         with self.request_lock:
             if self.state == ConnectionState.PENDING:
-                try:
-                    self._connect(timeout)
-                except Exception:
-                    self.connect_failed = True
-                    raise
+                if self.socket:
+                    self._create_connection(self.socket)
+                else:
+                    try:
+                        self._connect(timeout)
+                    except Exception:
+                        self.connect_failed = True
+                        raise
             elif self.state in (ConnectionState.READY, ConnectionState.IDLE):
                 pass
             elif self.state == ConnectionState.ACTIVE and self.is_http2:
@@ -70,16 +77,23 @@ class SyncHTTPConnection(SyncHTTPTransport):
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
-        socket = self.backend.open_tcp_stream(
+        self.socket = self.backend.open_tcp_stream(
             hostname, port, ssl_context, timeout
         )
+        self._create_connection(self.socket)
+
+    def _create_connection(self, socket: SyncSocketStream) -> None:
         http_version = socket.get_http_version()
         if http_version == "HTTP/2":
             self.is_http2 = True
-            self.connection = SyncHTTP2Connection(socket=socket, backend=self.backend)
+            self.connection = SyncHTTP2Connection(
+                socket=socket, backend=self.backend, ssl_context=self.ssl_context
+            )
         else:
             self.is_http11 = True
-            self.connection = SyncHTTP11Connection(socket=socket)
+            self.connection = SyncHTTP11Connection(
+                socket=socket, ssl_context=self.ssl_context
+            )
 
     @property
     def state(self) -> ConnectionState:
@@ -99,3 +113,4 @@ class SyncHTTPConnection(SyncHTTPTransport):
     def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
         if self.connection is not None:
             self.connection.start_tls(hostname, timeout)
+            self.socket = self.connection.socket

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -123,7 +123,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
             event = self._receive_event(timeout)
             if isinstance(event, h11.Data):
                 yield bytes(event.data)
-            elif isinstance(event, h11.EndOfMessage):
+            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
     def _receive_event(self, timeout: TimeoutDict) -> H11Event:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -140,47 +140,52 @@ class SyncHTTPProxy(SyncConnectionPool):
         connection = self._get_connection_from_pool(origin)
 
         if connection is None:
-            connection = SyncHTTPConnection(
-                origin=origin, http2=False, ssl_context=self._ssl_context,
+            # First, create a connection to the proxy server
+            proxy_connection = SyncHTTPConnection(
+                origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
             with self._thread_lock:
                 self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+                self._connections[origin].add(proxy_connection)
 
-            # Establish the connection by issuing a CONNECT request...
+            # Issue a CONNECT request...
 
             # CONNECT www.example.org:80 HTTP/1.1
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers
-            proxy_response = connection.request(
+            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            proxy_response = proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
             proxy_stream = proxy_response[4]
 
-            # Ingest any request body.
-            read_body(proxy_stream)
+            # Read the response data without closing the socket
+            _ = b"".join([chunk for chunk in proxy_stream])
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.
             if proxy_status_code < 200 or proxy_status_code > 299:
-                with self._thread_lock:
-                    self._connections[connection.origin].remove(connection)
-                    if not self._connections[connection.origin]:
-                        del self._connections[connection.origin]
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Upgrade to TLS.
-            connection.start_tls(target, timeout)
+            # Create a new connection to the target
+            connection = SyncHTTPConnection(
+                origin=origin,
+                http2=False,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            with self._thread_lock:
+                self._connections[origin].remove(proxy_connection)
+                self._connections[origin].add(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.
         response = connection.request(
-            method, url, headers=headers, stream=stream, timeout=timeout
+            method, url, headers=headers, stream=stream, timeout=timeout,
         )
         wrapped_stream = ResponseByteStream(
             response[4], connection=connection, callback=self._response_closed

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -137,9 +137,6 @@ class SyncHTTPProxy(SyncConnectionPool):
             proxy_connection = SyncHTTPConnection(
                 origin=self.proxy_origin, http2=False, ssl_context=self._ssl_context,
             )
-            with self._thread_lock:
-                self._connections.setdefault(origin, set())
-                self._connections[origin].add(proxy_connection)
 
             # Issue a CONNECT request...
 
@@ -174,9 +171,7 @@ class SyncHTTPProxy(SyncConnectionPool):
                 ssl_context=self._ssl_context,
                 socket=proxy_connection.socket,
             )
-            with self._thread_lock:
-                self._connections[origin].remove(proxy_connection)
-                self._connections[origin].add(connection)
+            self._add_to_pool(connection)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -159,13 +159,15 @@ class SyncHTTPProxy(SyncConnectionPool):
             for _ in proxy_stream:
                 pass
 
-            # If the proxy responds with an error, then drop the connection
-            # from the pool, and raise an exception.
+            # See if the tunnel was successfully established.
             if proxy_status_code < 200 or proxy_status_code > 299:
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
-            # Create a new connection to the target
+            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+            # This means the proxy connection is now unusable, and we must create
+            # a new one for regular requests, making sure to use the same socket to
+            # retain the tunnel.
             connection = SyncHTTPConnection(
                 origin=origin,
                 http2=False,

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -65,11 +65,15 @@ class SyncHTTPProxy(SyncConnectionPool):
         if self._keepalive_expiry is not None:
             self._keepalive_sweep()
 
-        if self.proxy_mode == "FORWARD_ONLY":
+        if (
+            self.proxy_mode == "DEFAULT" and url[0] == b"http"
+        ) or self.proxy_mode == "FORWARD_ONLY":
+            # By default HTTP requests should be forwarded.
             return self._forward_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )
         else:
+            # By default HTTPS should be tunnelled.
             return self._tunnel_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -19,8 +19,7 @@ class SyncHTTPProxy(SyncConnectionPool):
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
     * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",
-    "FORWARD_ONLY", or "TUNNEL_ONLY". "DEFAULT" is identical to "FORWARD_ONLY"
-    but is kept for backward compatibility purposes.
+    "FORWARD_ONLY", or "TUNNEL_ONLY".
     * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
@@ -33,8 +32,8 @@ class SyncHTTPProxy(SyncConnectionPool):
     def __init__(
         self,
         proxy_origin: Origin,
-        proxy_mode: str,
         proxy_headers: Headers = None,
+        proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
         max_connections: int = None,
         max_keepalive: int = None,

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -156,7 +156,8 @@ class SyncHTTPProxy(SyncConnectionPool):
             proxy_stream = proxy_response[4]
 
             # Read the response data without closing the socket
-            _ = b"".join([chunk for chunk in proxy_stream])
+            for _ in proxy_stream:
+                pass
 
             # If the proxy responds with an error, then drop the connection
             # from the pool, and raise an exception.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -18,8 +18,9 @@ class SyncHTTPProxy(SyncConnectionPool):
     service as a 3-tuple of (scheme, host, port).
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
-    * **proxy_mode** - `str` - A proxy mode to operate in. May be "FORWARD",
-    or "TUNNEL".
+    * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",
+    "FORWARD_ONLY", or "TUNNEL_ONLY". "DEFAULT" is identical to "FORWARD_ONLY"
+    but is kept for backward compatibility purposes.
     * **ssl_context** - `Optional[SSLContext]` - An SSL context to use for
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
@@ -40,7 +41,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         keepalive_expiry: float = None,
         http2: bool = False,
     ):
-        assert proxy_mode in ("FORWARD", "TUNNEL")
+        assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
         self.proxy_origin = proxy_origin
         self.proxy_headers = [] if proxy_headers is None else proxy_headers
@@ -64,7 +65,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         if self._keepalive_expiry is not None:
             self._keepalive_sweep()
 
-        if self.proxy_mode == "FORWARD":
+        if self.proxy_mode == "FORWARD_ONLY":
             return self._forward_request(
                 method, url, headers=headers, stream=stream, timeout=timeout
             )

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -8,13 +8,6 @@ from .connection import SyncHTTPConnection
 from .connection_pool import SyncConnectionPool, ResponseByteStream
 
 
-def read_body(stream: SyncByteStream) -> bytes:
-    try:
-        return b"".join([chunk for chunk in stream])
-    finally:
-        stream.close()
-
-
 class SyncHTTPProxy(SyncConnectionPool):
     """
     A connection pool for making HTTP requests via an HTTP proxy.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -154,9 +154,9 @@ class SyncHTTPProxy(SyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = self.proxy_headers or [(b"host", self.proxy_origin[1])]
+            headers = self.proxy_headers + ([] if headers is None else headers)
             proxy_response = proxy_connection.request(
-                b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
+                b"CONNECT", connect_url, headers=headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -147,9 +147,9 @@ class SyncHTTPProxy(SyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            headers = self.proxy_headers + ([] if headers is None else headers)
+            proxy_headers = self._get_tunnel_proxy_headers(headers)
             proxy_response = proxy_connection.request(
-                b"CONNECT", connect_url, headers=headers, timeout=timeout
+                b"CONNECT", connect_url, headers=proxy_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]
@@ -187,3 +187,34 @@ class SyncHTTPProxy(SyncConnectionPool):
             response[4], connection=connection, callback=self._response_closed
         )
         return response[0], response[1], response[2], response[3], wrapped_stream
+
+    def _get_tunnel_proxy_headers(self, request_headers: Headers = None) -> Headers:
+        """Returns the headers for the CONNECT request to the tunnel proxy.
+
+        These do not include _all_ the request headers, but we make sure Host
+        is present as it's required for any h11 connection. If not in the proxy
+        headers we try to pull it from the request headers.
+
+        We also attach `Accept: */*` if not present in the user's proxy headers.
+        """
+        proxy_headers = []
+        should_add_accept_header = True
+        should_add_host_header = True
+        for header in self.proxy_headers:
+            proxy_headers.append(header)
+            if header[0] == b"accept":
+                should_add_accept_header = False
+            if header[0] == b"host":
+                should_add_host_header = False
+
+        if should_add_accept_header:
+            proxy_headers.append((b"accept", b"*/*"))
+
+        if should_add_host_header and request_headers:
+            try:
+                host_header = next(h for h in request_headers if h[0] == b"host")
+                proxy_headers.append(host_header)
+            except StopIteration:
+                pass
+
+        return proxy_headers

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -177,7 +177,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-@pytest.mark.parametrize("proxy_mode", ["FORWARD", "TUNNEL"])
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.usefixtures("async_environment")
 async def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
@@ -187,7 +187,7 @@ async def test_http_proxy(
     headers = [(b"host", b"example.org")]
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode == "TUNNEL" else None
+    proxy_headers = headers if proxy_mode in ("DEFAULT", "TUNNEL_ONLY") else None
     async with httpcore.AsyncHTTPProxy(
         proxy_server, proxy_mode, proxy_headers=proxy_headers
     ) as http:

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -187,7 +187,7 @@ async def test_http_proxy(
     headers = [(b"host", b"example.org")]
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode in ("DEFAULT", "TUNNEL_ONLY") else None
+    proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     async with httpcore.AsyncHTTPProxy(
         proxy_server, proxy_mode, proxy_headers=proxy_headers
     ) as http:

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -189,7 +189,7 @@ async def test_http_proxy(
     # Forwarding will use the request headers
     proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     async with httpcore.AsyncHTTPProxy(
-        proxy_server, proxy_mode, proxy_headers=proxy_headers
+        proxy_server, proxy_headers=proxy_headers, proxy_mode=proxy_mode
     ) as http:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -182,7 +182,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
 async def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
-    async with httpcore.AsyncHTTPProxy(proxy_server) as http:
+    async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -189,7 +189,7 @@ def test_http_proxy(
     # Forwarding will use the request headers
     proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     with httpcore.SyncHTTPProxy(
-        proxy_server, proxy_mode, proxy_headers=proxy_headers
+        proxy_server, proxy_headers=proxy_headers, proxy_mode=proxy_mode
     ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -187,7 +187,7 @@ def test_http_proxy(
     headers = [(b"host", b"example.org")]
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode in ("DEFAULT", "TUNNEL_ONLY") else None
+    proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     with httpcore.SyncHTTPProxy(
         proxy_server, proxy_mode, proxy_headers=proxy_headers
     ) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -182,7 +182,7 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
 def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
-    with httpcore.SyncHTTPProxy(proxy_server) as http:
+    with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -177,7 +177,7 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-@pytest.mark.parametrize("proxy_mode", ["FORWARD", "TUNNEL"])
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 
 def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
@@ -187,7 +187,7 @@ def test_http_proxy(
     headers = [(b"host", b"example.org")]
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode == "TUNNEL" else None
+    proxy_headers = headers if proxy_mode in ("DEFAULT", "TUNNEL_ONLY") else None
     with httpcore.SyncHTTPProxy(
         proxy_server, proxy_mode, proxy_headers=proxy_headers
     ) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -177,15 +177,20 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
+@pytest.mark.parametrize("proxy_mode", ["FORWARD", "TUNNEL"])
 
 def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
-    with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
-        method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+    method = b"GET"
+    url = (b"http", b"example.org", 80, b"/")
+    headers = [(b"host", b"example.org")]
+    # Tunnel requires the host header to be present,
+    # Forwarding will use the request headers
+    proxy_headers = headers if proxy_mode == "TUNNEL" else None
+    with httpcore.SyncHTTPProxy(
+        proxy_server, proxy_mode, proxy_headers=proxy_headers
+    ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
         )


### PR DESCRIPTION
Fixes #54 split from #55 excluding support for tunneling HTTPS requests. Changes:

- First establish an HTTP connection to our proxy since CONNECT is an HTTP method handled by h11.
- Once successful discard the connection but prevent closing the socket.
- Allow passing a socket to the AsyncHTTPConnection and create a new h11 connection to the target.
