### PR TITLE
Use `wait_closed` with asyncio, with socket unwrapping workaround.

### DIFF
--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -169,7 +169,7 @@ class SocketStream(AsyncSocketStream):
                 else:
                     if hasattr(self.stream_writer, "wait_closed"):
                         # Python 3.7+
-                        await self.stream_writer.wait_closed()
+                        await self.stream_writer.wait_closed()  # type: ignore
 
     def is_connection_dropped(self) -> bool:
         # Counter-intuitively, what we really want to know here is whether the socket is

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -158,6 +158,8 @@ class SocketStream(AsyncSocketStream):
         async with self.write_lock:
             with map_exceptions({OSError: CloseError}):
                 self.stream_writer.close()
+                # Unwrap the SSL socket, ignoring want-read errors.
+                # Refs https://bugs.python.org/issue39758
                 try:
                     ssl_object = self.stream_writer.get_extra_info("ssl_object")
                     if ssl_object is not None:
@@ -165,7 +167,9 @@ class SocketStream(AsyncSocketStream):
                 except SSLWantReadError:
                     pass
                 else:
-                    await self.stream_writer.wait_closed()
+                    if hasattr(self.stream_writer, "wait_closed"):
+                        # Python 3.7+
+                        await self.stream_writer.wait_closed()
 
     def is_connection_dropped(self) -> bool:
         # Counter-intuitively, what we really want to know here is whether the socket is

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -1,5 +1,5 @@
 import asyncio
-from ssl import SSLContext
+from ssl import SSLContext, SSLWantReadError
 from typing import Optional
 
 from .._exceptions import (
@@ -158,6 +158,14 @@ class SocketStream(AsyncSocketStream):
         async with self.write_lock:
             with map_exceptions({OSError: CloseError}):
                 self.stream_writer.close()
+                try:
+                    ssl_object = self.stream_writer.get_extra_info("ssl_object")
+                    if ssl_object is not None:
+                        ssl_object.unwrap()
+                except SSLWantReadError:
+                    pass
+                else:
+                    await self.stream_writer.wait_closed()
 
     def is_connection_dropped(self) -> bool:
         # Counter-intuitively, what we really want to know here is whether the socket is


### PR DESCRIPTION
Proposal for working around https://bugs.python.org/issue39758 and addressing resulting bugs such as https://github.com/encode/httpx/issues/825 and https://github.com/encode/httpx/issues/914

Really we *ought* to be calling `.wait_closed` on closing sockets in asyncio, but we've not been able to because of a bug in cpython that can cause it to hang indefinitely on SSL termination. A workaround here is to explicitly deal with the socket unwrapping ourselves.

I've issued this as a draft PR since at the *very* least it'd need some verification.