### PR TITLE
Add support for `backend="anyio"`

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -1,0 +1,198 @@
+import select
+from ssl import SSLContext
+from typing import Optional
+
+import anyio.abc
+from anyio import BrokenResourceError, EndOfStream
+from anyio.abc import SocketAttribute
+from anyio.streams.tls import TLSAttribute, TLSStream
+
+from .._exceptions import (
+    CloseError,
+    ConnectError,
+    ConnectTimeout,
+    ReadError,
+    ReadTimeout,
+    WriteError,
+    WriteTimeout,
+)
+from .._types import TimeoutDict
+from .base import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
+
+
+class SocketStream(AsyncSocketStream):
+    def __init__(self, stream: anyio.abc.ByteStream) -> None:
+        self.stream = stream
+        self.read_lock = anyio.create_lock()
+        self.write_lock = anyio.create_lock()
+
+    def get_http_version(self) -> str:
+        if self.stream.extra(TLSAttribute.alpn_protocol, None) == "h2":
+            return "HTTP/2"
+
+        return "HTTP/1.1"
+
+    async def start_tls(
+        self,
+        hostname: bytes,
+        ssl_context: SSLContext,
+        timeout: TimeoutDict,
+    ) -> "SocketStream":
+        connect_timeout = timeout.get("connect")
+        try:
+            async with anyio.fail_after(connect_timeout):
+                ssl_stream = await TLSStream.wrap(
+                    self.stream,
+                    ssl_context=ssl_context,
+                    hostname=hostname.decode("ascii"),
+                )
+        except TimeoutError:
+            raise ConnectTimeout from None
+        except BrokenResourceError as exc:
+            raise ConnectError from exc
+
+        return SocketStream(ssl_stream)
+
+    async def read(self, n: int, timeout: TimeoutDict) -> bytes:
+        read_timeout = timeout.get("read")
+        async with self.read_lock:
+            try:
+                async with anyio.fail_after(read_timeout):
+                    return await self.stream.receive(n)
+            except TimeoutError:
+                raise ReadTimeout from None
+            except BrokenResourceError as exc:
+                raise ReadError from exc
+            except EndOfStream:
+                raise ReadError("Server disconnected while attempting read") from None
+
+    async def write(self, data: bytes, timeout: TimeoutDict) -> None:
+        if not data:
+            return
+
+        write_timeout = timeout.get("write")
+        async with self.write_lock:
+            try:
+                async with anyio.fail_after(write_timeout):
+                    return await self.stream.send(data)
+            except TimeoutError:
+                raise WriteTimeout from None
+            except BrokenResourceError as exc:
+                raise WriteError from exc
+
+    async def aclose(self) -> None:
+        async with self.write_lock:
+            try:
+                await self.stream.aclose()
+            except BrokenResourceError as exc:
+                raise CloseError from exc
+
+    def is_connection_dropped(self) -> bool:
+        raw_socket = self.stream.extra(SocketAttribute.raw_socket)
+        rready, _wready, _xready = select.select([raw_socket], [], [], 0)
+        return bool(rready)
+
+
+class Lock(AsyncLock):
+    def __init__(self) -> None:
+        self._lock = anyio.create_lock()
+
+    async def release(self) -> None:
+        await self._lock.release()
+
+    async def acquire(self) -> None:
+        await self._lock.acquire()
+
+
+class Semaphore(AsyncSemaphore):
+    def __init__(self, max_value: int, exc_class: type):
+        self.max_value = max_value
+        self.exc_class = exc_class
+
+    @property
+    def semaphore(self) -> anyio.abc.Semaphore:
+        if not hasattr(self, "_semaphore"):
+            self._semaphore = anyio.create_semaphore(self.max_value)
+        return self._semaphore
+
+    async def acquire(self, timeout: float = None) -> None:
+        async with anyio.move_on_after(timeout):
+            await self.semaphore.acquire()
+            return
+
+        raise self.exc_class()
+
+    async def release(self) -> None:
+        await self.semaphore.release()
+
+
+class AnyIOBackend(AsyncBackend):
+    async def open_tcp_stream(
+        self,
+        hostname: bytes,
+        port: int,
+        ssl_context: Optional[SSLContext],
+        timeout: TimeoutDict,
+        *,
+        local_address: Optional[str],
+    ) -> AsyncSocketStream:
+        connect_timeout = timeout.get("connect")
+        # Trio will support local_address from 0.16.1 onwards.
+        # We only include the keyword argument if a local_address
+        #  argument has been passed.
+        kwargs: dict = {} if local_address is None else {"local_host": local_address}
+        unicode_host = hostname.decode("utf-8")
+
+        try:
+            async with anyio.fail_after(connect_timeout):
+                stream: anyio.abc.ByteStream
+                stream = await anyio.connect_tcp(unicode_host, port, **kwargs)
+                if ssl_context:
+                    stream = await TLSStream.wrap(
+                        stream,
+                        hostname=unicode_host,
+                        ssl_context=ssl_context,
+                        standard_compatible=False,
+                    )
+        except TimeoutError:
+            raise ConnectTimeout from None
+        except BrokenResourceError as exc:
+            raise ConnectError from exc
+
+        return SocketStream(stream=stream)
+
+    async def open_uds_stream(
+        self,
+        path: str,
+        hostname: bytes,
+        ssl_context: Optional[SSLContext],
+        timeout: TimeoutDict,
+    ) -> AsyncSocketStream:
+        connect_timeout = timeout.get("connect")
+        unicode_host = hostname.decode("utf-8")
+
+        try:
+            async with anyio.fail_after(connect_timeout):
+                stream: anyio.abc.ByteStream = await anyio.connect_unix(path)
+                if ssl_context:
+                    stream = await TLSStream.wrap(
+                        stream,
+                        hostname=unicode_host,
+                        ssl_context=ssl_context,
+                        standard_compatible=False,
+                    )
+        except TimeoutError:
+            raise ConnectTimeout from None
+        except BrokenResourceError as exc:
+            raise ConnectError from exc
+
+        return SocketStream(stream=stream)
+
+    def create_lock(self) -> AsyncLock:
+        return Lock()
+
+    def create_semaphore(self, max_value: int, exc_class: type) -> AsyncSemaphore:
+        return Semaphore(max_value, exc_class=exc_class)
+
+    async def time(self) -> float:
+        return await anyio.current_time()

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -25,6 +25,10 @@ def lookup_async_backend(name: str) -> "AsyncBackend":
         from .curio import CurioBackend
 
         return CurioBackend()
