### PR TITLE
Version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.9.0 (May 21th, 2020)
+
+### Changed
+
+- URL port becomes an `Optional[int]` instead of `int`. (Pull #92)
+
+### Fixed
+
+- Honor HTTP/2 max concurrent streams settings. (Pull #89, #90)
+- Remove incorrect debug log. (Pull #83)
+
 ## 0.8.4 (May 11th, 2020)
 
 ### Added

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "WriteError",
     "CloseError",
 ]
-__version__ = "0.8.4"
+__version__ = "0.9.0"


### PR DESCRIPTION
I think we can push the 0.9.0 for `httpcore` now, which we'll use with `httpx` 0.13.