### PR TITLE
Run test suite on "merge to master" actions.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -2,6 +2,8 @@
 name: Test Suite
 
 on:
+  push:
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
So I *think* we need to also run our test suite on the final merge to master, not just on the PR itself.

If we're not doing this, then it's not clear to me that the associated badge is going to actually reflect "colour of the last PR that was merged to master". Having said that, it's actually a bit inscrutable to me.

Something that might help thrash this out would be to leave things as they currently are, and issue a PR with *deliberately* failing tests, and find the answer to...

* Does issuing the PR on it's own update the badge colour?
* Does merging the PR update the badge colour?

I realise I've not worded any of this very clearly, but it's actually not as obvious as you might think that the current test suite behaviour we've got is associated with a meaningful badge.