### PR TITLE
Add an `UnsupportedProtocol` exception

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -12,6 +12,7 @@ from ._exceptions import (
     ReadError,
     ReadTimeout,
     TimeoutException,
+    UnsupportedProtocol,
     WriteError,
     WriteTimeout,
 )
@@ -38,5 +39,6 @@ __all__ = [
     "ReadError",
     "WriteError",
     "CloseError",
+    "UnsupportedProtocol",
 ]
 __version__ = "0.9.1"

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -126,7 +126,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     ) -> Tuple[bytes, int, bytes, Headers, AsyncByteStream]:
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
-            raise UnsupportedProtocol("Unsupported URL protocol '{scheme}'")
+            raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")
 
         origin = url_to_origin(url)
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -2,7 +2,7 @@ from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
 
 from .._backends.auto import AsyncLock, AsyncSemaphore, AutoBackend
-from .._exceptions import PoolTimeout
+from .._exceptions import PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -124,7 +124,10 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         stream: AsyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, AsyncByteStream]:
-        assert url[0] in (b"http", b"https")
+        if url[0] not in (b"http", b"https"):
+            scheme = url[0].decode("latin-1")
+            raise UnsupportedProtocol("Unsupported URL protocol '{scheme}'")
+
         origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:

--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -13,6 +13,10 @@ def map_exceptions(map: Dict[Type[Exception], Type[Exception]]) -> Iterator[None
         raise
 
 
+class UnsupportedProtocol(Exception):
+    pass
+
+
 class ProtocolError(Exception):
     pass
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -126,7 +126,7 @@ class SyncConnectionPool(SyncHTTPTransport):
     ) -> Tuple[bytes, int, bytes, Headers, SyncByteStream]:
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
-            raise UnsupportedProtocol("Unsupported URL protocol '{scheme}'")
+            raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")
 
         origin = url_to_origin(url)
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -2,7 +2,7 @@ from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple
 
 from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
-from .._exceptions import PoolTimeout
+from .._exceptions import PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -124,7 +124,10 @@ class SyncConnectionPool(SyncHTTPTransport):
         stream: SyncByteStream = None,
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, SyncByteStream]:
-        assert url[0] in (b"http", b"https")
+        if url[0] not in (b"http", b"https"):
+            scheme = url[0].decode("latin-1")
+            raise UnsupportedProtocol("Unsupported URL protocol '{scheme}'")
+
         origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -57,9 +57,7 @@ async def test_ftp_request() -> None:
         url = (b"ftp", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
         with pytest.raises(httpcore.UnsupportedProtocol):
-            http_version, status_code, reason, headers, stream = await http.request(
-                method, url, headers
-            )
+            await http.request(method, url, headers)
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -51,6 +51,18 @@ async def test_https_request() -> None:
 
 
 @pytest.mark.usefixtures("async_environment")
+async def test_ftp_request() -> None:
+    async with httpcore.AsyncConnectionPool() as http:
+        method = b"GET"
+        url = (b"ftp", b"example.org", 443, b"/")
+        headers = [(b"host", b"example.org")]
+        with pytest.raises(httpcore.UnsupportedProtocol):
+            http_version, status_code, reason, headers, stream = await http.request(
+                method, url, headers
+            )
+
+
+@pytest.mark.usefixtures("async_environment")
 async def test_http2_request() -> None:
     async with httpcore.AsyncConnectionPool(http2=True) as http:
         method = b"GET"

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -51,7 +51,7 @@ async def test_https_request() -> None:
 
 
 @pytest.mark.usefixtures("async_environment")
-async def test_ftp_request() -> None:
+async def test_request_unsupported_protocol() -> None:
     async with httpcore.AsyncConnectionPool() as http:
         method = b"GET"
         url = (b"ftp", b"example.org", 443, b"/")

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -51,15 +51,13 @@ def test_https_request() -> None:
 
 
 
-def test_ftp_request() -> None:
+def test_request_unsupported_protocol() -> None:
     with httpcore.SyncConnectionPool() as http:
         method = b"GET"
         url = (b"ftp", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
         with pytest.raises(httpcore.UnsupportedProtocol):
-            http_version, status_code, reason, headers, stream = http.request(
-                method, url, headers
-            )
+            http.request(method, url, headers)
 
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -51,6 +51,18 @@ def test_https_request() -> None:
 
 
 
+def test_ftp_request() -> None:
+    with httpcore.SyncConnectionPool() as http:
+        method = b"GET"
+        url = (b"ftp", b"example.org", 443, b"/")
+        headers = [(b"host", b"example.org")]
+        with pytest.raises(httpcore.UnsupportedProtocol):
+            http_version, status_code, reason, headers, stream = http.request(
+                method, url, headers
+            )
+
+
+
 def test_http2_request() -> None:
     with httpcore.SyncConnectionPool(http2=True) as http:
         method = b"GET"


### PR DESCRIPTION
Closes #124

Once we tie this exception through to `httpx`, this will allow us to drop `enforce_http_url` in `httpx`, and instead defer the decision entirely to the transport layer.

Will later allow us to support mounting transports on schemes other than `http`, `https`.