### PR TITLE
Fix forward proxy adding connection to pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Fix connections using proxy forwarding requests not being added to the
+connection pool properly.
+
 ## 0.8.1 (April 30th, 2020)
 
 ### Changed

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -96,9 +96,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             connection = AsyncHTTPConnection(
                 origin=origin, http2=False, ssl_context=self._ssl_context,
             )
-            async with self._thread_lock:
-                self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+            await self._add_to_pool(connection)
 
         # Issue a forwarded proxy request...
 

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -96,9 +96,7 @@ class SyncHTTPProxy(SyncConnectionPool):
             connection = SyncHTTPConnection(
                 origin=origin, http2=False, ssl_context=self._ssl_context,
             )
-            with self._thread_lock:
-                self._connections.setdefault(origin, set())
-                self._connections[origin].add(connection)
+            self._add_to_pool(connection)
 
         # Issue a forwarded proxy request...
 

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -186,11 +186,17 @@ async def test_http_proxy(
     method = b"GET"
     url = (b"http", b"example.org", 80, b"/")
     headers = [(b"host", b"example.org")]
+    max_connections = 1
+    max_keepalive = 2
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
     proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     async with httpcore.AsyncHTTPProxy(
-        proxy_server, proxy_headers=proxy_headers, proxy_mode=proxy_mode
+        proxy_server,
+        proxy_headers=proxy_headers,
+        proxy_mode=proxy_mode,
+        max_connections=max_connections,
+        max_keepalive=max_keepalive,
     ) as http:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers
@@ -213,11 +219,15 @@ async def test_proxy_https_requests(
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")
     headers = proxy_headers = [(b"host", b"example.org")]
+    max_connections = 1
+    max_keepalive = 2
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
         proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         ssl_context=ca_ssl_context,
+        max_connections=max_connections,
+        max_keepalive=max_keepalive,
     ) as http:
         http_version, status_code, reason, headers, stream = await http.request(
             method, url, headers

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -186,11 +186,17 @@ def test_http_proxy(
     method = b"GET"
     url = (b"http", b"example.org", 80, b"/")
     headers = [(b"host", b"example.org")]
+    max_connections = 1
+    max_keepalive = 2
     # Tunnel requires the host header to be present,
     # Forwarding will use the request headers
     proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     with httpcore.SyncHTTPProxy(
-        proxy_server, proxy_headers=proxy_headers, proxy_mode=proxy_mode
+        proxy_server,
+        proxy_headers=proxy_headers,
+        proxy_mode=proxy_mode,
+        max_connections=max_connections,
+        max_keepalive=max_keepalive,
     ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
@@ -213,11 +219,15 @@ def test_proxy_https_requests(
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")
     headers = proxy_headers = [(b"host", b"example.org")]
+    max_connections = 1
+    max_keepalive = 2
     with httpcore.SyncHTTPProxy(
         proxy_server,
         proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         ssl_context=ca_ssl_context,
+        max_connections=max_connections,
+        max_keepalive=max_keepalive,
     ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/issues/922

The issue was that we were manually adding the connection to the pool rather than using the `_add_to_pool` method. By doing this we never acquired (or created) the semaphore, so when attempting to close the connection a new one was created and tried to be released, raising the BoundedSemaphore exception.

Interestingly, this didn't show up in our test suite because when `max_connections` is `None` which is the default we use a `NullSemaphore`. I added both `max_connections` and `max_keepalive` to our proxy tests to cover this particular PR, maybe we should add them to all tests?