### PR TITLE
Optional HTTP/2

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -10,7 +10,7 @@ from .base import (
     ConnectionState,
     NewConnectionRequired,
 )
-from .http import BaseHTTPConnection
+from .http import AsyncBaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
-        self.connection: Optional[BaseHTTPConnection] = None
+        self.connection: Optional[AsyncBaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
         self.connect_failed = False

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,5 +1,5 @@
 from ssl import SSLContext
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from .._backends.auto import AsyncLock, AsyncSocketStream, AutoBackend
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -10,8 +10,7 @@ from .base import (
     ConnectionState,
     NewConnectionRequired,
 )
-from .http2 import AsyncHTTP2Connection
-from .http11 import AsyncHTTP11Connection
+from .http import BaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -32,7 +31,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
-        self.connection: Union[None, AsyncHTTP11Connection, AsyncHTTP2Connection] = None
+        self.connection: Optional[BaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
         self.connect_failed = False
@@ -110,11 +109,15 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
             "create_connection socket=%r http_version=%r", socket, http_version
         )
         if http_version == "HTTP/2":
+            from .http2 import AsyncHTTP2Connection
+
             self.is_http2 = True
             self.connection = AsyncHTTP2Connection(
                 socket=socket, backend=self.backend, ssl_context=self.ssl_context
             )
         else:
+            from .http11 import AsyncHTTP11Connection
+
             self.is_http11 = True
             self.connection = AsyncHTTP11Connection(
                 socket=socket, ssl_context=self.ssl_context
@@ -126,7 +129,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
             return ConnectionState.CLOSED
         elif self.connection is None:
             return ConnectionState.PENDING
-        return self.connection.state
+        return self.connection.get_state()
 
     def is_connection_dropped(self) -> bool:
         return self.connection is not None and self.connection.is_connection_dropped()
@@ -138,9 +141,8 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
     async def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
         if self.connection is not None:
             logger.trace("start_tls hostname=%r timeout=%r", hostname, timeout)
-            await self.connection.start_tls(hostname, timeout)
+            self.socket = await self.connection.start_tls(hostname, timeout)
             logger.trace("start_tls complete hostname=%r timeout=%r", hostname, timeout)
-            self.socket = self.connection.socket
 
     async def aclose(self) -> None:
         async with self.request_lock:

--- a/httpcore/_async/http.py
+++ b/httpcore/_async/http.py
@@ -3,7 +3,7 @@ from .._types import TimeoutDict
 from .base import AsyncHTTPTransport, ConnectionState
 
 
-class BaseHTTPConnection(AsyncHTTPTransport):
+class AsyncBaseHTTPConnection(AsyncHTTPTransport):
     def info(self) -> str:
         raise NotImplementedError()  # pragma: nocover
 

--- a/httpcore/_async/http.py
+++ b/httpcore/_async/http.py
@@ -1,0 +1,35 @@
+from .._backends.auto import AsyncSocketStream
+from .._types import TimeoutDict
+from .base import AsyncHTTPTransport, ConnectionState
+
+
+class BaseHTTPConnection(AsyncHTTPTransport):
+    def info(self) -> str:
+        raise NotImplementedError()  # pragma: nocover
+
+    def get_state(self) -> ConnectionState:
+        """
+        Return the current state.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    def mark_as_ready(self) -> None:
+        """
+        The connection has been acquired from the pool, and the state
+        should reflect that.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    def is_connection_dropped(self) -> bool:
+        """
+        Return 'True' if the connection has been dropped by the remote end.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    async def start_tls(
+        self, hostname: bytes, timeout: TimeoutDict = None
+    ) -> AsyncSocketStream:
+        """
+        Upgrade the underlying socket to TLS.
+        """
+        raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -8,7 +8,7 @@ from .._exceptions import ProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import AsyncByteStream, ConnectionState
-from .http import BaseHTTPConnection
+from .http import AsyncBaseHTTPConnection
 
 H11Event = Union[
     h11.Request,
@@ -22,7 +22,7 @@ H11Event = Union[
 logger = get_logger(__name__)
 
 
-class AsyncHTTP11Connection(BaseHTTPConnection):
+class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
     READ_NUM_BYTES = 4096
 
     def __init__(

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -13,7 +13,7 @@ from .._exceptions import PoolTimeout, ProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import AsyncByteStream, ConnectionState, NewConnectionRequired
-from .http import BaseHTTPConnection
+from .http import AsyncBaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -25,7 +25,7 @@ def get_reason_phrase(status_code: int) -> bytes:
         return b""
 
 
-class AsyncHTTP2Connection(BaseHTTPConnection):
+class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
     READ_NUM_BYTES = 4096
     CONFIG = H2Configuration(validate_inbound_headers=False)
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -12,12 +12,8 @@ from .._backends.auto import AsyncLock, AsyncSemaphore, AsyncSocketStream, AutoB
 from .._exceptions import PoolTimeout, ProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
-from .base import (
-    AsyncByteStream,
-    AsyncHTTPTransport,
-    ConnectionState,
-    NewConnectionRequired,
-)
+from .base import AsyncByteStream, ConnectionState, NewConnectionRequired
+from .http import BaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -29,7 +25,7 @@ def get_reason_phrase(status_code: int) -> bytes:
         return b""
 
 
-class AsyncHTTP2Connection(AsyncHTTPTransport):
+class AsyncHTTP2Connection(BaseHTTPConnection):
     READ_NUM_BYTES = 4096
     CONFIG = H2Configuration(validate_inbound_headers=False)
 
@@ -84,8 +80,13 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
             )
         return self._max_streams_semaphore
 
-    async def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
-        pass
+    async def start_tls(
+        self, hostname: bytes, timeout: TimeoutDict = None
+    ) -> AsyncSocketStream:
+        raise NotImplementedError("TLS upgrade not supported on HTTP/2 connections.")
+
+    def get_state(self) -> ConnectionState:
+        return self.state
 
     def mark_as_ready(self) -> None:
         if self.state == ConnectionState.IDLE:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,5 +1,5 @@
 from ssl import SSLContext
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -10,8 +10,7 @@ from .base import (
     ConnectionState,
     NewConnectionRequired,
 )
-from .http2 import SyncHTTP2Connection
-from .http11 import SyncHTTP11Connection
+from .http import BaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -32,7 +31,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
-        self.connection: Union[None, SyncHTTP11Connection, SyncHTTP2Connection] = None
+        self.connection: Optional[BaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
         self.connect_failed = False
@@ -110,11 +109,15 @@ class SyncHTTPConnection(SyncHTTPTransport):
             "create_connection socket=%r http_version=%r", socket, http_version
         )
         if http_version == "HTTP/2":
+            from .http2 import SyncHTTP2Connection
+
             self.is_http2 = True
             self.connection = SyncHTTP2Connection(
                 socket=socket, backend=self.backend, ssl_context=self.ssl_context
             )
         else:
+            from .http11 import SyncHTTP11Connection
+
             self.is_http11 = True
             self.connection = SyncHTTP11Connection(
                 socket=socket, ssl_context=self.ssl_context
@@ -126,7 +129,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
             return ConnectionState.CLOSED
         elif self.connection is None:
             return ConnectionState.PENDING
-        return self.connection.state
+        return self.connection.get_state()
 
     def is_connection_dropped(self) -> bool:
         return self.connection is not None and self.connection.is_connection_dropped()
@@ -138,9 +141,8 @@ class SyncHTTPConnection(SyncHTTPTransport):
     def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
         if self.connection is not None:
             logger.trace("start_tls hostname=%r timeout=%r", hostname, timeout)
-            self.connection.start_tls(hostname, timeout)
+            self.socket = self.connection.start_tls(hostname, timeout)
             logger.trace("start_tls complete hostname=%r timeout=%r", hostname, timeout)
-            self.socket = self.connection.socket
 
     def close(self) -> None:
         with self.request_lock:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -10,7 +10,7 @@ from .base import (
     ConnectionState,
     NewConnectionRequired,
 )
-from .http import BaseHTTPConnection
+from .http import SyncBaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
-        self.connection: Optional[BaseHTTPConnection] = None
+        self.connection: Optional[SyncBaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
         self.connect_failed = False

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -3,7 +3,7 @@ from .._types import TimeoutDict
 from .base import SyncHTTPTransport, ConnectionState
 
 
-class BaseHTTPConnection(SyncHTTPTransport):
+class SyncBaseHTTPConnection(SyncHTTPTransport):
     def info(self) -> str:
         raise NotImplementedError()  # pragma: nocover
 

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -1,0 +1,35 @@
+from .._backends.auto import SyncSocketStream
+from .._types import TimeoutDict
+from .base import SyncHTTPTransport, ConnectionState
+
+
+class BaseHTTPConnection(SyncHTTPTransport):
+    def info(self) -> str:
+        raise NotImplementedError()  # pragma: nocover
+
+    def get_state(self) -> ConnectionState:
+        """
+        Return the current state.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    def mark_as_ready(self) -> None:
+        """
+        The connection has been acquired from the pool, and the state
+        should reflect that.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    def is_connection_dropped(self) -> bool:
+        """
+        Return 'True' if the connection has been dropped by the remote end.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    def start_tls(
+        self, hostname: bytes, timeout: TimeoutDict = None
+    ) -> SyncSocketStream:
+        """
+        Upgrade the underlying socket to TLS.
+        """
+        raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -8,7 +8,7 @@ from .._exceptions import ProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import SyncByteStream, ConnectionState
-from .http import BaseHTTPConnection
+from .http import SyncBaseHTTPConnection
 
 H11Event = Union[
     h11.Request,
@@ -22,7 +22,7 @@ H11Event = Union[
 logger = get_logger(__name__)
 
 
-class SyncHTTP11Connection(BaseHTTPConnection):
+class SyncHTTP11Connection(SyncBaseHTTPConnection):
     READ_NUM_BYTES = 4096
 
     def __init__(

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -7,7 +7,8 @@ from .._backends.auto import SyncSocketStream
 from .._exceptions import ProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
-from .base import SyncByteStream, SyncHTTPTransport, ConnectionState
+from .base import SyncByteStream, ConnectionState
+from .http import BaseHTTPConnection
 
 H11Event = Union[
     h11.Request,
@@ -21,7 +22,7 @@ H11Event = Union[
 logger = get_logger(__name__)
 
 
-class SyncHTTP11Connection(SyncHTTPTransport):
+class SyncHTTP11Connection(BaseHTTPConnection):
     READ_NUM_BYTES = 4096
 
     def __init__(
@@ -39,6 +40,9 @@ class SyncHTTP11Connection(SyncHTTPTransport):
 
     def info(self) -> str:
         return f"HTTP/1.1, {self.state.name}"
+
+    def get_state(self) -> ConnectionState:
+        return self.state
 
     def mark_as_ready(self) -> None:
         if self.state == ConnectionState.IDLE:
@@ -72,9 +76,12 @@ class SyncHTTP11Connection(SyncHTTPTransport):
         )
         return (http_version, status_code, reason_phrase, headers, stream)
 
-    def start_tls(self, hostname: bytes, timeout: TimeoutDict = None) -> None:
+    def start_tls(
+        self, hostname: bytes, timeout: TimeoutDict = None
+    ) -> SyncSocketStream:
         timeout = {} if timeout is None else timeout
         self.socket = self.socket.start_tls(hostname, self.ssl_context, timeout)
+        return self.socket
 
     def _send_request(
         self, method: bytes, url: URL, headers: Headers, timeout: TimeoutDict,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -13,7 +13,7 @@ from .._exceptions import PoolTimeout, ProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import SyncByteStream, ConnectionState, NewConnectionRequired
-from .http import BaseHTTPConnection
+from .http import SyncBaseHTTPConnection
 
 logger = get_logger(__name__)
 
@@ -25,7 +25,7 @@ def get_reason_phrase(status_code: int) -> bytes:
         return b""
 
 
-class SyncHTTP2Connection(BaseHTTPConnection):
+class SyncHTTP2Connection(SyncBaseHTTPConnection):
     READ_NUM_BYTES = 4096
     CONFIG = H2Configuration(validate_inbound_headers=False)
 


### PR DESCRIPTION
For consideration.
We might want to think again about having HTTP/2 be an optional install for our `httpx` 1.0 release onwards.

Done:

* Provide a base HTTP Connection class interface, that is agnostic of HTTP/1.1 and HTTP/2.
* Use the base HTTP Connection class for the `.connection` signature in `AsyncHTTPConnection`.
* Lazily import either `AsyncHTTP11Connection` or `AsyncHTTP2Connection` as required.

To do:

* Import `h2` in `AsyncConnectionPool` if `http2=True` is set, so that we get nice early errors if it is not installed.
* Move `h2` to an optional install, requiring `pip install httpcore[http2]`
