### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ async with httpcore.AsyncConnectionPool() as http:
     )
 
     try:
-        body = b''.join(chunk async for chunk in stream)
+        body = b''.join([chunk async for chunk in stream])
     finally:
-        await stream.close()
+        await stream.aclose()
 
     print(status_code, body)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,9 @@ async with httpcore.AsyncConnectionPool() as http:
     )
 
     try:
-        body = b''.join(chunk async for chunk in stream)
+        body = b''.join([chunk async for chunk in stream])
     finally:
-        await stream.close()
+        await stream.aclose()
 
     print(status_code, body)
 ```


### PR DESCRIPTION
Tiny fix of example code block in `README.md` and docs.

Noticed this when I used the example code in a test case for `RESPX`.