### PR TITLE
Prettify unasync output

### DIFF
--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import Iterator, Callable, List, Tuple, Type
+from typing import Callable, Iterator, List, Tuple, Type
 
 from .._types import URL, Headers, TimeoutDict
 

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,14 +1,14 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple, Union
 
-from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
+from .._backends.auto import SyncBackend, SyncLock, SyncSocketStream
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, url_to_origin
 from .base import (
-    SyncByteStream,
-    SyncHTTPTransport,
     ConnectionState,
     NewConnectionRequired,
+    SyncByteStream,
+    SyncHTTPTransport,
 )
 from .http2 import SyncHTTP2Connection
 from .http11 import SyncHTTP11Connection
@@ -89,9 +89,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
         try:
-            return self.backend.open_tcp_stream(
-                hostname, port, ssl_context, timeout
-            )
+            return self.backend.open_tcp_stream(hostname, port, ssl_context, timeout)
         except Exception:
             self.connect_failed = True
             raise

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,16 +1,16 @@
 from ssl import SSLContext
-from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
 
-from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
+from .._backends.auto import SyncBackend, SyncLock, SyncSemaphore
 from .._exceptions import PoolTimeout
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
 from .base import (
-    SyncByteStream,
-    SyncHTTPTransport,
     ConnectionState,
     NewConnectionRequired,
+    SyncByteStream,
+    SyncHTTPTransport,
 )
 from .connection import SyncHTTPConnection
 
@@ -164,9 +164,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         )
         return response[0], response[1], response[2], response[3], wrapped_stream
 
-    def _get_connection_from_pool(
-        self, origin: Origin
-    ) -> Optional[SyncHTTPConnection]:
+    def _get_connection_from_pool(self, origin: Origin) -> Optional[SyncHTTPConnection]:
         # Determine expired keep alive connections on this origin.
         seen_http11 = False
         pending_connection = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -7,7 +7,7 @@ from .._backends.auto import SyncSocketStream
 from .._exceptions import ProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
