### PR TITLE
Fix headers in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ async with httpcore.AsyncConnectionPool() as http:
     http_version, status_code, reason_phrase, headers, stream = await http.request(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
+        headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
     )
 
     try:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ async with httpcore.AsyncConnectionPool() as http:
     http_version, status_code, reason_phrase, headers, stream = await http.request(
         method=b'GET',
         url=(b'https', b'example.org', 433, b'/'),
-        headers=[(b'host': b'example.org'), (b'user-agent': 'httpcore')]
+        headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
     )
 
     try:


### PR DESCRIPTION
- The `README.md` example was missing the mandatory `host` header. Used the same as in the docs home example for consistency.
- The `headers` in docs home were using an invalid syntax.