### PR TITLE
Add local_address support for curio

### DIFF
--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -155,9 +155,13 @@ class CurioBackend(AsyncBackend):
             OSError: ConnectError,
         }
         host = hostname.decode("ascii")
-        kwargs = (
-            {} if ssl_context is None else {"ssl": ssl_context, "server_hostname": host}
-        )
+
+        kwargs: dict = {}
+        if ssl_context is not None:
+            kwargs["ssl"] = ssl_context
+            kwargs["server_hostname"] = host
+        if local_address is not None:
+            kwargs["source_addr"] = (local_address, 0)
 
         with map_exceptions(exc_map):
             sock: curio.io.Socket = await curio.timeout_after(


### PR DESCRIPTION
Realized that #175 did not make use of the `local_address` parameter (refs #134).

Relevant part of the curio docs is here: https://curio.readthedocs.io/en/latest/reference.html#open_connection

> _source_addr_ specifies the source address to use on the socket. 