### PR TITLE
Add 'backend=<str>' parameter

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple
 
-from .._backends.auto import AsyncLock, AsyncSocketStream, AutoBackend
+from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, url_to_origin
 from .base import (
@@ -24,6 +24,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         ssl_context: SSLContext = None,
         socket: AsyncSocketStream = None,
         local_address: str = None,
+        backend: AsyncBackend = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -40,7 +41,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.is_http2 = False
         self.connect_failed = False
         self.expires_at: Optional[float] = None
-        self.backend = AutoBackend()
+        self.backend = AutoBackend() if backend is None else backend
 
     def __repr__(self) -> str:
         http_version = "UNKNOWN"

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -2,7 +2,8 @@ import warnings
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
 
-from .._backends.auto import AsyncLock, AsyncSemaphore, AutoBackend
+from .._backends.auto import AsyncLock, AsyncSemaphore
+from .._backends.base import lookup_async_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -52,12 +53,12 @@ class ResponseByteStream(AsyncByteStream):
 
     async def aclose(self) -> None:
         try:
-            #  Call the underlying stream close callback.
+            # Call the underlying stream close callback.
             # This will be a call to `AsyncHTTP11Connection._response_closed()`
             # or `AsyncHTTP2Stream._response_closed()`.
             await self.stream.aclose()
         finally:
-            #  Call the connection pool close callback.
+            # Call the connection pool close callback.
             # This will be a call to `AsyncConnectionPool._response_closed()`.
             await self.callback(self.connection)
 
@@ -83,6 +84,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     `local_address="0.0.0.0"` will connect using an `AF_INET` address (IPv4),
     while using `local_address="::"` will connect using an `AF_INET6` address
     (IPv6).
+    * **backend** - `str` - A name indicating which concurrency backend to use.
     """
 
     def __init__(
@@ -95,6 +97,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         uds: str = None,
         local_address: str = None,
         max_keepalive: int = None,
+        backend: str = "auto",
     ):
         if max_keepalive is not None:
             warnings.warn(
@@ -112,7 +115,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self._local_address = local_address
         self._connections: Dict[Origin, Set[AsyncHTTPConnection]] = {}
         self._thread_lock = ThreadLock()
-        self._backend = AutoBackend()
+        self._backend = lookup_async_backend(backend)
         self._next_keepalive_check = 0.0
 
         if http2:
@@ -178,6 +181,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                         uds=self._uds,
                         ssl_context=self._ssl_context,
                         local_address=self._local_address,
+                        backend=self._backend,
                     )
                     logger.trace("created connection=%r", connection)
                     await self._add_to_pool(connection, timeout=timeout)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -8,7 +8,7 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import AsyncLock, AsyncSemaphore, AsyncSocketStream, AutoBackend
+from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 from .._bytestreams import AsyncIteratorByteStream, PlainByteStream
 from .._exceptions import PoolTimeout, RemoteProtocolError
 from .._types import URL, Headers, TimeoutDict
@@ -33,7 +33,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
     def __init__(
         self,
         socket: AsyncSocketStream,
-        backend: AutoBackend,
+        backend: AsyncBackend,
         ssl_context: SSLContext = None,
     ):
         self.socket = socket

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -60,6 +60,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        backend: str = "auto",
         # Deprecated argument style:
         max_keepalive: int = None,
     ):
@@ -74,6 +75,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
             http2=http2,
+            backend=backend,
             max_keepalive=max_keepalive,
         )
 

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -1,8 +1,38 @@
 from ssl import SSLContext
 from types import TracebackType
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 from .._types import TimeoutDict
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .sync import SyncBackend
+
+
+def lookup_async_backend(name: str) -> "AsyncBackend":
+    if name == "auto":
+        from .auto import AutoBackend
+
+        return AutoBackend()
+    elif name == "asyncio":
+        from .asyncio import AsyncioBackend
+
+        return AsyncioBackend()
+    elif name == "trio":
+        from .trio import TrioBackend
+
+        return TrioBackend()
+    elif name == "curio":
+        from .curio import CurioBackend
+
+        return CurioBackend()
+
+    raise ValueError("Invalid backend name {name!r}")
+
+
+def lookup_sync_backend(name: str) -> "SyncBackend":
+    from .sync import SyncBackend
+
+    return SyncBackend()
 
 
 class AsyncSocketStream:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,7 +1,7 @@
 from ssl import SSLContext
 from typing import List, Optional, Tuple
 
-from .._backends.auto import SyncLock, SyncSocketStream, SyncBackend
+from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, url_to_origin
 from .base import (
@@ -24,6 +24,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         ssl_context: SSLContext = None,
         socket: SyncSocketStream = None,
         local_address: str = None,
+        backend: SyncBackend = None,
     ):
         self.origin = origin
         self.http2 = http2
@@ -40,7 +41,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.is_http2 = False
         self.connect_failed = False
         self.expires_at: Optional[float] = None
-        self.backend = SyncBackend()
+        self.backend = SyncBackend() if backend is None else backend
 
     def __repr__(self) -> str:
         http_version = "UNKNOWN"

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -2,7 +2,8 @@ import warnings
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple
 
-from .._backends.auto import SyncLock, SyncSemaphore, SyncBackend
+from .._backends.sync import SyncLock, SyncSemaphore
+from .._backends.base import lookup_sync_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -52,12 +53,12 @@ class ResponseByteStream(SyncByteStream):
 
     def close(self) -> None:
         try:
-            #  Call the underlying stream close callback.
+            # Call the underlying stream close callback.
             # This will be a call to `SyncHTTP11Connection._response_closed()`
             # or `SyncHTTP2Stream._response_closed()`.
             self.stream.close()
         finally:
-            #  Call the connection pool close callback.
+            # Call the connection pool close callback.
             # This will be a call to `SyncConnectionPool._response_closed()`.
             self.callback(self.connection)
 
@@ -83,6 +84,7 @@ class SyncConnectionPool(SyncHTTPTransport):
     `local_address="0.0.0.0"` will connect using an `AF_INET` address (IPv4),
     while using `local_address="::"` will connect using an `AF_INET6` address
     (IPv6).
+    * **backend** - `str` - A name indicating which concurrency backend to use.
     """
 
     def __init__(
@@ -95,6 +97,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         uds: str = None,
         local_address: str = None,
         max_keepalive: int = None,
+        backend: str = "sync",
     ):
         if max_keepalive is not None:
             warnings.warn(
@@ -112,7 +115,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         self._local_address = local_address
         self._connections: Dict[Origin, Set[SyncHTTPConnection]] = {}
         self._thread_lock = ThreadLock()
-        self._backend = SyncBackend()
+        self._backend = lookup_sync_backend(backend)
         self._next_keepalive_check = 0.0
 
         if http2:
@@ -178,6 +181,7 @@ class SyncConnectionPool(SyncHTTPTransport):
                         uds=self._uds,
                         ssl_context=self._ssl_context,
                         local_address=self._local_address,
+                        backend=self._backend,
                     )
                     logger.trace("created connection=%r", connection)
                     self._add_to_pool(connection, timeout=timeout)

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -1,4 +1,4 @@
-from .._backends.auto import SyncSocketStream
+from .._backends.sync import SyncSocketStream
 from .._types import TimeoutDict
 from .base import SyncHTTPTransport, ConnectionState
 

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -3,7 +3,7 @@ from typing import Iterator, List, Tuple, Union
 
 import h11
 
-from .._backends.auto import SyncSocketStream
+from .._backends.sync import SyncSocketStream
 from .._bytestreams import IteratorByteStream, PlainByteStream
 from .._exceptions import LocalProtocolError, RemoteProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -8,7 +8,7 @@ from h2.config import H2Configuration
 from h2.exceptions import NoAvailableStreamIDError
 from h2.settings import SettingCodes, Settings
 
-from .._backends.auto import SyncLock, SyncSemaphore, SyncSocketStream, SyncBackend
+from .._backends.sync import SyncBackend, SyncLock, SyncSemaphore, SyncSocketStream
 from .._bytestreams import IteratorByteStream, PlainByteStream
 from .._exceptions import PoolTimeout, RemoteProtocolError
 from .._types import URL, Headers, TimeoutDict

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -60,6 +60,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
         http2: bool = False,
+        backend: str = "sync",
         # Deprecated argument style:
         max_keepalive: int = None,
     ):
