### PR TITLE
Add LocalProtocolError, RemoteProtocolError

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -8,6 +8,8 @@ from ._exceptions import (
     NetworkError,
     PoolTimeout,
     ProtocolError,
+    RemoteProtocolError,
+    LocalProtocolError,
     ProxyError,
     ReadError,
     ReadTimeout,
@@ -38,5 +40,7 @@ __all__ = [
     "ReadError",
     "WriteError",
     "CloseError",
+    "LocalProtocolError",
+    "RemoteProtocolError",
 ]
 __version__ = "0.9.1"

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -2,7 +2,7 @@ from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
 
 from .._backends.auto import AsyncLock, AsyncSemaphore, AutoBackend
-from .._exceptions import PoolTimeout
+from .._exceptions import PoolTimeout, LocalProtocolError
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -125,6 +125,10 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, AsyncByteStream]:
         assert url[0] in (b"http", b"https")
+
+        if not url[1]:
+            raise LocalProtocolError("Missing hostname in URL.")
+
         origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -127,7 +127,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
             raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")
-         if not url[1]:
+        if not url[1]:
             raise LocalProtocolError("Missing hostname in URL.")
 
         origin = url_to_origin(url)

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -4,7 +4,7 @@ from typing import AsyncIterator, List, Tuple, Union
 import h11
 
 from .._backends.auto import AsyncSocketStream
-from .._exceptions import ProtocolError, map_exceptions
+from .._exceptions import RemoteProtocolError, LocalProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import AsyncByteStream, AsyncHTTPTransport, ConnectionState
@@ -84,7 +84,8 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
         """
         logger.trace("send_request method=%r url=%r headers=%s", method, url, headers)
         _scheme, _host, _port, target = url
-        event = h11.Request(method=method, target=target, headers=headers)
+        with map_exceptions({h11.LocalProtocolError: LocalProtocolError}):
+            event = h11.Request(method=method, target=target, headers=headers)
         await self._send_event(event, timeout)
 
     async def _send_request_body(
@@ -144,7 +145,7 @@ class AsyncHTTP11Connection(AsyncHTTPTransport):
         Read a single `h11` event, reading more data from the network if needed.
         """
         while True:
-            with map_exceptions({h11.RemoteProtocolError: ProtocolError}):
+            with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
                 event = self.h11_state.next_event()
 
             if event is h11.NEED_DATA:

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -9,7 +9,7 @@ from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
 from .._backends.auto import AsyncLock, AsyncSemaphore, AsyncSocketStream, AutoBackend
-from .._exceptions import PoolTimeout, ProtocolError
+from .._exceptions import PoolTimeout, RemoteProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import (
@@ -214,7 +214,7 @@ class AsyncHTTP2Connection(AsyncHTTPTransport):
             logger.trace("receive_event stream_id=%r event=%s", event_stream_id, event)
 
             if hasattr(event, "error_code"):
-                raise ProtocolError(event)
+                raise RemoteProtocolError(event)
 
             if event_stream_id in self.events:
                 self.events[event_stream_id].append(event)

--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -17,6 +17,14 @@ class ProtocolError(Exception):
     pass
 
 
+class RemoteProtocolError(ProtocolError):
+    pass
+
+
+class LocalProtocolError(ProtocolError):
+    pass
+
+
 class ProxyError(Exception):
     pass
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -127,7 +127,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
             raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")
-         if not url[1]:
+        if not url[1]:
             raise LocalProtocolError("Missing hostname in URL.")
 
         origin = url_to_origin(url)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -2,7 +2,7 @@ from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple
 
 from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
-from .._exceptions import PoolTimeout
+from .._exceptions import PoolTimeout, LocalProtocolError
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -125,6 +125,10 @@ class SyncConnectionPool(SyncHTTPTransport):
         timeout: TimeoutDict = None,
     ) -> Tuple[bytes, int, bytes, Headers, SyncByteStream]:
         assert url[0] in (b"http", b"https")
+
+        if not url[1]:
+            raise LocalProtocolError("Missing hostname in URL.")
+
         origin = url_to_origin(url)
 
         if self._keepalive_expiry is not None:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -9,7 +9,7 @@ from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
 from .._backends.auto import SyncLock, SyncSemaphore, SyncSocketStream, SyncBackend
-from .._exceptions import PoolTimeout, ProtocolError
+from .._exceptions import PoolTimeout, RemoteProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import (
@@ -214,7 +214,7 @@ class SyncHTTP2Connection(SyncHTTPTransport):
             logger.trace("receive_event stream_id=%r event=%s", event_stream_id, event)
 
             if hasattr(event, "error_code"):
-                raise ProtocolError(event)
+                raise RemoteProtocolError(event)
 
             if event_stream_id in self.events:
                 self.events[event_stream_id].append(event)


### PR DESCRIPTION
Distinguish between local and remote protocol errors, so that we can expose local errors for invalid requests, eg...

```python
>>> import httpcore
>>> http = httpcore.SyncConnectionPool()
>>> http.request(b"GET", (b'https', b'example.org', 443, b'/'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_sync/connection_pool.py", line 153, in request
    method, url, headers=headers, stream=stream, timeout=timeout
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_sync/connection.py", line 93, in request
    return self.connection.request(method, url, headers, stream, timeout)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_sync/http11.py", line 61, in request
    self._send_request(method, url, headers, timeout)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_sync/http11.py", line 88, in _send_request
    event = h11.Request(method=method, target=target, headers=headers)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_exceptions.py", line 12, in map_exceptions
    raise to_exc(exc) from None
httpcore._exceptions.LocalProtocolError: Missing mandatory Host: header
```

And...

```python
>>> import httpcore
>>> http = httpcore.SyncConnectionPool()
>>> http.request(b"GET", (b'https', b'', 443, b'/'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_sync/connection_pool.py", line 130, in request
    raise LocalProtocolError("Missing hostname in URL.")
httpcore._exceptions.LocalProtocolError: Missing hostname in URL.
```