### PR TITLE
Port becomes optional

### DIFF
--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -87,7 +87,7 @@ class AsyncHTTPTransport:
         **Parameters:**
 
         * **method** - `bytes` - The HTTP method, such as `b'GET'`.
-        * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of
+        * **url** - `Tuple[bytes, bytes, Optional[int], bytes]` - The URL as a 4-tuple of
         (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers
         to send with the request.

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 from .._backends.auto import AsyncLock, AsyncSocketStream, AutoBackend
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, url_to_origin
 from .base import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -55,7 +55,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         stream: AsyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], AsyncByteStream]:
-        assert url[:3] == self.origin
+        assert url_to_origin(url) == self.origin
         async with self.request_lock:
             if self.state == ConnectionState.PENDING:
                 if not self.socket:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -5,7 +5,7 @@ from .._backends.auto import AsyncLock, AsyncSemaphore, AutoBackend
 from .._exceptions import PoolTimeout
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, url_to_origin
 from .base import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -124,8 +124,8 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         stream: AsyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, AsyncByteStream]:
-        timeout = {} if timeout is None else timeout
-        origin = url[:3]
+        assert url[0] in (b'http', b'https')
+        origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:
             await self._keepalive_sweep()

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -307,7 +307,10 @@ class AsyncHTTP2Stream:
     ) -> None:
         scheme, hostname, port, path = url
         default_port = {b"http": 80, b"https": 443}.get(scheme)
