### PR TITLE
Max concurrent stream improvements

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -72,7 +72,7 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
         # We do this lazily, to make sure backend autodetection always
         # runs within an async context.
         if not hasattr(self, "_max_streams_semaphore"):
-            max_streams = self.h2_state.remote_settings.max_concurrent_streams
+            max_streams = self.h2_state.local_settings.max_concurrent_streams
             self._max_streams_semaphore = self.backend.create_semaphore(
                 max_streams, exc_class=PoolTimeout
             )
@@ -102,6 +102,8 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
                 await self.send_connection_init(timeout)
                 self.sent_connection_init = True
 
+        await self.max_streams_semaphore.acquire()
+        try:
             try:
                 stream_id = self.h2_state.get_next_available_stream_id()
             except NoAvailableStreamIDError:
@@ -110,10 +112,13 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
             else:
                 self.state = ConnectionState.ACTIVE
 
-        h2_stream = AsyncHTTP2Stream(stream_id=stream_id, connection=self)
-        self.streams[stream_id] = h2_stream
-        self.events[stream_id] = []
-        return await h2_stream.request(method, url, headers, stream, timeout)
+            h2_stream = AsyncHTTP2Stream(stream_id=stream_id, connection=self)
+            self.streams[stream_id] = h2_stream
+            self.events[stream_id] = []
+            return await h2_stream.request(method, url, headers, stream, timeout)
+        except Exception:
+            self.max_streams_semaphore.release()
+            raise
 
     async def send_connection_init(self, timeout: TimeoutDict) -> None:
         """
@@ -242,15 +247,18 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
         await self.socket.write(data_to_send, timeout)
 
     async def close_stream(self, stream_id: int) -> None:
-        logger.trace("close_stream stream_id=%r", stream_id)
-        del self.streams[stream_id]
-        del self.events[stream_id]
+        try:
+            logger.trace("close_stream stream_id=%r", stream_id)
+            del self.streams[stream_id]
+            del self.events[stream_id]
 
-        if not self.streams:
-            if self.state == ConnectionState.ACTIVE:
-                self.state = ConnectionState.IDLE
-            elif self.state == ConnectionState.FULL:
-                await self.aclose()
+            if not self.streams:
+                if self.state == ConnectionState.ACTIVE:
+                    self.state = ConnectionState.IDLE
+                elif self.state == ConnectionState.FULL:
+                    await self.aclose()
+        finally:
+            self.max_streams_semaphore.release()
 
 
 class AsyncHTTP2Stream:
@@ -276,21 +284,16 @@ class AsyncHTTP2Stream:
             b"content-length" in seen_headers or b"transfer-encoding" in seen_headers
         )
 
-        await self.connection.max_streams_semaphore.acquire()
-        try:
-            await self.send_headers(method, url, headers, has_body, timeout)
-            if has_body:
-                await self.send_body(stream, timeout)
+        await self.send_headers(method, url, headers, has_body, timeout)
+        if has_body:
+            await self.send_body(stream, timeout)
 
-            # Receive the response.
-            status_code, headers = await self.receive_response(timeout)
-            reason_phrase = get_reason_phrase(status_code)
-            stream = AsyncByteStream(
-                aiterator=self.body_iter(timeout), aclose_func=self._response_closed
-            )
-        except Exception:
-            self.connection.max_streams_semaphore.release()
-            raise
+        # Receive the response.
+        status_code, headers = await self.receive_response(timeout)
+        reason_phrase = get_reason_phrase(status_code)
+        stream = AsyncByteStream(
+            aiterator=self.body_iter(timeout), aclose_func=self._response_closed
+        )
 
         return (b"HTTP/2", status_code, reason_phrase, headers, stream)
 
@@ -362,7 +365,4 @@ class AsyncHTTP2Stream:
                 break
 
     async def _response_closed(self) -> None:
-        try:
-            await self.connection.close_stream(self.stream_id)
-        finally:
-            self.connection.max_streams_semaphore.release()
+        await self.connection.close_stream(self.stream_id)


### PR DESCRIPTION
Right, there was some stuff I didn't quite get correct in #89

Absurdly I'd forgotten to use `http2=True` in my testings. This is the script I'm using now for this...

```python
import asyncio
import httpcore


async def main():
    async with httpcore.AsyncConnectionPool(http2=True) as client:
        await asyncio.gather(*[request(client, idx) for idx in range(1000)])

async def request(client, idx):
    http_version, status_code, reason_phrase, headers, stream = await client.request(
        method=b'GET',
        url=(b'https', b'example.org', 443, b'/'),
        headers=[(b'host', b'example.org:443')]
    )

    try:
        body = b''.join([chunk async for chunk in stream])
    finally:
        await stream.aclose()


asyncio.run(main())
```

The changes here are:

* We need to use the *local* settings to determine how many concurrent streams *we* can issue, not the remote settings.
* The `stream_id = self.h2_state.get_next_available_stream_id()` needs to be part of the semaphore-limited wrapped code, or else it stops incrementing once we've hit the concurrency limit. As a result I've moved the wrapping layer out from `AsyncHTTP2Stream` onto `AsyncHTTP2Connection` instead.