+    elif name == "anyio":
+        from .anyio import AnyIOBackend
+
+        return AnyIOBackend()
 
     raise ValueError("Invalid backend name {name!r}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 -e .[http2]
 
 # Optionals
+anyio >= 2.0.0rc2
+curio >= 1.4
 trio
 trio-typing
-curio
 
 # Docs
 mkautodoc

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -20,7 +20,7 @@ def read_body(stream: httpcore.SyncByteStream) -> bytes:
 
 
 def test_http_request() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
@@ -37,7 +37,7 @@ def test_http_request() -> None:
 
 
 def test_https_request() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
@@ -54,7 +54,7 @@ def test_https_request() -> None:
 
 
 def test_request_unsupported_protocol() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"ftp", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
@@ -64,7 +64,7 @@ def test_request_unsupported_protocol() -> None:
 
 
 def test_http2_request() -> None:
-    with httpcore.SyncConnectionPool(http2=True) as http:
+    with httpcore.SyncConnectionPool(backend="sync", http2=True) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
@@ -81,7 +81,7 @@ def test_http2_request() -> None:
 
 
 def test_closing_http_request() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org"), (b"connection", b"close")]
@@ -98,7 +98,7 @@ def test_closing_http_request() -> None:
 
 
 def test_http_request_reuse_connection() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
@@ -128,7 +128,7 @@ def test_http_request_reuse_connection() -> None:
 
 
 def test_https_request_reuse_connection() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
@@ -158,7 +158,7 @@ def test_https_request_reuse_connection() -> None:
 
 
 def test_http_request_cannot_reuse_dropped_connection() -> None:
-    with httpcore.SyncConnectionPool() as http:
+    with httpcore.SyncConnectionPool(backend="sync") as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
@@ -198,7 +198,10 @@ def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
     headers = [(b"host", b"example.org")]
     max_connections = 1
     with httpcore.SyncHTTPProxy(
-        proxy_server, proxy_mode=proxy_mode, max_connections=max_connections
+        proxy_server,
+        proxy_mode=proxy_mode,
+        max_connections=max_connections,
+        backend="sync",
     ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
@@ -213,7 +216,9 @@ def test_http_proxy(proxy_server: URL, proxy_mode: str) -> None:
 
 # This doesn't run with trio, since trio doesn't support local_address.
 def test_http_request_local_address() -> None:
-    with httpcore.SyncConnectionPool(local_address="0.0.0.0") as http:
+    with httpcore.SyncConnectionPool(
+        backend="sync", local_address="0.0.0.0"
+    ) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")
         headers = [(b"host", b"example.org")]
@@ -245,6 +250,7 @@ def test_proxy_https_requests(
         ssl_context=ca_ssl_context,
         max_connections=max_connections,
         http2=http2,
+        backend="sync",
     ) as http:
         http_version, status_code, reason, headers, stream = http.request(
             method, url, headers
@@ -293,7 +299,7 @@ def test_connection_pool_get_connection_info(
     expected_during_idle: dict,
 ) -> None:
     with httpcore.SyncConnectionPool(
-        http2=http2, keepalive_expiry=keepalive_expiry
+        backend="sync", http2=http2, keepalive_expiry=keepalive_expiry
     ) as http:
         method = b"GET"
         url = (b"https", b"example.org", 443, b"/")
@@ -324,7 +330,7 @@ def test_connection_pool_get_connection_info(
 def test_http_request_unix_domain_socket(uds_server: Server) -> None:
     uds = uds_server.config.uds
     assert uds is not None
-    with httpcore.SyncConnectionPool(uds=uds) as http:
+    with httpcore.SyncConnectionPool(backend="sync", uds=uds) as http:
         method = b"GET"
         url = (b"http", b"localhost", None, b"/")
         headers = [(b"host", b"localhost")]
@@ -345,7 +351,7 @@ def test_max_keepalive_connections_handled_correctly(
     max_keepalive: int, connections_number: int
 ) -> None:
     with httpcore.SyncConnectionPool(
-        max_keepalive_connections=max_keepalive, keepalive_expiry=60
+        backend="sync", max_keepalive_connections=max_keepalive, keepalive_expiry=60
     ) as http:
         method = b"GET"
         url = (b"http", b"example.org", 80, b"/")


### PR DESCRIPTION
Builds on #169, with a minimal as possible change footprint.

Last hurdle to clear would be switching out the cases where I've used `backend="anyio"` to be parameterized to use both `backend="auto"|"anyio"`. The `unasync.py` script will need to strip out that parameterisation for the sync case, which needs to just always use `backend="sync"`.

I'm really keen on us also using anyio to slim down any gnarly in the test suite that it can help us address, but we should treat that as an entirely isolated issue. (Using `anyio` to run our tests is an independent concern to what backend implementation we want to use.)