### PR TITLE
Tweak type hints for transport context managers

### DIFF
--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -2,7 +2,7 @@ import enum
 from types import TracebackType
 from typing import AsyncIterator, List, Tuple, Type
 
-from .._types import URL, Headers, TimeoutDict
+from .._types import T, URL, Headers, TimeoutDict
 
 
 class NewConnectionRequired(Exception):
@@ -106,7 +106,7 @@ class AsyncHTTPTransport:
         and any keep alive connections.
         """
 
-    async def __aenter__(self) -> "AsyncHTTPTransport":
+    async def __aenter__(self: T) -> T:
         return self
 
     async def __aexit__(

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -2,7 +2,7 @@ import enum
 from types import TracebackType
 from typing import Iterator, List, Tuple, Type
 
-from .._types import URL, Headers, TimeoutDict
+from .._types import T, URL, Headers, TimeoutDict
 
 
 class NewConnectionRequired(Exception):
@@ -106,7 +106,7 @@ class SyncHTTPTransport:
         and any keep alive connections.
         """
 
-    def __enter__(self) -> "SyncHTTPTransport":
+    def __enter__(self: T) -> T:
         return self
 
     def __exit__(

--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -2,8 +2,9 @@
 Type definitions for type checking purposes.
 """
 
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import List, Mapping, Optional, Tuple, Union, TypeVar
 
+T = TypeVar("T")
 StrOrBytes = Union[str, bytes]
 Origin = Tuple[bytes, bytes, int]
 URL = Tuple[bytes, bytes, Optional[int], bytes]


### PR DESCRIPTION
Small user experience improvement :-)

Currently we have this:

```python
with ConcreteTransport() as transport:
    reveal_type(transport)  # SyncHTTPTransport
```

This PR allows doing this:

```python
with ConcreteTransport() as transport:
    reveal_type(transport)  # ConcreteTransport
```

This helps when accessing transport-specific attributes and methods (such as `.get_connection_info()` on connection pools), both for type checkers and IDEs.