### PR TITLE
Use pip 2020 resolver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--use-feature="2020-resolver"
+
 -e .[http2]
 
 # Optionals

--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,6 @@ else
     PIP="pip"
 fi
 
+"$PIP" install -U "pip >= 20.2"
 "$PIP" install -r "$REQUIREMENTS"
 "$PIP" install -e .


### PR DESCRIPTION
Promted by https://github.com/encode/httpcore/pull/151#issuecomment-672290787 and https://github.com/encode/httpcore/pull/162/files#r470961811, alternative to #151.

It's better we use the (still beta, but soon enabled-by-default) new pip resolver anyway!

https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html