-from .base import SyncByteStream, SyncHTTPTransport, ConnectionState
+from .base import ConnectionState, SyncByteStream, SyncHTTPTransport
 
 H11Event = Union[
     h11.Request,
@@ -57,12 +57,9 @@ class SyncHTTP11Connection(SyncHTTPTransport):
 
         self._send_request(method, url, headers, timeout)
         self._send_request_body(stream, timeout)
-        (
-            http_version,
-            status_code,
-            reason_phrase,
-            headers,
-        ) = self._receive_response(timeout)
+        (http_version, status_code, reason_phrase, headers,) = self._receive_response(
+            timeout
+        )
         stream = SyncByteStream(
             iterator=self._receive_response_data(timeout),
             close_func=self._response_closed,
@@ -84,9 +81,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         event = h11.Request(method=method, target=target, headers=headers)
         self._send_event(event, timeout)
 
-    def _send_request_body(
-        self, stream: SyncByteStream, timeout: TimeoutDict
-    ) -> None:
+    def _send_request_body(self, stream: SyncByteStream, timeout: TimeoutDict) -> None:
         """
         Send the request body.
         """
@@ -121,9 +116,7 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         http_version = b"HTTP/" + event.http_version
         return http_version, event.status_code, event.reason, event.headers
 
-    def _receive_response_data(
-        self, timeout: TimeoutDict
-    ) -> Iterator[bytes]:
+    def _receive_response_data(self, timeout: TimeoutDict) -> Iterator[bytes]:
         """
         Read the response data from the network.
         """

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from ssl import SSLContext
-from typing import Iterator, Dict, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import h2.connection
 import h2.events
@@ -8,15 +8,15 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import SyncLock, SyncSemaphore, SyncSocketStream, SyncBackend
+from .._backends.auto import SyncBackend, SyncLock, SyncSemaphore, SyncSocketStream
 from .._exceptions import PoolTimeout, ProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import (
-    SyncByteStream,
-    SyncHTTPTransport,
     ConnectionState,
     NewConnectionRequired,
+    SyncByteStream,
+    SyncHTTPTransport,
 )
 
 logger = get_logger(__name__)
@@ -187,9 +187,7 @@ class SyncHTTP2Connection(SyncHTTPTransport):
             flow = min(local_flow, connection_flow)
         return flow
 
-    def wait_for_event(
-        self, stream_id: int, timeout: TimeoutDict
-    ) -> h2.events.Event:
+    def wait_for_event(self, stream_id: int, timeout: TimeoutDict) -> h2.events.Event:
         """
         Returns the next event for a given stream.
         If no events are available yet, then waits on the network until
@@ -228,9 +226,7 @@ class SyncHTTP2Connection(SyncHTTPTransport):
         data_to_send = self.h2_state.data_to_send()
         self.socket.write(data_to_send, timeout)
 
-    def send_data(
-        self, stream_id: int, chunk: bytes, timeout: TimeoutDict
-    ) -> None:
+    def send_data(self, stream_id: int, chunk: bytes, timeout: TimeoutDict) -> None:
         logger.trace("send_data stream_id=%r chunk=%r", stream_id, chunk)
         self.h2_state.send_data(stream_id, chunk)
         data_to_send = self.h2_state.data_to_send()

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -6,7 +6,7 @@ from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, url_to_origin
 from .base import SyncByteStream
 from .connection import SyncHTTPConnection
-from .connection_pool import SyncConnectionPool, ResponseByteStream
+from .connection_pool import ResponseByteStream, SyncConnectionPool
 
 logger = get_logger(__name__)
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,7 +8,8 @@ export SOURCE_FILES="httpcore tests"
 
 set -x
 
+scripts/unasync
+
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
 ${PREFIX}isort --project=httpcore $SOURCE_FILES
-${PREFIX}black --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' --target-version=py36 $SOURCE_FILES
-scripts/unasync
+${PREFIX}black --target-version=py36 $SOURCE_FILES

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import typing
 
 import pytest
 import trustme
-
 from mitmproxy import options, proxy
 from mitmproxy.tools.dump import DumpMaster
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -16,7 +16,6 @@ def read_body(stream: httpcore.SyncByteStream) -> bytes:
         stream.close()
 
 
-
 def test_http_request() -> None:
     with httpcore.SyncConnectionPool() as http:
         method = b"GET"
@@ -31,7 +30,6 @@ def test_http_request() -> None:
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1  # type: ignore
-
 
 
 def test_https_request() -> None:
@@ -50,7 +48,6 @@ def test_https_request() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-
 def test_http2_request() -> None:
     with httpcore.SyncConnectionPool(http2=True) as http:
         method = b"GET"
@@ -67,7 +64,6 @@ def test_http2_request() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-
 def test_closing_http_request() -> None:
     with httpcore.SyncConnectionPool() as http:
         method = b"GET"
@@ -82,7 +78,6 @@ def test_closing_http_request() -> None:
         assert status_code == 200
         assert reason == b"OK"
         assert url[:3] not in http._connections  # type: ignore
-
 
 
 def test_http_request_reuse_connection() -> None:
@@ -114,7 +109,6 @@ def test_http_request_reuse_connection() -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-
 def test_https_request_reuse_connection() -> None:
     with httpcore.SyncConnectionPool() as http:
         method = b"GET"
@@ -142,7 +136,6 @@ def test_https_request_reuse_connection() -> None:
         assert status_code == 200
         assert reason == b"OK"
         assert len(http._connections[url[:3]]) == 1  # type: ignore
-
 
 
 def test_http_request_cannot_reuse_dropped_connection() -> None:
@@ -179,7 +172,6 @@ def test_http_request_cannot_reuse_dropped_connection() -> None:
 
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
-
 def test_http_proxy(
     proxy_server: typing.Tuple[bytes, bytes, int], proxy_mode: str
 ) -> None:
@@ -206,7 +198,6 @@ def test_http_proxy(
 
 # mitmproxy does not support forwarding HTTPS requests
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "TUNNEL_ONLY"])
-
 @pytest.mark.parametrize("http2", [False, True])
 def test_proxy_https_requests(
     proxy_server: typing.Tuple[bytes, bytes, int],
@@ -244,7 +235,6 @@ def test_proxy_https_requests(
         (True, ["HTTP/2, ACTIVE, 2 streams"]),
     ],
 )
-
 def test_connection_pool_get_connection_info(http2, expected) -> None:
     with httpcore.SyncConnectionPool(http2=http2) as http:
         method = b"GET"


### PR DESCRIPTION
Mostly a developer quality of life improvement — I figured it was easy enough to tweak our `lint` script so that it runs code formatters on the unasynced code, so that when navigating the sync code we can save things without the IDE reformatting everything.

The important bit here is the modification to `scripts/lint`: https://github.com/encode/httpcore/pull/114/files#diff-6694ef873aea668ceffff73715edc0fd
The rest comes from running `scripts/lint`.