### PR TITLE
Fix server disconnect behaviour.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -210,6 +210,9 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         Read some data from the network, and update the H2 state.
         """
         data = await self.socket.read(self.READ_NUM_BYTES, timeout)
+        if data == b"":
+            raise RemoteProtocolError("Server disconnected")
+
         events = self.h2_state.receive_data(data)
         for event in events:
             event_stream_id = getattr(event, "stream_id", 0)

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -131,12 +131,9 @@ class SocketStream(AsyncSocketStream):
         exc_map = {asyncio.TimeoutError: ReadTimeout, OSError: ReadError}
         async with self.read_lock:
             with map_exceptions(exc_map):
-                data = await asyncio.wait_for(
+                return await asyncio.wait_for(
                     self.stream_reader.read(n), timeout.get("read")
                 )
-                if data == b"":
-                    raise ReadError("Server disconnected while attempting read")
-                return data
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:
         if not data:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -59,10 +59,7 @@ class SyncSocketStream:
         with self.read_lock:
             with map_exceptions(exc_map):
                 self.sock.settimeout(read_timeout)
-                data = self.sock.recv(n)
-                if data == b"":
-                    raise ReadError("Server disconnected while attempting read")
-                return data
+                return self.sock.recv(n)
 
     def write(self, data: bytes, timeout: TimeoutDict) -> None:
         write_timeout = timeout.get("write")

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -60,10 +60,7 @@ class SocketStream(AsyncSocketStream):
         async with self.read_lock:
             with map_exceptions(exc_map):
                 with trio.fail_after(read_timeout):
-                    data = await self.stream.receive_some(max_bytes=n)
-                    if data == b"":
-                        raise ReadError("Server disconnected while attempting read")
-                    return data
+                    return await self.stream.receive_some(max_bytes=n)
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:
         if not data:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -210,6 +210,9 @@ class SyncHTTP2Connection(SyncBaseHTTPConnection):
         Read some data from the network, and update the H2 state.
         """
         data = self.socket.read(self.READ_NUM_BYTES, timeout)
+        if data == b"":
+            raise RemoteProtocolError("Server disconnected")
+
         events = self.h2_state.receive_data(data)
         for event in events:
             event_stream_id = getattr(event, "stream_id", 0)


### PR DESCRIPTION
Based on #159 but narrowing things down a bit.

Fixes an issue in HTTP/1.1 when the server does not include the `Content-Length` or set `Transfer-Encoding: chunked` but instead uses a server disconnect to signal the end of the response body.

If the server disconnects under HTTP/2 then raise an appropriate error.
