### PR TITLE
Add assertion in local_address test

### DIFF
--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -214,11 +214,11 @@ async def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
 @pytest.mark.asyncio
 # This doesn't run with trio, since trio doesn't support local_address.
 async def test_http_request_local_address() -> None:
-    # By default systems seem to bind to a private IP like 10.x.x.x.
-    # We forcefully use the system local IP, something like 192.168.x.x,
-    # to be able to distinguish that local_address is correctly applied.
+    # Forcefully use the system local IP, instead of a randomly assigned
+    # client IP address. Its shape may differ based on the type of network we're
+    # connected to (eg 10.x.x.x, 192.168.x.x, or 172.20.10.x) so we can't make any
+    # assumption there.
     local_address = get_local_ip_address()
-    assert local_address.startswith("192.168.")
 
     async with httpcore.AsyncConnectionPool(local_address=local_address) as http:
         method = b"GET"

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -6,7 +6,7 @@ import pytest
 import httpcore
 from httpcore._types import URL
 from tests.conftest import Server
-from tests.utils import getsockname, get_local_ip_address
+from tests.utils import get_local_ip_address, getsockname
 
 
 async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
@@ -217,7 +217,6 @@ async def test_http_request_local_address() -> None:
     # By default systems seem to bind to a private IP like 10.x.x.x.
     # We forcefully use the system local IP, something like 192.168.x.x,
     # to be able to distinguish that local_address is correctly applied.
-    # NOTE: this requires the machine to be connected to the Internet.
     local_address = get_local_ip_address()
     assert local_address.startswith("192.168.")
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -214,11 +214,11 @@ def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
 
 # This doesn't run with trio, since trio doesn't support local_address.
 def test_http_request_local_address() -> None:
-    # By default systems seem to bind to a private IP like 10.x.x.x.
-    # We forcefully use the system local IP, something like 192.168.x.x,
-    # to be able to distinguish that local_address is correctly applied.
+    # Forcefully use the system local IP, instead of a randomly assigned
+    # client IP address. Its shape may differ based on the type of network we're
+    # connected to (eg 10.x.x.x, 192.168.x.x, or 172.20.10.x) so we can't make any
+    # assumption there.
     local_address = get_local_ip_address()
-    assert local_address.startswith("192.168.")
 
     with httpcore.SyncConnectionPool(local_address=local_address) as http:
         method = b"GET"

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -6,7 +6,7 @@ import pytest
 import httpcore
 from httpcore._types import URL
 from tests.conftest import Server
-from tests.utils import getsockname, get_local_ip_address
+from tests.utils import get_local_ip_address, getsockname
 
 
 def read_body(stream: httpcore.SyncByteStream) -> bytes:
@@ -217,7 +217,6 @@ def test_http_request_local_address() -> None:
     # By default systems seem to bind to a private IP like 10.x.x.x.
     # We forcefully use the system local IP, something like 192.168.x.x,
     # to be able to distinguish that local_address is correctly applied.
-    # NOTE: this requires the machine to be connected to the Internet.
     local_address = get_local_ip_address()
     assert local_address.startswith("192.168.")
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -6,6 +6,7 @@ import pytest
 import httpcore
 from httpcore._types import URL
 from tests.conftest import Server
+from tests.utils import getsockname, get_local_ip_address
 
 
 def read_body(stream: httpcore.SyncByteStream) -> bytes:
@@ -213,7 +214,14 @@ def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
 
 # This doesn't run with trio, since trio doesn't support local_address.
 def test_http_request_local_address() -> None:
-    with httpcore.SyncConnectionPool(local_address="0.0.0.0") as http:
+    # By default systems seem to bind to a private IP like 10.x.x.x.
+    # We forcefully use the system local IP, something like 192.168.x.x,
+    # to be able to distinguish that local_address is correctly applied.
+    # NOTE: this requires the machine to be connected to the Internet.
+    local_address = get_local_ip_address()
+    assert local_address.startswith("192.168.")
+
+    with httpcore.SyncConnectionPool(local_address=local_address) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
@@ -222,6 +230,8 @@ def test_http_request_local_address() -> None:
         )
         read_body(stream)
 
+        client_host, _ = getsockname(stream.connection.socket)  # type: ignore
+        assert client_host == local_address
         assert http_version == b"HTTP/1.1"
         assert status_code == 200
         assert reason == b"OK"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,23 @@
+import socket
+from typing import Any, Tuple
+
+from httpcore._backends.asyncio import SocketStream as AsyncIOSocketStream
+from httpcore._backends.curio import SocketStream as CurioSocketStream
+from httpcore._backends.sync import SyncSocketStream
+
+
+def get_local_ip_address() -> str:
+    return socket.gethostbyname(socket.gethostname())
+
+
+def getsockname(stream: Any) -> Tuple[str, int]:
+    if isinstance(stream, AsyncIOSocketStream):
+        sock = stream.stream_reader._transport.get_extra_info("socket")  # type: ignore
+    elif isinstance(stream, CurioSocketStream):
+        sock = stream.socket._socket
+    elif isinstance(stream, SyncSocketStream):
+        sock = stream.sock
+    else:  # pragma: no cover
+        raise NotImplementedError(stream)
+
+    return sock.getsockname()


### PR DESCRIPTION
Refs https://github.com/encode/httpcore/pull/134#discussion_r465971408

Our `local_address` test didn't actually verify that `local_address` was used to bind the client socket.

Scratched my head a little, and after some investigation I found out that using `local_address=<local machine IP>` seems to be a repeatable pattern that we can assert against (though we can't know for sure what that IP will look like exactly).