### PR TITLE
Allowed expiring connections where idle time == expiration time

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -292,7 +292,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             if (
                 connection.state == ConnectionState.IDLE
                 and connection.expires_at is not None
-                and now > connection.expires_at
+                and now >= connection.expires_at
             ):
                 connections_to_close.add(connection)
                 await self._remove_from_pool(connection)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -292,7 +292,7 @@ class SyncConnectionPool(SyncHTTPTransport):
             if (
                 connection.state == ConnectionState.IDLE
                 and connection.expires_at is not None
-                and now > connection.expires_at
+                and now >= connection.expires_at
             ):
                 connections_to_close.add(connection)
                 self._remove_from_pool(connection)


### PR DESCRIPTION
On uvloop, the timer is only accurate to a millisecond. This negatively affects the `test_connection_pool_get_connection_info` test which may fail because the code runs so fast that the check is done on the same millisecond the connections have expired. This should have no practical implications elsewhere.