### PR TITLE
Added http3 argument to AsyncHTTPConnection, AsyncConnectionPool, SyncHTTPConnection, SyncConnectionPool (#275)

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -20,6 +20,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self,
         origin: Origin,
         http2: bool = False,
+        http3: bool = False,
         uds: str = None,
         ssl_context: SSLContext = None,
         socket: AsyncSocketStream = None,
@@ -27,6 +28,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
     ):
         self.origin = origin
         self.http2 = http2
+        self.http3 = http3
         self.uds = uds
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
@@ -38,6 +40,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.connection: Optional[AsyncBaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
+        self.is_http3 = False
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = AutoBackend()
@@ -48,6 +51,8 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
             http_version = "HTTP/1.1"
         elif self.is_http2:
             http_version = "HTTP/2"
+        elif self.is_http3:
+            http_version = "HTTP/3"
         return f"<AsyncHTTPConnection http_version={http_version} state={self.state}>"
 
     def info(self) -> str:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,3 +1,4 @@
+import importlib.util
 import warnings
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
@@ -92,6 +93,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        http3: bool = False,
         uds: str = None,
         local_address: str = None,
         max_keepalive: int = None,
@@ -108,6 +110,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry
         self._http2 = http2
+        self._http3 = http3
         self._uds = uds
         self._local_address = local_address
         self._connections: Dict[Origin, Set[AsyncHTTPConnection]] = {}
@@ -122,6 +125,15 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                 raise ImportError(
                     "Attempted to use http2=True, but the 'h2' "
                     "package is not installed. Use 'pip install httpcore[http2]'."
+                )
+
+        if http3:
+            spec = importlib.util.find_spec("aioquic")
+
+            if spec is None:
+                raise ImportError(
+                    "Attempted to use http2=True, but the 'aioquic' "
+                    "package is not installed. Use 'pip install httpcore[http3]'."
                 )
 
     @property
@@ -175,6 +187,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                     connection = AsyncHTTPConnection(
                         origin=origin,
                         http2=self._http2,
+                        http3=self._http3,
                         uds=self._uds,
                         ssl_context=self._ssl_context,
                         local_address=self._local_address,

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -20,6 +20,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self,
         origin: Origin,
         http2: bool = False,
+        http3: bool = False,
         uds: str = None,
         ssl_context: SSLContext = None,
         socket: SyncSocketStream = None,
@@ -27,6 +28,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
     ):
         self.origin = origin
         self.http2 = http2
+        self.http3 = http3
         self.uds = uds
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
@@ -38,6 +40,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.connection: Optional[SyncBaseHTTPConnection] = None
         self.is_http11 = False
         self.is_http2 = False
+        self.is_http3 = False
         self.connect_failed = False
         self.expires_at: Optional[float] = None
         self.backend = SyncBackend()
@@ -48,6 +51,8 @@ class SyncHTTPConnection(SyncHTTPTransport):
             http_version = "HTTP/1.1"
         elif self.is_http2:
             http_version = "HTTP/2"
+        elif self.is_http3:
+            http_version = "HTTP/3"
         return f"<SyncHTTPConnection http_version={http_version} state={self.state}>"
 
     def info(self) -> str:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,3 +1,4 @@
+import importlib.util
 import warnings
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple
@@ -92,6 +93,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        http3: bool = False,
         uds: str = None,
         local_address: str = None,
         max_keepalive: int = None,
@@ -108,6 +110,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry
         self._http2 = http2
+        self._http3 = http3
         self._uds = uds
         self._local_address = local_address
         self._connections: Dict[Origin, Set[SyncHTTPConnection]] = {}
@@ -122,6 +125,15 @@ class SyncConnectionPool(SyncHTTPTransport):
                 raise ImportError(
                     "Attempted to use http2=True, but the 'h2' "
                     "package is not installed. Use 'pip install httpcore[http2]'."
+                )
+
+        if http3:
+            spec = importlib.util.find_spec("aioquic")
+
+            if spec is None:
+                raise ImportError(
+                    "Attempted to use http2=True, but the 'aioquic' "
+                    "package is not installed. Use 'pip install httpcore[http3]'."
                 )
 
     @property
@@ -175,6 +187,7 @@ class SyncConnectionPool(SyncHTTPTransport):
                     connection = SyncHTTPConnection(
                         origin=origin,
                         http2=self._http2,
+                        http3=self._http3,
                         uds=self._uds,
                         ssl_context=self._ssl_context,
                         local_address=self._local_address,

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     install_requires=["h11>=0.8,<0.10", "sniffio==1.*"],
     extras_require={
         "http2": ["h2==3.*"],
+        "http3": ["aioquic>=0.9"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,5 +1,6 @@
 import platform
 import ssl
+from unittest.mock import patch
 
 import pytest
 
@@ -364,3 +365,11 @@ async def test_max_keepalive_connections_handled_correctly(
 
             connections_in_pool = next(iter(stats.values()))
             assert len(connections_in_pool) == min(connections_number, max_keepalive)
+
+
+@pytest.mark.asyncio
+@patch("importlib.util.find_spec", return_value=None)
+async def test_cannot_create_connection_pool_with_http3_without_lib(find_spec_mock):
+    with pytest.raises(ImportError):
+        async with httpcore.AsyncConnectionPool(http3=True):
+            pass

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,6 @@
 import platform
 import ssl
+from unittest.mock import patch
 
 import pytest
 
@@ -364,3 +365,11 @@ def test_max_keepalive_connections_handled_correctly(
 
             connections_in_pool = next(iter(stats.values()))
             assert len(connections_in_pool) == min(connections_number, max_keepalive)
+
+
+
+@patch("importlib.util.find_spec", return_value=None)
+def test_cannot_create_connection_pool_with_http3_without_lib(find_spec_mock):
+    with pytest.raises(ImportError):
+        with httpcore.SyncConnectionPool(http3=True):
+            pass


### PR DESCRIPTION
Started to work with https://github.com/encode/httpx/issues/275

Added http3 flag to ConnectionPool-s and Connection-s

Added check that `aioquic` (python http3 implementation) is installed when `http3=True`