### PR TITLE
Finalize optional HTTP/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Some things HTTP Core does do:
 * Automatic connection pooling.
 * HTTP(S) proxy support.
 
+## Installation
+
+For HTTP/1.1 only support, install with...
+
+```shell
+$ pip install httpcore
+```
+
+For HTTP/1.1 and HTTP/2 support, install with...
+
+```shell
+$ pip install httpcore[http2]
+```
+
 ## Quickstart
 
 Here's an example of making an HTTP GET request using `httpcore`...

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,20 @@ Some things HTTP Core does do:
 * Automatic connection pooling.
 * HTTP(S) proxy support.
 
+## Installation
+
+For HTTP/1.1 only support, install with...
+
+```shell
+$ pip install httpcore
+```
+
+For HTTP/1.1 and HTTP/2 support, install with...
+
+```shell
+$ pip install httpcore[http2]
+```
+
 ## Quickstart
 
 Here's an example of making an HTTP GET request using `httpcore`...

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -96,6 +96,15 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self._backend = AutoBackend()
         self._next_keepalive_check = 0.0
 
+        if http2:
+            try:
+                import h2
+            except ImportError:
+                raise ImportError(
+                    "Attempted to use http2=True, but the 'h2' "
+                    "package is not installed. Use 'pip install httpcore[http2]'."
+                )
+
     @property
     def _connection_semaphore(self) -> AsyncSemaphore:
         # We do this lazily, to make sure backend autodetection always

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -96,6 +96,15 @@ class SyncConnectionPool(SyncHTTPTransport):
         self._backend = SyncBackend()
         self._next_keepalive_check = 0.0
 
+        if http2:
+            try:
+                import h2
+            except ImportError:
+                raise ImportError(
+                    "Attempted to use http2=True, but the 'h2' "
+                    "package is not installed. Use 'pip install httpcore[http2]'."
+                )
+
     @property
     def _connection_semaphore(self) -> SyncSemaphore:
         # We do this lazily, to make sure backend autodetection always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e .
+-e .[http2]
 
 # Optionals
 trio

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,10 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11>=0.8,<0.10", "h2==3.*", "sniffio==1.*"],
+    install_requires=["h11>=0.8,<0.10", "sniffio==1.*"],
+    extras_require={
+        "http2": ["h2==3.*",]
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     zip_safe=False,
     install_requires=["h11>=0.8,<0.10", "sniffio==1.*"],
     extras_require={
-        "http2": ["h2==3.*",]
+        "http2": ["h2==3.*"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
We'd need to follow up on this with either...

* Making http/2 optional in `httpx` 0.14
* Using `httpcore[http2]` in the `httpx` 0.14 setup.py info.

Of those two I think we should *probably?* push on and make the change with `httpx` 0.14, since it's where we're headed anyway.