### PR TITLE
Improve handling of server disconnects on HTTP/2

### DIFF
--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -131,12 +131,9 @@ class SocketStream(AsyncSocketStream):
         exc_map = {asyncio.TimeoutError: ReadTimeout, OSError: ReadError}
         async with self.read_lock:
             with map_exceptions(exc_map):
-                data = await asyncio.wait_for(
+                return await asyncio.wait_for(
                     self.stream_reader.read(n), timeout.get("read")
                 )
-                if data == b"":
-                    raise ReadError("Server disconnected while attempting read")
-                return data
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:
         if not data:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -59,10 +59,7 @@ class SyncSocketStream:
         with self.read_lock:
             with map_exceptions(exc_map):
                 self.sock.settimeout(read_timeout)
-                data = self.sock.recv(n)
-                if data == b"":
-                    raise ReadError("Server disconnected while attempting read")
-                return data
+                return self.sock.recv(n)
 
     def write(self, data: bytes, timeout: TimeoutDict) -> None:
         write_timeout = timeout.get("write")

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -210,6 +210,16 @@ class SyncHTTP2Connection(SyncBaseHTTPConnection):
         Read some data from the network, and update the H2 state.
         """
         data = self.socket.read(self.READ_NUM_BYTES, timeout)
+
+        if data == b"":
+            # The server has disconnected. `h11` deals with this "empty data" signal
+            # correctly, but h2 doesn't. So we raise an exception equivalent to
+            # what would be raised in the HTTP/1.1 case.
+            raise RemoteProtocolError(
+                "peer closed connection without sending complete message body "
+                "(incomplete chunked read)"
+            )
+
         events = self.h2_state.receive_data(data)
         for event in events:
             event_stream_id = getattr(event, "stream_id", 0)


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/issues/1174
Refs https://github.com/encode/httpcore/issues/110

This is a cleanup of #112.

#112 tried to fix #110 by handling the `b""` message received from sockets as early as possible.

This actually isn't quite the right approach, since it's possible that a server disconnects just after it sent the full response, which is a valid scenario. This edge case is effectively causing regressions in HTTPX 0.14.0. (See reproduction example with NGINX in https://github.com/encode/httpx/issues/1174#issuecomment-673076946.)

Going back over my analysis in https://github.com/encode/httpcore/issues/110#issuecomment-654891958, I realized that the fix in #112 should have focused on HTTP/2 specifically.

* `h11` does the right thing upon receiving `b""`, that is raise an exception which we translate into `RemoteProtocolError`.
* Alas, `h2` doesn't raise such an exception, leaving us to have to detect "the server has disconnected because `b""` was received" ourselves.

So this PR basically reverts #112, and adds a fix specifically for HTTP/2 (with a small tweak in the trio backend so that it returns `b""` instead of raising its own `ReadError` too early), making it so that the same error than in the `h11` case is raised.

* I verified this against my setup in https://github.com/encode/httpcore/issues/110#issuecomment-654891958 (all cases now raise a proper `RemoteProtocolError`).
* I verified that this fixes the regression reproducible in https://github.com/encode/httpx/issues/1174.

(Ideally we'd have test cases for this, but we already discussed this in #112: it's complicated.)