### PR TITLE
Support HTTPS requests on tunnel proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed tunnel proxy support.
+
 ## 0.7.0 (March 5th, 2020)
 
 - First integration with HTTPX.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -160,6 +160,11 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
+            # Upgrade to TLS if required
+            # We assume the target speaks TLS on the specified port
+            if url[0] == b"https":
+                await proxy_connection.start_tls(url[1], timeout)
+
             # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
             # This means the proxy connection is now unusable, and we must create
             # a new one for regular requests, making sure to use the same socket to

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -160,6 +160,11 @@ class SyncHTTPProxy(SyncConnectionPool):
                 msg = "%d %s" % (proxy_status_code, proxy_reason_phrase.decode("ascii"))
                 raise ProxyError(msg)
 
+            # Upgrade to TLS if required
+            # We assume the target speaks TLS on the specified port
+            if url[0] == b"https":
+                proxy_connection.start_tls(url[1], timeout)
+
             # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
             # This means the proxy connection is now unusable, and we must create
             # a new one for regular requests, making sure to use the same socket to

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ autoflake
 mypy
 isort
 mitmproxy
+trustme

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,3 +1,4 @@
+import ssl
 import typing
 
 import pytest
@@ -195,6 +196,33 @@ def test_http_proxy(
             method, url, headers
         )
         body = read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"
+
+
+# mitmproxy does not support forwarding HTTPS requests
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "TUNNEL_ONLY"])
+
+def test_proxy_https_requests(
+    proxy_server: typing.Tuple[bytes, bytes, int],
+    ca_ssl_context: ssl.SSLContext,
+    proxy_mode: str,
+) -> None:
+    method = b"GET"
+    url = (b"https", b"example.org", 443, b"/")
+    headers = proxy_headers = [(b"host", b"example.org")]
+    with httpcore.SyncHTTPProxy(
+        proxy_server,
+        proxy_headers=proxy_headers,
+        proxy_mode=proxy_mode,
+        ssl_context=ca_ssl_context,
+    ) as http:
+        http_version, status_code, reason, headers, stream = http.request(
+            method, url, headers
+        )
+        _ = read_body(stream)
 
         assert http_version == b"HTTP/1.1"
         assert status_code == 200


### PR DESCRIPTION
This PR extends https://github.com/encode/httpcore/pull/57 adding support for HTTPS.

The bulk of changes are around managing SSL certificates for mitmproxy to use in tests.