### PR TITLE
Version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ Use either `pip install httpcore` for HTTP/1.1 support only, or
 
 - HTTP/2 support becomes optional. (Pull #121, #130)
 - Add `local_address=...` support. (Pull #100, #134)
-- Add `SimpleByteStream`, `IteratorByteStream`, `AsyncIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
+- Add `PlainByteStream`, `IteratorByteStream`, `AsyncIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
 - Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
 - Add `UnsupportedProtocol` exception. (Pull #128)
-- Support simple non-streaming byte content with `AsyncByteStream` and `SyncByteStream`. (#127)
 - Add `.get_connection_info()` method. (Pull #102)
 - Add better TRACE logs. (Pull #101)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0
 
-The most notable change in the 0.10.0 release is that HTTP/2 support is now
-fully optional.
+The most notable change in the 0.10.0 release is that HTTP/2 support is now fully optional.
 
-Use either `pip install httpcore` for HTTP/1.1 support only, or
-`pip install httpcore[http2]` for HTTP/1.1 and HTTP/2 support.
+Use either `pip install httpcore` for HTTP/1.1 support only, or `pip install httpcore[http2]` for HTTP/1.1 and HTTP/2 support.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Use either `pip install httpcore` for HTTP/1.1 support only, or
 
 - HTTP/2 support becomes optional. (Pull #121, #130)
 - Add `local_address=...` support. (Pull #100, #134)
-- Add `ContentByteStream`, `IteratorByteStream`, `AIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
+- Add `SimpleByteStream`, `IteratorByteStream`, `AsyncIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
 - Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
 - Add `UnsupportedProtocol` exception. (Pull #128)
 - Support simple non-streaming byte content with `AsyncByteStream` and `SyncByteStream`. (#127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.10.0
+## 0.10.0 (August 7th, 2020)
 
 The most notable change in the 0.10.0 release is that HTTP/2 support is now fully optional.
 
@@ -17,8 +17,12 @@ Use either `pip install httpcore` for HTTP/1.1 support only, or `pip install htt
 - Add `PlainByteStream`, `IteratorByteStream`, `AsyncIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
 - Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
 - Add `UnsupportedProtocol` exception. (Pull #128)
-- Add `.get_connection_info()` method. (Pull #102)
+- Add `.get_connection_info()` method. (Pull #102, #137)
 - Add better TRACE logs. (Pull #101)
+
+### Changed
+
+- `max_keepalive` is deprecated in favour of `max_keepalive_connections`. (Pull #140)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Use either `pip install httpcore` for HTTP/1.1 support only, or
 ### Added
 
 - HTTP/2 support becomes optional. (Pull #121, #130)
-- Add `local_address=...` support. (Pull #100)
+- Add `local_address=...` support. (Pull #100, #134)
+- Add `ContentByteStream`, `IteratorByteStream`, `AIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
 - Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
 - Add `UnsupportedProtocol` exception. (Pull #128)
 - Support simple non-streaming byte content with `AsyncByteStream` and `SyncByteStream`. (#127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.10.0
+
+The most notable change in the 0.10.0 release is that HTTP/2 support is now
+fully optional.
+
+Use either `pip install httpcore` for HTTP/1.1 support only, or
+`pip install httpcore[http2]` for HTTP/1.1 and HTTP/2 support.
+
+### Added
+
+- HTTP/2 support becomes optional. (Pull #121, #130)
+- Add `local_address=...` support. (Pull #100)
+- Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
+- Add `UnsupportedProtocol` exception. (Pull #128)
+- Support simple non-streaming byte content with `AsyncByteStream` and `SyncByteStream`. (#127)
+- Add `.get_connection_info()` method. (Pull #102)
+- Add better TRACE logs. (Pull #101)
+
+### Fixed
+
+- Improve handling of server disconnects. (Pull #112)
+
 ## 0.9.1 (May 27th, 2020)
 
 ### Fixed

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
     "RemoteProtocolError",
     "UnsupportedProtocol",
 ]
-__version__ = "0.9.1"
+__version__ = "0.10.0"


### PR DESCRIPTION
## 0.10.0 (August 7th, 2020)

The most notable change in the 0.10.0 release is that HTTP/2 support is now fully optional.

Use either `pip install httpcore` for HTTP/1.1 support only, or `pip install httpcore[http2]` for HTTP/1.1 and HTTP/2 support.

### Added

- HTTP/2 support becomes optional. (Pull #121, #130)
- Add `local_address=...` support. (Pull #100, #134)
- Add `PlainByteStream`, `IteratorByteStream`, `AsyncIteratorByteStream`. The `AsyncByteSteam` and `SyncByteStream` classes are now pure interface classes. (#133)
- Add `LocalProtocolError`, `RemoteProtocolError` exceptions. (Pull #129)
- Add `UnsupportedProtocol` exception. (Pull #128)
- Add `.get_connection_info()` method. (Pull #102, #137)
- Add better TRACE logs. (Pull #101)

### Changed

- `max_keepalive` is deprecated in favour of `max_keepalive_connections`. (Pull #140)

### Fixed

- Improve handling of server disconnects. (Pull #112)