### PR TITLE
Support eg. `AsyncByteStream(content=b'...')`

### DIFF
--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -5,10 +5,6 @@ from typing import AsyncIterator, Callable, List, Tuple, Type
 from .._types import URL, Headers, TimeoutDict
 
 
-async def empty() -> AsyncIterator:
-    yield b""
-
-
 class NewConnectionRequired(Exception):
     pass
 
@@ -45,17 +41,25 @@ class AsyncByteStream:
     """
 
     def __init__(
-        self, aiterator: AsyncIterator[bytes] = None, aclose_func: Callable = None,
+        self,
+        content: bytes = b"",
+        aiterator: AsyncIterator[bytes] = None,
+        aclose_func: Callable = None,
     ) -> None:
-        self.aiterator = empty() if aiterator is None else aiterator
+        assert aiterator is None or not content
+        self.content = content
+        self.aiterator = aiterator
         self.aclose_func = aclose_func
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         """
         Yield bytes representing the request or response body.
         """
-        async for chunk in self.aiterator:
-            yield chunk
+        if self.aiterator is None:
+            yield self.content
+        else:
+            async for chunk in self.aiterator:
+                yield chunk
 
     async def aclose(self) -> None:
         """

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -5,10 +5,6 @@ from typing import Iterator, Callable, List, Tuple, Type
 from .._types import URL, Headers, TimeoutDict
 
 
-def empty() -> Iterator:
-    yield b""
-
-
 class NewConnectionRequired(Exception):
     pass
 
@@ -45,17 +41,25 @@ class SyncByteStream:
     """
 
     def __init__(
-        self, iterator: Iterator[bytes] = None, close_func: Callable = None,
+        self,
+        content: bytes = b"",
+        iterator: Iterator[bytes] = None,
+        close_func: Callable = None,
     ) -> None:
-        self.iterator = empty() if iterator is None else iterator
+        assert iterator is None or not content
+        self.content = content
+        self.iterator = iterator
         self.close_func = close_func
 
     def __iter__(self) -> Iterator[bytes]:
         """
         Yield bytes representing the request or response body.
         """
-        for chunk in self.iterator:
-            yield chunk
+        if self.iterator is None:
+            yield self.content
+        else:
+            for chunk in self.iterator:
+                yield chunk
 
     def close(self) -> None:
         """


### PR DESCRIPTION
Nicer base class implementations for `AsyncByteStream` and `SyncByteStream`.

Allows for eg `AsyncByteStream(content=b'...')` usages.

Closes #125