@@ -74,6 +75,7 @@ class SyncHTTPProxy(SyncConnectionPool):
             max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
             http2=http2,
+            backend=backend,
             max_keepalive=max_keepalive,
         )
 

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -5,7 +5,7 @@ import pytest
 
 import httpcore
 from httpcore._types import URL
-from tests.conftest import Server
+from tests.conftest import Server, detect_backend
 
 
 async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
@@ -364,3 +364,20 @@ async def test_max_keepalive_connections_handled_correctly(
 
             connections_in_pool = next(iter(stats.values()))
             assert len(connections_in_pool) == min(connections_number, max_keepalive)
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_explicit_backend_name() -> None:
+    async with httpcore.AsyncConnectionPool(backend=detect_backend()) as http:
+        method = b"GET"
+        url = (b"http", b"example.org", 80, b"/")
+        headers = [(b"host", b"example.org")]
+        http_version, status_code, reason, headers, stream = await http.request(
+            method, url, headers
+        )
+        await read_body(stream)
+
+        assert http_version == b"HTTP/1.1"
+        assert status_code == 200
+        assert reason == b"OK"
+        assert len(http._connections[url[:3]]) == 1  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,3 +185,12 @@ def uds_server() -> typing.Iterator[Server]:
             yield server
     finally:
         os.remove(uds)
+
+
+def detect_backend() -> str:
+    import sniffio
+
+    try:
+        return sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        return "sync"

--- a/unasync.py
+++ b/unasync.py
@@ -22,6 +22,8 @@ SUBS = [
     ('@pytest.mark.trio', ''),
     ('@pytest.mark.curio', ''),
     ('@pytest.mark.usefixtures.*', ''),
+    ('lookup_async_backend', "lookup_sync_backend"),
+    ('auto', 'sync'),
 ]
 COMPILED_SUBS = [
     (re.compile(r'(^|\b)' + regex + r'($|\b)'), repl)

--- a/unasync.py
+++ b/unasync.py
@@ -24,6 +24,7 @@ SUBS = [
     ('@pytest.mark.usefixtures.*', ''),
     ('lookup_async_backend', "lookup_sync_backend"),
     ('auto', 'sync'),
+    ('anyio', 'sync'),
 ]
 COMPILED_SUBS = [
     (re.compile(r'(^|\b)' + regex + r'($|\b)'), repl)


### PR DESCRIPTION
Add support for `httpcore.AsyncConnectionPool(backend=...)`.

The default behaviour is to use:

* `httpcore.AsyncConnectionPool(backend="auto")`

Which will auto-select an appropriate backend.
The following are also valid...

* `httpcore.AsyncConnectionPool(backend="asyncio")`
* `httpcore.AsyncConnectionPool(backend="trio")`
* `httpcore.AsyncConnectionPool(backend="curio")`

One motivation here is that this PR would allow us to merge a new `AnyIO` backend, without committing ourselves to a switch. We could add `backend="anyio"` in addition to the existing `backend="auto"`.

In the sync case `backend` is currently always just `"sync"`.