-        authority = b"%s:%d" % (hostname, port) if port != default_port else hostname
+        if port is None or port == default_port:
+            authority = hostname
+        else:
+            authority = b"%s:%d" % (hostname, port)
 
         headers = [
             (b":method", method),

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -72,7 +72,7 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
         # We do this lazily, to make sure backend autodetection always
         # runs within an async context.
         if not hasattr(self, "_max_streams_semaphore"):
-            max_streams = self.h2_state.remote_settings.max_concurrent_streams
+            max_streams = self.h2_state.local_settings.max_concurrent_streams
             self._max_streams_semaphore = self.backend.create_semaphore(
                 max_streams, exc_class=PoolTimeout
             )
@@ -102,6 +102,8 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
                 await self.send_connection_init(timeout)
                 self.sent_connection_init = True
 
+        await self.max_streams_semaphore.acquire()
+        try:
             try:
                 stream_id = self.h2_state.get_next_available_stream_id()
             except NoAvailableStreamIDError:
@@ -110,10 +112,13 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
             else:
                 self.state = ConnectionState.ACTIVE
 
-        h2_stream = AsyncHTTP2Stream(stream_id=stream_id, connection=self)
-        self.streams[stream_id] = h2_stream
-        self.events[stream_id] = []
-        return await h2_stream.request(method, url, headers, stream, timeout)
+            h2_stream = AsyncHTTP2Stream(stream_id=stream_id, connection=self)
+            self.streams[stream_id] = h2_stream
+            self.events[stream_id] = []
+            return await h2_stream.request(method, url, headers, stream, timeout)
+        except Exception:
+            self.max_streams_semaphore.release()
+            raise
 
     async def send_connection_init(self, timeout: TimeoutDict) -> None:
         """
@@ -242,15 +247,18 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
         await self.socket.write(data_to_send, timeout)
 
     async def close_stream(self, stream_id: int) -> None:
-        logger.trace("close_stream stream_id=%r", stream_id)
-        del self.streams[stream_id]
-        del self.events[stream_id]
+        try:
+            logger.trace("close_stream stream_id=%r", stream_id)
+            del self.streams[stream_id]
+            del self.events[stream_id]
 
-        if not self.streams:
-            if self.state == ConnectionState.ACTIVE:
-                self.state = ConnectionState.IDLE
-            elif self.state == ConnectionState.FULL:
-                await self.aclose()
+            if not self.streams:
+                if self.state == ConnectionState.ACTIVE:
+                    self.state = ConnectionState.IDLE
+                elif self.state == ConnectionState.FULL:
+                    await self.aclose()
+        finally:
+            self.max_streams_semaphore.release()
 
 
 class AsyncHTTP2Stream:
@@ -276,21 +284,16 @@ class AsyncHTTP2Stream:
             b"content-length" in seen_headers or b"transfer-encoding" in seen_headers
         )
 
-        await self.connection.max_streams_semaphore.acquire()
-        try:
-            await self.send_headers(method, url, headers, has_body, timeout)
-            if has_body:
-                await self.send_body(stream, timeout)
+        await self.send_headers(method, url, headers, has_body, timeout)
+        if has_body:
+            await self.send_body(stream, timeout)
 
-            # Receive the response.
-            status_code, headers = await self.receive_response(timeout)
-            reason_phrase = get_reason_phrase(status_code)
-            stream = AsyncByteStream(
-                aiterator=self.body_iter(timeout), aclose_func=self._response_closed
-            )
-        except Exception:
-            self.connection.max_streams_semaphore.release()
-            raise
+        # Receive the response.
+        status_code, headers = await self.receive_response(timeout)
+        reason_phrase = get_reason_phrase(status_code)
+        stream = AsyncByteStream(
+            aiterator=self.body_iter(timeout), aclose_func=self._response_closed
+        )
 
         return (b"HTTP/2", status_code, reason_phrase, headers, stream)
 
@@ -362,7 +365,4 @@ class AsyncHTTP2Stream:
                 break
 
     async def _response_closed(self) -> None:
-        try:
-            await self.connection.close_stream(self.stream_id)
-        finally:
-            self.connection.max_streams_semaphore.release()
+        await self.connection.close_stream(self.stream_id)

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -34,8 +34,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
 
     **Parameters:**
 
-    * **proxy_origin** - `Tuple[bytes, bytes, int]` - The address of the proxy
-    service as a 3-tuple of (scheme, host, port).
+    * **proxy_url** - `Tuple[bytes, bytes, Optional[int], bytes]` - The URL of
+    the proxy service as a 4-tuple of (scheme, host, port, path).
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
     * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -87,7 +87,7 @@ class SyncHTTPTransport:
         **Parameters:**
 
         * **method** - `bytes` - The HTTP method, such as `b'GET'`.
-        * **url** - `Tuple[bytes, bytes, int, bytes]` - The URL as a 4-tuple of
+        * **url** - `Tuple[bytes, bytes, Optional[int], bytes]` - The URL as a 4-tuple of
         (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers
         to send with the request.

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, url_to_origin
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,
@@ -55,7 +55,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         stream: SyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, List[Tuple[bytes, bytes]], SyncByteStream]:
-        assert url[:3] == self.origin
+        assert url_to_origin(url) == self.origin
         with self.request_lock:
             if self.state == ConnectionState.PENDING:
                 if not self.socket:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -5,7 +5,7 @@ from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
 from .._exceptions import PoolTimeout
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, url_to_origin
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,
@@ -124,8 +124,8 @@ class SyncConnectionPool(SyncHTTPTransport):
         stream: SyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, SyncByteStream]:
-        timeout = {} if timeout is None else timeout
-        origin = url[:3]
+        assert url[0] in (b'http', b'https')
+        origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:
             self._keepalive_sweep()

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -307,7 +307,10 @@ class SyncHTTP2Stream:
     ) -> None:
         scheme, hostname, port, path = url
         default_port = {b"http": 80, b"https": 443}.get(scheme)
-        authority = b"%s:%d" % (hostname, port) if port != default_port else hostname
+        if port is None or port == default_port:
+            authority = hostname
+        else:
+            authority = b"%s:%d" % (hostname, port)
 
         headers = [
             (b":method", method),

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -34,8 +34,8 @@ class SyncHTTPProxy(SyncConnectionPool):
 
     **Parameters:**
 
-    * **proxy_origin** - `Tuple[bytes, bytes, int]` - The address of the proxy
-    service as a 3-tuple of (scheme, host, port).
+    * **proxy_url** - `Tuple[bytes, bytes, Optional[int], bytes]` - The URL of
+    the proxy service as a 4-tuple of (scheme, host, port, path).
     * **proxy_headers** - `Optional[List[Tuple[bytes, bytes]]]` - A list of
     proxy headers to include.
     * **proxy_mode** - `str` - A proxy mode to operate in. May be "DEFAULT",

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from .._exceptions import ProxyError
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, url_to_origin
 from .base import SyncByteStream
 from .connection import SyncHTTPConnection
 from .connection_pool import SyncConnectionPool, ResponseByteStream
@@ -51,7 +51,7 @@ class SyncHTTPProxy(SyncConnectionPool):
 
     def __init__(
         self,
-        proxy_origin: Origin,
+        proxy_url: URL,
         proxy_headers: Headers = None,
         proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
@@ -62,7 +62,7 @@ class SyncHTTPProxy(SyncConnectionPool):
     ):
         assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
-        self.proxy_origin = proxy_origin
+        self.proxy_origin = url_to_origin(proxy_url)
         self.proxy_headers = [] if proxy_headers is None else proxy_headers
         self.proxy_mode = proxy_mode
         super().__init__(
@@ -137,7 +137,12 @@ class SyncHTTPProxy(SyncConnectionPool):
         # GET https://www.example.org/path HTTP/1.1
         # [proxy headers]
         # [headers]
-        target = b"%b://%b:%d%b" % url
+        scheme, host, port, path = url
+        if port is None:
+            target = b"%b://%b%b" % (scheme, host, path)
+        else:
+            target = b"%b://%b:%d%b" % (scheme, host, port, path)
+
         url = self.proxy_origin + (target,)
         headers = merge_headers(self.proxy_headers, headers)
 
@@ -161,7 +166,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         Tunnelled proxy requests require an initial CONNECT request to
         establish the connection, and then send regular requests.
         """
-        origin = url[:3]
+        origin = url_to_origin(url)
         connection = self._get_connection_from_pool(origin)
 
         if connection is None:
@@ -176,7 +181,10 @@ class SyncHTTPProxy(SyncConnectionPool):
 
             # CONNECT www.example.org:80 HTTP/1.1
             # [proxy-headers]
-            target = b"%b:%d" % (url[1], url[2])
+            if url[2] is None:
+                target = url[1]
+            else:
+                target = b"%b:%d" % (url[1], url[2])
             connect_url = self.proxy_origin + (target,)
             connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
             connect_headers = merge_headers(connect_headers, self.proxy_headers)

--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -6,6 +6,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 StrOrBytes = Union[str, bytes]
 Origin = Tuple[bytes, bytes, int]
-URL = Tuple[bytes, bytes, int, bytes]
+URL = Tuple[bytes, bytes, Optional[int], bytes]
 Headers = List[Tuple[bytes, bytes]]
 TimeoutDict = Dict[str, Optional[float]]

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import typing
+from ._types import URL, Origin
 
 _LOGGER_INITIALIZED = False
 TRACE_LOG_LEVEL = 5
@@ -47,3 +48,10 @@ def get_logger(name: str) -> Logger:
     logger.trace = trace  # type: ignore
 
     return typing.cast(Logger, logger)
+
+
+def url_to_origin(url: URL) -> Origin:
+    scheme, host, explicit_port = url[:3]
+    default_port = {b'http': 80, b'https': 443}[scheme]
+    port = default_port if explicit_port is None else explicit_port
+    return scheme, host, port


### PR DESCRIPTION
* Port in URL becomes optional.
* Origin stays as `Tuple[bytes, bytes, int]`, since we need a canonical form there.
* `proxy_origin` becomes `proxy_url` for better consistency.

HTTPX would need to update the `proxy_origin` form it uses to `proxy_url`.
