### PR TITLE
 Set __module__ = "httpcore" for all over the public API

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -50,3 +50,9 @@ __all__ = [
     "PlainByteStream",
 ]
 __version__ = "0.10.1"
+
+__locals = locals()
+
+for name in __all__:
+    if not name.startswith("__"):
+        setattr(__locals[name], "__module__", "httpcore")  # noqa


### PR DESCRIPTION
I did it as it's done in https://github.com/encode/httpx/pull/1155 (nice idea)