### PR TITLE
get-or-create-connection should be an atomic operation

### DIFF
--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, Optional, Set, Tuple
 
-from .._backends.auto import SyncSemaphore, SyncBackend
+from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
 from .._exceptions import PoolTimeout
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -107,6 +107,12 @@ class SyncConnectionPool(SyncHTTPTransport):
 
         return self._internal_semaphore
 
+    @property
+    def _connection_acquiry_lock(self) -> SyncLock:
+        if not hasattr(self, "_internal_connection_acquiry_lock"):
+            self._internal_connection_acquiry_lock = self._backend.create_lock()
+        return self._internal_connection_acquiry_lock
+
     def request(
         self,
         method: bytes,
@@ -123,13 +129,17 @@ class SyncConnectionPool(SyncHTTPTransport):
 
         connection: Optional[SyncHTTPConnection] = None
         while connection is None:
-            connection = self._get_connection_from_pool(origin)
+            with self._connection_acquiry_lock:
+                # We get-or-create a connection as an atomic operation, to ensure
+                # that HTTP/2 requests issued in close concurrency will end up
+                # on the same connection.
+                connection = self._get_connection_from_pool(origin)
 
-            if connection is None:
-                connection = SyncHTTPConnection(
-                    origin=origin, http2=self._http2, ssl_context=self._ssl_context,
-                )
-                self._add_to_pool(connection, timeout=timeout)
+                if connection is None:
+                    connection = SyncHTTPConnection(
+                        origin=origin, http2=self._http2, ssl_context=self._ssl_context,
+                    )
+                    self._add_to_pool(connection, timeout=timeout)
 
             try:
                 response = connection.request(


### PR DESCRIPTION
Closes #80

I've only addressed this in ConnectionPool.
It's less clear to me what the behaviour should look like for proxies, so let's treat that in a separate issue & PR.