### PR TITLE
Tweak `get_connection_info()` and `keepalive_expiry` behaviour.

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -144,8 +144,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
 
         origin = url_to_origin(url)
 
-        if self._keepalive_expiry is not None:
-            await self._keepalive_sweep()
+        await self._keepalive_sweep()
 
         connection: Optional[AsyncHTTPConnection] = None
         while connection is None:
@@ -262,13 +261,14 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         """
         Remove any IDLE connections that have expired past their keep-alive time.
         """
-        assert self._keepalive_expiry is not None
+        if self._keepalive_expiry is None:
+            return
 
         now = self._backend.time()
         if now < self._next_keepalive_check:
             return
 
-        self._next_keepalive_check = now + 1.0
+        self._next_keepalive_check = now + min(1.0, self._keepalive_expiry)
         connections_to_close = set()
 
         for connection in self._get_all_connections():
@@ -321,10 +321,12 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         for connection in connections:
             await connection.aclose()
 
-    def get_connection_info(self) -> Dict[str, List[str]]:
+    async def get_connection_info(self) -> Dict[str, List[str]]:
         """
         Returns a dict of origin URLs to a list of summary strings for each connection.
         """
+        await self._keepalive_sweep()
+
         stats = {}
         for origin, connections in self._connections.items():
             stats[origin_to_url_string(origin)] = [

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -261,19 +261,52 @@ async def test_proxy_https_requests(
 
 
 @pytest.mark.parametrize(
-    "http2,expected",
+    "http2,keepalive_expiry,expected_during_active,expected_during_idle",
     [
-        (False, ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]),
-        (True, ["HTTP/2, ACTIVE, 2 streams"]),
+        (
+            False,
+            60.0,
+            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://example.org": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
+        ),
+        (
+            True,
+            60.0,
+            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://example.org": ["HTTP/2, IDLE, 0 streams"]},
+        ),
+        (
+            False,
+            0.0,
+            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {},
+        ),
+        (True, 0.0, {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]}, {},),
     ],
 )
 @pytest.mark.usefixtures("async_environment")
-async def test_connection_pool_get_connection_info(http2, expected) -> None:
-    async with httpcore.AsyncConnectionPool(http2=http2) as http:
+async def test_connection_pool_get_connection_info(
+    http2, keepalive_expiry, expected_during_active, expected_during_idle
+) -> None:
+    async with httpcore.AsyncConnectionPool(
+        http2=http2, keepalive_expiry=keepalive_expiry
+    ) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
-        for _ in range(2):
-            _ = await http.request(method, url, headers)
-        stats = http.get_connection_info()
-        assert stats == {"https://example.org": expected}
+
+        _, _, _, _, stream_1 = await http.request(method, url, headers)
+        _, _, _, _, stream_2 = await http.request(method, url, headers)
+
+        try:
+            stats = await http.get_connection_info()
+            assert stats == expected_during_active
+        finally:
+            await read_body(stream_1)
+            await read_body(stream_2)
+
+        stats = await http.get_connection_info()
+        assert stats == expected_during_idle
+
+    stats = await http.get_connection_info()
+    assert stats == {}

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -261,19 +261,52 @@ def test_proxy_https_requests(
 
 
 @pytest.mark.parametrize(
-    "http2,expected",
+    "http2,keepalive_expiry,expected_during_active,expected_during_idle",
     [
-        (False, ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]),
-        (True, ["HTTP/2, ACTIVE, 2 streams"]),
+        (
+            False,
+            60.0,
+            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://example.org": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
+        ),
+        (
+            True,
+            60.0,
+            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://example.org": ["HTTP/2, IDLE, 0 streams"]},
+        ),
+        (
+            False,
+            0.0,
+            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {},
+        ),
+        (True, 0.0, {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]}, {},),
     ],
 )
 
-def test_connection_pool_get_connection_info(http2, expected) -> None:
-    with httpcore.SyncConnectionPool(http2=http2) as http:
+def test_connection_pool_get_connection_info(
+    http2, keepalive_expiry, expected_during_active, expected_during_idle
+) -> None:
+    with httpcore.SyncConnectionPool(
+        http2=http2, keepalive_expiry=keepalive_expiry
+    ) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
-        for _ in range(2):
-            _ = http.request(method, url, headers)
+
+        _, _, _, _, stream_1 = http.request(method, url, headers)
+        _, _, _, _, stream_2 = http.request(method, url, headers)
+
+        try:
+            stats = http.get_connection_info()
+            assert stats == expected_during_active
+        finally:
+            read_body(stream_1)
+            read_body(stream_2)
+
         stats = http.get_connection_info()
-        assert stats == {"https://example.org": expected}
+        assert stats == expected_during_idle
+
+    stats = http.get_connection_info()
+    assert stats == {}


### PR DESCRIPTION
There are two changes here...

```python
stats = pool.get_connection_info()
```

Instead becomes...

```python
stats = await pool.get_connection_info()
```

This is important because it allows us to run a keep-alive expiry sweep before returning the connection info, so you'll be seeing more valid information.

Secondly, we were previously capping our keep-alive expiry checks to *at most once per second*. Now if `keepalive_expiry` is set, and is *less* than 1.0, then we'll check for expiry more frequently than once per second. In particular this ensures that `keepalive_expiry=0.0` functions as expected.

*Note that `.get_connection_info()` is only introduced from 0.10 onwards, so this is an addition, not a breaking change.*
 