### PR TITLE
Improve handling of server disconnects

### DIFF
--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -131,9 +131,12 @@ class SocketStream(AsyncSocketStream):
         exc_map = {asyncio.TimeoutError: ReadTimeout, OSError: ReadError}
         async with self.read_lock:
             with map_exceptions(exc_map):
-                return await asyncio.wait_for(
+                data = await asyncio.wait_for(
                     self.stream_reader.read(n), timeout.get("read")
                 )
+                if data == b"":
+                    raise OSError("Server disconnected while attempting read")
+                return data
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:
         if not data:

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -135,7 +135,7 @@ class SocketStream(AsyncSocketStream):
                     self.stream_reader.read(n), timeout.get("read")
                 )
                 if data == b"":
-                    raise OSError("Server disconnected while attempting read")
+                    raise ReadError("Server disconnected while attempting read")
                 return data
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -54,14 +54,14 @@ class SyncSocketStream:
 
     def read(self, n: int, timeout: TimeoutDict) -> bytes:
         read_timeout = timeout.get("read")
-        exc_map = {socket.timeout: ReadTimeout, OSError: ReadError}
+        exc_map = {socket.timeout: ReadTimeout, socket.error: ReadError}
 
         with self.read_lock:
             with map_exceptions(exc_map):
                 self.sock.settimeout(read_timeout)
                 data = self.sock.recv(n)
                 if data == b"":
-                    raise OSError("Server disconnected while attempting read")
+                    raise ReadError("Server disconnected while attempting read")
                 return data
 
     def write(self, data: bytes, timeout: TimeoutDict) -> None:

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -55,20 +55,14 @@ class SocketStream(AsyncSocketStream):
 
     async def read(self, n: int, timeout: TimeoutDict) -> bytes:
         read_timeout = none_as_inf(timeout.get("read"))
-        exc_map = {trio.TooSlowError: ReadTimeout, OSError: ReadError}
+        exc_map = {trio.TooSlowError: ReadTimeout, trio.BrokenResourceError: ReadError}
 
         async with self.read_lock:
             with map_exceptions(exc_map):
                 with trio.fail_after(read_timeout):
-                    try:
-                        data = await self.stream.receive_some(max_bytes=n)
-                    except trio.BrokenResourceError:
-                        message = "Server disconnected while attempting read"
-                        raise OSError(message) from None
-
+                    data = await self.stream.receive_some(max_bytes=n)
                     if data == b"":
-                        raise OSError("Server disconnected while attempting read")
-
+                        raise ReadError("Server disconnected while attempting read")
                     return data
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import typing
 
 import pytest
 import trustme
-
 from mitmproxy import options, proxy
 from mitmproxy.tools.dump import DumpMaster
 


### PR DESCRIPTION
Fixes #110, cc @nawarnoori

Now, the test setup detailed in https://github.com/encode/httpcore/issues/110#issuecomment-654891958 results in the following error in all cases:

```console
httpcore._exceptions.ReadError: Server disconnected while attempting read
```