### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+---
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: "Publish release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v1"
+        with:
+          python-version: 3.7
+      - name: "Publish"
+        run: "scripts/publish"
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -2,8 +2,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 VERSION_FILE="httpcore/__init__.py"
+PYTHONPATH=.
 
 if [ -d 'venv' ] ; then
     PREFIX="venv/bin/"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,34 +1,28 @@
 #!/bin/sh -e
 
-export VERSION=`cat httpcore/__init__.py | grep __version__ | sed "s/__version__ = //" | sed "s/'//g"`
-export PREFIX=""
+VERSION_FILE="httpcore/__init__.py"
+
 if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
+    PREFIX="venv/bin/"
+else
+    PREFIX=""
 fi
 
-scripts/clean
+if [ ! -z "$GITHUB_ACTIONS" ]; then
+  git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git config --local user.name "GitHub Action"
 
-if ! command -v "${PREFIX}twine" &>/dev/null ; then
-    echo "Unable to find the 'twine' command."
-    echo "Install from PyPI, using '${PREFIX}pip install twine'."
+  VERSION=`grep __version__ ${VERSION_FILE} | grep -o '[0-9][^"]*'`
+
+  if [ "refs/tags/${VERSION}" != "${GITHUB_REF}" ] ; then
+    echo "GitHub Ref '${GITHUB_REF}' did not match package version '${VERSION}'"
     exit 1
+  fi
 fi
 
-if ! command -v "${PREFIX}wheel" &>/dev/null ; then
-    echo "Unable to find the 'wheel' command."
-    echo "Install from PyPI, using '${PREFIX}pip install wheel'."
-    exit 1
-fi
+set -x
 
-find httpcore -type f -name "*.py[co]" -delete
-find httpcore -type d -name __pycache__ -delete
-
+${PREFIX}pip install twine wheel mkdocs mkdocs-material mkautodoc
 ${PREFIX}python setup.py sdist bdist_wheel
 ${PREFIX}twine upload dist/*
-${PREFIX}mkdocs gh-deploy
-
-echo "You probably want to also tag the version now:"
-echo "git tag -a ${VERSION} -m 'version ${VERSION}'"
-echo "git push --tags"
-
-scripts/clean
+${PREFIX}mkdocs gh-deploy --force


### PR DESCRIPTION
Adds a GitHub Actions based publish workflow, that deploys to PyPI, and pushes the docs when versions are tagged in GitHub.

Some notes on this:

* Anyone with maintainer permissions will be able to roll a release.
* Version tags should follow the "1.2.3" style. I'd probably prefer GitHub's recommendation of using "v1.2.3" for tags, but we've got history across our projects here, and I guess it's *more* worthwhile to stay in line with that.
* Deploys will fail if the tagged version does not match the `__init__.py` version, which is helpful, since it'll enforce that we've issued, approved, and merged a version PR first.
* Since I've enabled the "enforce up to date with master" setting on the repo, I've drop "build on push to master", and instead we *only* do builds against the PRs. Those two things together are really nice since it narrows the gap of possible "builds failing against master, tho they passed on the pull request", and also keeps the build history cleaner.
* There's some improvements we could make on the workflow, splitting out `install`, `build`, `deploy` steps, but we'll treat that separately.
 