### PR TITLE
Use isort 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ pytest-cov
 black
 autoflake
 mypy
-isort
+isort==5.*
 mitmproxy
 trustme

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}isort --project=httpcore --recursive --apply $SOURCE_FILES
+${PREFIX}isort --project=httpcore $SOURCE_FILES
 ${PREFIX}black --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' --target-version=py36 $SOURCE_FILES
 scripts/unasync

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,13 +8,10 @@ ignore_missing_imports = True
 plugins = trio_typing.plugin
 
 [tool:isort]
+profile = black
 combine_as_imports = True
-force_grid_wrap = 0
-include_trailing_comma = True
 known_first_party = httpcore,tests
 known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,pytest,rfc3986,setuptools,sniffio,trio,trustme,urllib3,uvicorn
-line_length = 88
-multi_line_output = 3
 
 [tool:pytest]
 addopts = --cov-report= --cov=httpcore --cov=tests -rxXs


### PR DESCRIPTION
Refs https://github.com/encode/httpx/pull/1050

See https://timothycrosley.github.io/isort/CHANGELOG/#500-penny-july-4-2020

Also pins `isort==5.*`.

I reckon the breaking change here in `isort` is going to require action from most projects that depend on it… Starlette, Uvicorn, Databases, Typesystem and others are probably affected too. Will have to issue fixes for my projects as well…