### PR TITLE
Making release() and time() async

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -25,7 +25,7 @@ class NullSemaphore(AsyncSemaphore):
     async def acquire(self, timeout: float = None) -> None:
         return
 
-    def release(self) -> None:
+    async def release(self) -> None:
         return
 
 
@@ -315,7 +315,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         logger.trace("removing connection from pool=%r", connection)
         async with self._thread_lock:
             if connection in self._connections.get(connection.origin, set()):
-                self._connection_semaphore.release()
+                await self._connection_semaphore.release()
                 self._connections[connection.origin].remove(connection)
                 if not self._connections[connection.origin]:
                     del self._connections[connection.origin]

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -265,7 +265,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                 remove_from_pool = True
                 close_connection = True
             elif self._keepalive_expiry is not None:
-                now = self._backend.time()
+                now = await self._backend.time()
                 connection.expires_at = now + self._keepalive_expiry
 
         if remove_from_pool:
@@ -281,7 +281,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if self._keepalive_expiry is None:
             return
 
-        now = self._backend.time()
+        now = await self._backend.time()
         if now < self._next_keepalive_check:
             return
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -125,7 +125,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
             self.events[stream_id] = []
             return await h2_stream.request(method, url, headers, stream, timeout)
         except Exception:
-            self.max_streams_semaphore.release()
+            await self.max_streams_semaphore.release()
             raise
 
     async def send_connection_init(self, timeout: TimeoutDict) -> None:
@@ -269,7 +269,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
                 elif self.state == ConnectionState.FULL:
                     await self.aclose()
         finally:
-            self.max_streams_semaphore.release()
+            await self.max_streams_semaphore.release()
 
 
 class AsyncHTTP2Stream:

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -204,7 +204,7 @@ class Semaphore(AsyncSemaphore):
         except asyncio.TimeoutError:
             raise self.exc_class()
 
-    def release(self) -> None:
+    async def release(self) -> None:
         self.semaphore.release()
 
 

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -180,7 +180,7 @@ class Lock(AsyncLock):
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
 
-    def release(self) -> None:
+    async def release(self) -> None:
         self._lock.release()
 
     async def acquire(self) -> None:

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -267,6 +267,6 @@ class AsyncioBackend(AsyncBackend):
     def create_semaphore(self, max_value: int, exc_class: type) -> AsyncSemaphore:
         return Semaphore(max_value, exc_class=exc_class)
 
-    def time(self) -> float:
+    async def time(self) -> float:
         loop = asyncio.get_event_loop()
         return loop.time()

--- a/httpcore/_backends/auto.py
+++ b/httpcore/_backends/auto.py
@@ -56,5 +56,5 @@ class AutoBackend(AsyncBackend):
     def create_semaphore(self, max_value: int, exc_class: type) -> AsyncSemaphore:
         return self.backend.create_semaphore(max_value, exc_class=exc_class)
 
-    def time(self) -> float:
-        return self.backend.time()
+    async def time(self) -> float:
+        return await self.backend.time()

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -96,5 +96,5 @@ class AsyncBackend:
     def create_semaphore(self, max_value: int, exc_class: type) -> AsyncSemaphore:
         raise NotImplementedError()  # pragma: no cover
 
-    def time(self) -> float:
+    async def time(self) -> float:
         raise NotImplementedError()  # pragma: no cover

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -65,7 +65,7 @@ class AsyncSemaphore:
     async def acquire(self, timeout: float = None) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    def release(self) -> None:
+    async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -47,9 +47,9 @@ class AsyncLock:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        self.release()
+        await self.release()
 
-    def release(self) -> None:
+    async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
     async def acquire(self) -> None:

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -198,5 +198,5 @@ class TrioBackend(AsyncBackend):
     def create_semaphore(self, max_value: int, exc_class: type) -> AsyncSemaphore:
         return Semaphore(max_value, exc_class=exc_class)
 
-    def time(self) -> float:
+    async def time(self) -> float:
         return trio.current_time()

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -102,7 +102,7 @@ class Lock(AsyncLock):
     def __init__(self) -> None:
         self._lock = trio.Lock()
 
-    def release(self) -> None:
+    async def release(self) -> None:
         self._lock.release()
 
     async def acquire(self) -> None:

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -129,7 +129,7 @@ class Semaphore(AsyncSemaphore):
 
         raise self.exc_class()
 
-    def release(self) -> None:
+    async def release(self) -> None:
         self.semaphore.release()
 
 


### PR DESCRIPTION
In https://github.com/encode/httpcore/pull/169 and #168 you can find pretty the same changes:
`AsyncBackend::time` , `AsyncSemaphore::release` and `AsyncLock::release` have been made async.

I extracted these changes into the separated PR to make the changeset be discussed here.