### PR TITLE
Use `socket.create_connection`

### DIFF
--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -126,13 +126,12 @@ class SyncBackend:
         ssl_context: Optional[SSLContext],
         timeout: TimeoutDict,
     ) -> SyncSocketStream:
+        address = (hostname.decode("ascii"), port)
         connect_timeout = timeout.get("connect")
         exc_map = {socket.timeout: ConnectTimeout, socket.error: ConnectError}
 
         with map_exceptions(exc_map):
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(connect_timeout)
-            sock.connect((hostname.decode("ascii"), port))
+            sock = socket.create_connection(address, connect_timeout)
             if ssl_context is not None:
                 sock = ssl_context.wrap_socket(
                     sock, server_hostname=hostname.decode("ascii")


### PR DESCRIPTION
Switch the sync `open_tcp_connection` to use `socket.create_connection`.

This gives us *far* more sensible host resolution, since it will attempt all records, and also means that we've switched sync to IPv4 + IPv6 support.

Really there's more we could do here too... `urllib3` *automatically* determines if IPv6 support is present on the system. https://github.com/urllib3/urllib3/blob/11d68efa7c150823472f0e5309c3a08a1a10c2f2/src/urllib3/util/connection.py#L33-L86

We probably want to do the same, but let's treat that seperately.