### PR TITLE
Fix max_keepalive_connections config

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -105,7 +105,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
 
         self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self._max_connections = max_connections
-        self._max_keepalive = max_keepalive
+        self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry
         self._http2 = http2
         self._uds = uds
@@ -259,8 +259,8 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         elif connection.state == ConnectionState.IDLE:
             num_connections = len(self._get_all_connections())
             if (
-                self._max_keepalive is not None
-                and num_connections > self._max_keepalive
+                self._max_keepalive_connections is not None
+                and num_connections > self._max_keepalive_connections
             ):
                 remove_from_pool = True
                 close_connection = True

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -105,7 +105,7 @@ class SyncConnectionPool(SyncHTTPTransport):
 
         self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self._max_connections = max_connections
-        self._max_keepalive = max_keepalive
+        self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry
         self._http2 = http2
         self._uds = uds
@@ -259,8 +259,8 @@ class SyncConnectionPool(SyncHTTPTransport):
         elif connection.state == ConnectionState.IDLE:
             num_connections = len(self._get_all_connections())
             if (
-                self._max_keepalive is not None
-                and num_connections > self._max_keepalive
+                self._max_keepalive_connections is not None
+                and num_connections > self._max_keepalive_connections
             ):
                 remove_from_pool = True
                 close_connection = True

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,6 +1,5 @@
-import ssl
 import platform
-from pathlib import Path
+import ssl
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import asyncio
+import contextlib
+import os
 import ssl
 import threading
-import typing
-import contextlib
 import time
+import typing
 
-import os
-import uvicorn
 import pytest
 import trustme
+import uvicorn
 from mitmproxy import options, proxy
 from mitmproxy.tools.dump import DumpMaster
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,6 +1,5 @@
-import ssl
 import platform
-from pathlib import Path
+import ssl
 
 import pytest
 


### PR DESCRIPTION
Our `max_keepalive_connections` config was not actually being passed along correctly, because we were still setting from the deprecated `max_connections` internally.

We need test cases here, but I'd be okay with us resolving this PR and issue a hotfix release without blocking on that, and then make it a priority.