### PR TITLE
Pin dependencies in requirements.txt and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,32 @@
+--use-feature="2020-resolver"
+
 -e .[http2]
 
 # Optionals
-trio
-trio-typing
-curio
+trio==0.16.0
+trio-typing==0.5.0
+curio==1.4
 
 # Docs
-mkautodoc
-mkdocs
-mkdocs-material
+mkautodoc==0.1.0
+mkdocs==1.1.2
+mkdocs-material==5.5.12
 
 # Packaging
-twine
-wheel
+twine==3.2.0
+wheel==0.35.1
 
 # Tests & Linting
-anyio >= 2.0.0rc2
-autoflake
+anyio==2.0.0
+autoflake==1.4
 black==20.8b1
-flake8
-flake8-bugbear
-flake8-pie
-isort==5.*
-mitmproxy
-mypy
-pytest
-pytest-cov
-trustme
-uvicorn
+flake8==3.8.3
+flake8-bugbear==20.1.4
+flake8-pie==0.6.1
+isort==5.5.2
+mitmproxy==5.2
+mypy==0.782
+pytest==6.0.2
+pytest-cov==2.10.1
+trustme==0.6.0
+uvicorn==0.11.8

--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,6 @@ else
     PIP="pip"
 fi
 
+"$PIP" install -U "pip >= 20.2" setuptools wheel
 "$PIP" install -r "$REQUIREMENTS"
 "$PIP" install -e .

--- a/scripts/install
+++ b/scripts/install
@@ -17,4 +17,3 @@ fi
 
 "$PIP" install -U "pip >= 20.2" setuptools wheel
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .


### PR DESCRIPTION
Alternative to #162 

This PR pins all entries in our current `requirements.txt`.

Does not include a freeze process, so that we don't have to deal with transitive dependencies cross-platform (see https://github.com/encode/httpcore/pull/162#issuecomment-691639992).

This way this would work is:

* Developers and CI install from `requirements.txt`. Top-level dependencies are pinned, underlying dependencies may change. We assume the pip 2020 resolver will always be able to find transitive dependencies that work. Should work on Linux, macOS, Windows, and any supported Python version.
* Dependabot comes in once a week to check in and update any top-level dev dependencies that need updating.