### PR TITLE
Specify newline="" to prevent newline translation on Windows

### DIFF
--- a/unasync.py
+++ b/unasync.py
@@ -36,7 +36,7 @@ def unasync_line(line):
 
 def unasync_file(in_path, out_path):
     with open(in_path, "r") as in_file:
-        with open(out_path, "w") as out_file:
+        with open(out_path, "w", newline="") as out_file:
             for line in in_file.readlines():
                 line = unasync_line(line)
                 out_file.write(line)


### PR DESCRIPTION
I am working on Windows, I have to set newline="" to disable universal newlines, which auto converts "\n" to "\r\n" on Windows:

https://docs.python.org/3/library/functions.html#open

> When writing output to the stream, if newline is None, any '\n' characters written are translated to the system default line separator, os.linesep. If newline is '' or '\n', no translation takes place. If newline is any of the other legal values, any '\n' characters written are translated to the given string.

Prompted by:
https://github.com/encode/httpcore/pull/154#discussion_r469231213