### PR TITLE
Fix up proxy header behaviour

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -8,14 +8,20 @@ from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool, ResponseByteStream
 
 
-def merge_headers(default_headers: Headers = None, override_headers: Headers = None) -> Headers:
+def merge_headers(
+    default_headers: Headers = None, override_headers: Headers = None
+) -> Headers:
     """
     Append default_headers and override_headers, de-duplicating if a key existing in both cases.
     """
     default_headers = [] if default_headers is None else default_headers
     override_headers = [] if override_headers is None else override_headers
     has_override = set([key.lower() for key, value in override_headers])
-    default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
+    default_headers = [
+        (key, value)
+        for key, value in default_headers
+        if key.lower() not in has_override
+    ]
     return default_headers + override_headers
 
 
@@ -155,7 +161,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = [(b'Host', target), (b'Accept', b'*/*')]
+            connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
             connect_headers = merge_headers(connect_headers, self.proxy_headers)
             proxy_response = await proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -8,6 +8,17 @@ from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool, ResponseByteStream
 
 
+def merge_headers(default_headers: Headers = None, override_headers: Headers = None) -> Headers:
+    """
+    Append default_headers and override_headers, de-duplicating if a key existing in both cases.
+    """
+    default_headers = [] if default_headers is None else default_headers
+    override_headers = [] if override_headers is None else override_headers
+    has_override = set([key.lower() for key, value in override_headers])
+    default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
+    return default_headers + override_headers
+
+
 class AsyncHTTPProxy(AsyncConnectionPool):
     """
     A connection pool for making HTTP requests via an HTTP proxy.
@@ -105,7 +116,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         # [headers]
         target = b"%b://%b:%d%b" % url
         url = self.proxy_origin + (target,)
-        headers = self.proxy_headers + ([] if headers is None else headers)
+        headers = merge_headers(self.proxy_headers, headers)
 
         response = await connection.request(
             method, url, headers=headers, stream=stream, timeout=timeout
@@ -144,8 +155,10 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
+            connect_headers = [(b'Host', target), (b'Accept', b'*/*')]
+            connect_headers = merge_headers(connect_headers, self.proxy_headers)
             proxy_response = await proxy_connection.request(
-                b"CONNECT", connect_url, headers=self.proxy_headers, timeout=timeout
+                b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -8,11 +8,20 @@ from .connection import SyncHTTPConnection
 from .connection_pool import SyncConnectionPool, ResponseByteStream
 
 
-def merge_headers(default_headers: Headers = None, override_headers: Headers = None) -> Headers:
+def merge_headers(
+    default_headers: Headers = None, override_headers: Headers = None
+) -> Headers:
+    """
+    Append default_headers and override_headers, de-duplicating if a key existing in both cases.
+    """
     default_headers = [] if default_headers is None else default_headers
     override_headers = [] if override_headers is None else override_headers
     has_override = set([key.lower() for key, value in override_headers])
-    default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
+    default_headers = [
+        (key, value)
+        for key, value in default_headers
+        if key.lower() not in has_override
+    ]
     return default_headers + override_headers
 
 
@@ -152,7 +161,7 @@ class SyncHTTPProxy(SyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
-            connect_headers = [(b'Host', target), (b'Accept', b'*/*')]
+            connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
             connect_headers = merge_headers(connect_headers, self.proxy_headers)
             proxy_response = proxy_connection.request(
                 b"CONNECT", connect_url, headers=connect_headers, timeout=timeout

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -8,6 +8,14 @@ from .connection import SyncHTTPConnection
 from .connection_pool import SyncConnectionPool, ResponseByteStream
 
 
+def merge_headers(default_headers: Headers = None, override_headers: Headers = None) -> Headers:
+    default_headers = [] if default_headers is None else default_headers
+    override_headers = [] if override_headers is None else override_headers
+    has_override = set([key.lower() for key, value in override_headers])
+    default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
+    return default_headers + override_headers
+
+
 class SyncHTTPProxy(SyncConnectionPool):
     """
     A connection pool for making HTTP requests via an HTTP proxy.
@@ -105,7 +113,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         # [headers]
         target = b"%b://%b:%d%b" % url
         url = self.proxy_origin + (target,)
-        headers = self.proxy_headers + ([] if headers is None else headers)
+        headers = merge_headers(self.proxy_headers, headers)
 
         response = connection.request(
             method, url, headers=headers, stream=stream, timeout=timeout
@@ -144,8 +152,10 @@ class SyncHTTPProxy(SyncConnectionPool):
             # [proxy-headers]
             target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
+            connect_headers = [(b'Host', target), (b'Accept', b'*/*')]
+            connect_headers = merge_headers(connect_headers, self.proxy_headers)
             proxy_response = proxy_connection.request(
-                b"CONNECT", connect_url, headers=self.proxy_headers, timeout=timeout
+                b"CONNECT", connect_url, headers=connect_headers, timeout=timeout
             )
             proxy_status_code = proxy_response[1]
             proxy_reason_phrase = proxy_response[2]

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -188,12 +188,8 @@ async def test_http_proxy(
     headers = [(b"host", b"example.org")]
     max_connections = 1
     max_keepalive = 2
-    # Tunnel requires the host header to be present,
-    # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
-        proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         max_keepalive=max_keepalive,
@@ -220,12 +216,11 @@ async def test_proxy_https_requests(
 ) -> None:
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")
-    headers = proxy_headers = [(b"host", b"example.org")]
+    headers = [(b"host", b"example.org")]
     max_connections = 1
     max_keepalive = 2
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
-        proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         ssl_context=ca_ssl_context,
         max_connections=max_connections,

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -188,12 +188,8 @@ def test_http_proxy(
     headers = [(b"host", b"example.org")]
     max_connections = 1
     max_keepalive = 2
-    # Tunnel requires the host header to be present,
-    # Forwarding will use the request headers
-    proxy_headers = headers if proxy_mode == "TUNNEL_ONLY" else None
     with httpcore.SyncHTTPProxy(
         proxy_server,
-        proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         max_keepalive=max_keepalive,
@@ -220,12 +216,11 @@ def test_proxy_https_requests(
 ) -> None:
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")
-    headers = proxy_headers = [(b"host", b"example.org")]
+    headers = [(b"host", b"example.org")]
     max_connections = 1
     max_keepalive = 2
     with httpcore.SyncHTTPProxy(
         proxy_server,
-        proxy_headers=proxy_headers,
         proxy_mode=proxy_mode,
         ssl_context=ca_ssl_context,
         max_connections=max_connections,


### PR DESCRIPTION
Refs https://github.com/encode/httpx/issues/929#issuecomment-624127681

* Add `Host` and `Accept: */*` headers by default on the tunnel CONNECT requests, if they're not already set.
* De-duplicate proxy headers vs request headers on forwarded requests, rather than naively concatenating them.

I think we should probably roll a new version of `httpcore` from this, then issue an `httpx 0.13.dev1`.