### PR TITLE
Docs on local_address wildcards

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -77,7 +77,11 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     * **keepalive_expiry** - `Optional[float]` - The maximum time to allow
     before closing a keep-alive connection.
     * **http2** - `bool` - Enable HTTP/2 support.
-    * **local_address** - `Optional[str]` - Local address to connect from.
+    * **local_address** - `Optional[str]` - Local address to connect from. Can
+    also be used to connect using a particular address family. Using
+    `local_address="0.0.0.0"` will connect using an `AF_INET` address (IPv4),
+    while using `local_address="::"` will connect using an `AF_INET6` address
+    (IPv6).
     """
 
     def __init__(

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -77,7 +77,11 @@ class SyncConnectionPool(SyncHTTPTransport):
     * **keepalive_expiry** - `Optional[float]` - The maximum time to allow
     before closing a keep-alive connection.
     * **http2** - `bool` - Enable HTTP/2 support.
-    * **local_address** - `Optional[str]` - Local address to connect from.
+    * **local_address** - `Optional[str]` - Local address to connect from. Can
+    also be used to connect using a particular address family. Using
+    `local_address="0.0.0.0"` will connect using an `AF_INET` address (IPv4),
+    while using `local_address="::"` will connect using an `AF_INET6` address
+    (IPv6).
     """
 
     def __init__(


### PR DESCRIPTION
Noticed that we don't have any helpful info on using `local_address` with wildcards to support IPv4-only or IPv6-only connections.

I *think* I've got all the wording about right here, but would welcome any reviews over it.