### PR TITLE
Tweak TimeoutDict type variance

### DIFF
--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -2,10 +2,10 @@
 Type definitions for type checking purposes.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Mapping, Optional, Tuple, Union
 
 StrOrBytes = Union[str, bytes]
 Origin = Tuple[bytes, bytes, int]
 URL = Tuple[bytes, bytes, Optional[int], bytes]
 Headers = List[Tuple[bytes, bytes]]
-TimeoutDict = Dict[str, Optional[float]]
+TimeoutDict = Mapping[str, Optional[float]]


### PR DESCRIPTION
Fixes a mypy error when `timeout` is defined as a separate variable:

```python
import httpcore

timeout = {"pool": 5.0}

with httpcore.SyncConnectionPool() as http:
    _ = http.request(b"GET", (b"https", b"example.com", 443, b"/"), timeout=timeout)
```

```console
debug/test.py:6: error: Argument "timeout" to "request" of "SyncHTTPTransport" has incompatible type "Dict[str, float]"; expected "Optional[Dict[str, Optional[float]]]"
debug/test.py:6: note: "Dict" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
debug/test.py:6: note: Consider using "Mapping" instead, which is covariant in the value type
Found 1 error in 1 file (checked 1 source file)
```

We've seen instances of this several times in the past for HTTPCore and HTTPX, it's a common gotcha…