### PR TITLE
Version 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.8.1 (April 30th, 2020)
+
+### Changed
+
+- Allow inherintance of both `httpcore.AsyncByteStream`, `httpcore.SyncByteStream` without type conflicts.
+
 ## 0.8.0 (April 30th, 2020)
 
 ### Fixed

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "WriteError",
     "CloseError",
 ]
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -45,24 +45,24 @@ class AsyncByteStream:
     """
 
     def __init__(
-        self, iterator: AsyncIterator[bytes] = None, close_func: Callable = None,
+        self, aiterator: AsyncIterator[bytes] = None, aclose_func: Callable = None,
     ) -> None:
-        self.iterator = empty() if iterator is None else iterator
-        self.close_func = close_func
+        self.aiterator = empty() if aiterator is None else aiterator
+        self.aclose_func = aclose_func
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         """
         Yield bytes representing the request or response body.
         """
-        async for chunk in self.iterator:
+        async for chunk in self.aiterator:
             yield chunk
 
     async def aclose(self) -> None:
         """
         Must be called by the client to indicate that the stream has been closed.
         """
-        if self.close_func is not None:
-            await self.close_func()
+        if self.aclose_func is not None:
+            await self.aclose_func()
 
 
 class AsyncHTTPTransport:

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -58,8 +58,8 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
             headers,
         ) = await self._receive_response(timeout)
         stream = AsyncByteStream(
-            iterator=self._receive_response_data(timeout),
-            close_func=self._response_closed,
+            aiterator=self._receive_response_data(timeout),
+            aclose_func=self._response_closed,
         )
         return (http_version, status_code, reason_phrase, headers, stream)
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -263,7 +263,7 @@ class AsyncHTTP2Stream:
         status_code, headers = await self.receive_response(timeout)
         reason_phrase = get_reason_phrase(status_code)
         stream = AsyncByteStream(
-            iterator=self.body_iter(timeout), close_func=self._response_closed
+            aiterator=self.body_iter(timeout), aclose_func=self._response_closed
         )
 
         return (b"HTTP/2", status_code, reason_phrase, headers, stream)

--- a/unasync.py
+++ b/unasync.py
@@ -12,6 +12,8 @@ SUBS = [
     ('async for', 'for'),
     ('await ', ''),
     ('aclose', 'close'),
+    ('aclose_func', 'close_func'),
+    ('aiterator', 'iterator'),
     ('__aenter__', '__enter__'),
     ('__aexit__', '__exit__'),
     ('__aiter__', '__iter__'),


### PR DESCRIPTION
The build for `httpx 0.13.0.dev0` failed mypy checks due to `SyncHTTPTransport` and `AsyncHTTPTransport` having incompatible types on `.iterator`.

The httpx ContentStream implementations inherit from *both* of those two classes.

In order to resolve that, I've ensured that we're using `aiterator`/`iterator` and `aclose_func`/`close_func` for the two different cases.