### PR TITLE
Version 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.10.1 (August 7th, 2020)
+
+- Include `max_keepalive_connections` on `AsyncHTTPProxy`/`SyncHTTPProxy` classes.
+
 ## 0.10.0 (August 7th, 2020)
 
 The most notable change in the 0.10.0 release is that HTTP/2 support is now fully optional.

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -49,4 +49,4 @@ __all__ = [
     "IteratorByteStream",
     "PlainByteStream",
 ]
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -44,8 +44,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
     connections to allow.
-    * **max_keepalive** - `Optional[int]` - The maximum number of connections
-    to allow before closing keep-alive connections.
+    * **max_keepalive_connections** - `Optional[int]` - The maximum number of
+    connections to allow before closing keep-alive connections.
     * **http2** - `bool` - Enable HTTP/2 support.
     """
 
@@ -56,9 +56,11 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
         max_connections: int = None,
-        max_keepalive: int = None,
+        max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        # Deprecated argument style:
+        max_keepalive: int = None,
     ):
         assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
@@ -68,9 +70,10 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         super().__init__(
             ssl_context=ssl_context,
             max_connections=max_connections,
-            max_keepalive=max_keepalive,
+            max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
             http2=http2,
+            max_keepalive=max_keepalive,
         )
 
     async def request(

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -44,8 +44,8 @@ class SyncHTTPProxy(SyncConnectionPool):
     verifying connections.
     * **max_connections** - `Optional[int]` - The maximum number of concurrent
     connections to allow.
-    * **max_keepalive** - `Optional[int]` - The maximum number of connections
-    to allow before closing keep-alive connections.
+    * **max_keepalive_connections** - `Optional[int]` - The maximum number of
+    connections to allow before closing keep-alive connections.
     * **http2** - `bool` - Enable HTTP/2 support.
     """
 
@@ -56,9 +56,11 @@ class SyncHTTPProxy(SyncConnectionPool):
         proxy_mode: str = "DEFAULT",
         ssl_context: SSLContext = None,
         max_connections: int = None,
-        max_keepalive: int = None,
+        max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        # Deprecated argument style:
+        max_keepalive: int = None,
     ):
         assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
@@ -68,9 +70,10 @@ class SyncHTTPProxy(SyncConnectionPool):
         super().__init__(
             ssl_context=ssl_context,
             max_connections=max_connections,
-            max_keepalive=max_keepalive,
+            max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
             http2=http2,
+            max_keepalive=max_keepalive,
         )
 
     def request(


### PR DESCRIPTION
## 0.10.1 (August 7th, 2020)

- Include `max_keepalive_connections` on `AsyncHTTPProxy`/`SyncHTTPProxy` classes.