### PR TITLE
Fix proxy_server fixture URL type

### DIFF
--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,9 +1,9 @@
 import ssl
-import typing
 
 import pytest
 
 import httpcore
+from httpcore._types import URL
 
 
 async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
@@ -180,9 +180,7 @@ async def test_http_request_cannot_reuse_dropped_connection() -> None:
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.usefixtures("async_environment")
-async def test_http_proxy(
-    proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
-) -> None:
+async def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
     method = b"GET"
     url = (b"http", b"example.org", 80, b"/")
     headers = [(b"host", b"example.org")]
@@ -209,10 +207,7 @@ async def test_http_proxy(
 @pytest.mark.usefixtures("async_environment")
 @pytest.mark.parametrize("http2", [False, True])
 async def test_proxy_https_requests(
-    proxy_server: typing.Tuple[bytes, bytes, int],
-    ca_ssl_context: ssl.SSLContext,
-    proxy_mode: str,
-    http2: bool,
+    proxy_server: URL, ca_ssl_context: ssl.SSLContext, proxy_mode: str, http2: bool,
 ) -> None:
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,10 @@ import typing
 
 import pytest
 import trustme
-
 from mitmproxy import options, proxy
 from mitmproxy.tools.dump import DumpMaster
+
+from httpcore._types import URL
 
 PROXY_HOST = "127.0.0.1"
 PROXY_PORT = 8080
@@ -101,9 +102,7 @@ def example_org_cert_path(example_org_cert: trustme.LeafCert) -> typing.Iterator
 
 
 @pytest.fixture()
-def proxy_server(
-    example_org_cert_path: str,
-) -> typing.Iterator[typing.Tuple[bytes, bytes, int]]:
+def proxy_server(example_org_cert_path: str) -> typing.Iterator[URL]:
     """Starts a proxy server on a different thread and yields its origin tuple.
 
     The server is configured to use a trustme CA and key, this will allow our
@@ -118,6 +117,6 @@ def proxy_server(
         thread = ProxyWrapper(PROXY_HOST, PROXY_PORT, certs=[example_org_cert_path])
         thread.start()
         thread.notify.started.wait()
-        yield (b"http", PROXY_HOST.encode(), PROXY_PORT)
+        yield (b"http", PROXY_HOST.encode(), PROXY_PORT, b"/")
     finally:
         thread.join()

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,9 +1,9 @@
 import ssl
-import typing
 
 import pytest
 
 import httpcore
+from httpcore._types import URL
 
 
 def read_body(stream: httpcore.SyncByteStream) -> bytes:
@@ -180,9 +180,7 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 
-def test_http_proxy(
-    proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
-) -> None:
+def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
     method = b"GET"
     url = (b"http", b"example.org", 80, b"/")
     headers = [(b"host", b"example.org")]
@@ -209,10 +207,7 @@ def test_http_proxy(
 
 @pytest.mark.parametrize("http2", [False, True])
 def test_proxy_https_requests(
-    proxy_server: typing.Tuple[bytes, bytes, int],
-    ca_ssl_context: ssl.SSLContext,
-    proxy_mode: str,
-    http2: bool,
+    proxy_server: URL, ca_ssl_context: ssl.SSLContext, proxy_mode: str, http2: bool,
 ) -> None:
     method = b"GET"
     url = (b"https", b"example.org", 443, b"/")


### PR DESCRIPTION
A quick one - `proxy_server` was using the old `(bytes, bytes, int)` URL form instead of `(bytes, bytes, Optional[int], bytes)`, which was causing mypy errors.

(Related: I think we should also try to get mypy to run on `tests/`, for the same reason than in HTTPX - it helps us catch any usage-related type hints bugs.)