### PR TITLE
Improve performance when receiving large responses

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 
 class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
-    READ_NUM_BYTES = 4096
+    READ_NUM_BYTES = 64 * 1024
 
     def __init__(
         self, socket: AsyncSocketStream, ssl_context: SSLContext = None,

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -26,7 +26,7 @@ def get_reason_phrase(status_code: int) -> bytes:
 
 
 class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
-    READ_NUM_BYTES = 4096
+    READ_NUM_BYTES = 64 * 1024
     CONFIG = H2Configuration(validate_inbound_headers=False)
 
     def __init__(

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 
 class SyncHTTP11Connection(SyncBaseHTTPConnection):
-    READ_NUM_BYTES = 4096
+    READ_NUM_BYTES = 64 * 1024
 
     def __init__(
         self, socket: SyncSocketStream, ssl_context: SSLContext = None,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -26,7 +26,7 @@ def get_reason_phrase(status_code: int) -> bytes:
 
 
 class SyncHTTP2Connection(SyncBaseHTTPConnection):
-    READ_NUM_BYTES = 4096
+    READ_NUM_BYTES = 64 * 1024
     CONFIG = H2Configuration(validate_inbound_headers=False)
 
     def __init__(


### PR DESCRIPTION
Fixes #135 

Reading the response body in bigger chunks results in a significant performance boost for large bodies, as shown in graphs listed in #135.