### PR TITLE
Implement socks5 proxy support using socksio

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -29,9 +29,9 @@ __all__ = [
     "AsyncByteStream",
     "AsyncConnectionPool",
     "AsyncHTTPProxy",
-    "AsyncSocksProxy",
     "AsyncHTTPTransport",
     "AsyncIteratorByteStream",
+    "AsyncSocksProxy",
     "CloseError",
     "ConnectError",
     "ConnectTimeout",
@@ -48,13 +48,14 @@ __all__ = [
     "SyncByteStream",
     "SyncConnectionPool",
     "SyncHTTPProxy",
-    "SyncSocksProxy",
     "SyncHTTPTransport",
+    "SyncSocksProxy",
     "TimeoutException",
     "UnsupportedProtocol",
     "WriteError",
     "WriteTimeout",
 ]
+
 __version__ = "0.11.1"
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -1,6 +1,7 @@
 from ._async.base import AsyncByteStream, AsyncHTTPTransport
 from ._async.connection_pool import AsyncConnectionPool
 from ._async.http_proxy import AsyncHTTPProxy
+from ._async.socks_proxy import AsyncSocksProxy
 from ._bytestreams import AsyncIteratorByteStream, IteratorByteStream, PlainByteStream
 from ._exceptions import (
     CloseError,
@@ -22,11 +23,13 @@ from ._exceptions import (
 from ._sync.base import SyncByteStream, SyncHTTPTransport
 from ._sync.connection_pool import SyncConnectionPool
 from ._sync.http_proxy import SyncHTTPProxy
+from ._sync.socks_proxy import SyncSocksProxy
 
 __all__ = [
     "AsyncByteStream",
     "AsyncConnectionPool",
     "AsyncHTTPProxy",
+    "AsyncSocksProxy",
     "AsyncHTTPTransport",
     "AsyncIteratorByteStream",
     "CloseError",
@@ -45,6 +48,7 @@ __all__ = [
     "SyncByteStream",
     "SyncConnectionPool",
     "SyncHTTPProxy",
+    "SyncSocksProxy",
     "SyncHTTPTransport",
     "TimeoutException",
     "UnsupportedProtocol",

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -49,7 +49,11 @@ class AsyncSocks5ProxyProtocol(AsyncSocksProxyProtocol):
         is_auth_required = await self._check_for_authentication(socket, timeout)
 
         if is_auth_required:
-            if self.proxy_credentials is None:
+            if (
+                self.proxy_credentials is None
+                or self.proxy_credentials.username is None
+                or self.proxy_credentials.password is None
+            ):
                 raise ProxyError(
                     "This proxy requires auth, but you didn't set user/password"
                 )
@@ -184,6 +188,10 @@ class AsyncSocksProxy(AsyncConnectionPool):
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
         scheme, remote_host, remote_port, path = url
+
+        if remote_port is None:
+            remote_port = 443 if scheme == b"https" else 80
+
         remote_origin = (scheme, remote_host, remote_port)
         ssl_context = self._ssl_context if scheme == b"https" else None
         connection = await self._get_connection_from_pool(remote_origin)

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -3,9 +3,10 @@ from typing import Tuple, cast
 
 from socksio import socks5
 
-from .. import AsyncByteStream, ProxyError
 from .._backends.base import AsyncSocketStream
+from .._exceptions import ProxyError
 from .._types import URL, Headers, Origin, SocksProxyCredentials, TimeoutDict
+from .base import AsyncByteStream
 from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool
 
@@ -182,24 +183,29 @@ class AsyncSocksProxy(AsyncConnectionPool):
 
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
-        scheme, host, port, path = url
-        origin = (scheme, host, port)
-        connection = await self._get_connection_from_pool(origin)
+        scheme, remote_host, remote_port, path = url
+        remote_origin = (scheme, remote_host, remote_port)
+        connection = await self._get_connection_from_pool(remote_origin)
 
         if connection is None:
-            _, hostname, port = self._proxy_origin
+            _, proxy_hostname, proxy_port = self._proxy_origin
             socket = await self._backend.open_tcp_stream(
-                hostname,
-                port,
+                proxy_hostname,
+                proxy_port,
                 None,
                 timeout,
-                local_address=self._local_address,
+                local_address=None,
             )
 
-            await self._proxy_protocol.connect(socket, hostname, port, timeout)
+            await self._proxy_protocol.connect(
+                socket, remote_host, remote_port, timeout
+            )
 
             connection = AsyncHTTPConnection(
-                origin, http2=self._http2, ssl_context=self._ssl_context, socket=socket
+                remote_origin,
+                http2=self._http2,
+                ssl_context=self._ssl_context,
+                socket=socket,
             )
 
             await self._add_to_pool(connection, timeout)

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -185,6 +185,7 @@ class AsyncSocksProxy(AsyncConnectionPool):
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
         scheme, remote_host, remote_port, path = url
         remote_origin = (scheme, remote_host, remote_port)
+        ssl_context = self._ssl_context if scheme == b"https" else None
         connection = await self._get_connection_from_pool(remote_origin)
 
         if connection is None:
@@ -200,6 +201,9 @@ class AsyncSocksProxy(AsyncConnectionPool):
             await self._proxy_protocol.connect(
                 socket, remote_host, remote_port, timeout
             )
+
+            if ssl_context:
+                socket = await socket.start_tls(remote_host, ssl_context, timeout)
 
             connection = AsyncHTTPConnection(
                 remote_origin,

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -1,0 +1,207 @@
+from ssl import SSLContext
+from typing import Tuple, cast
+
+from socksio import socks5
+
+from .. import AsyncByteStream, ProxyError
+from .._backends.base import AsyncSocketStream
+from .._types import URL, Headers, Origin, SocksProxyCredentials, TimeoutDict
+from .connection import AsyncHTTPConnection
+from .connection_pool import AsyncConnectionPool
+
+
+class AsyncSocksProxyProtocol:
+    async def connect(
+        self,
+        socket: AsyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> None:
+        raise NotImplementedError
+
+
+class AsyncSocks5ProxyProtocol(AsyncSocksProxyProtocol):
+    def __init__(self, proxy_credentials: SocksProxyCredentials = None):
+        self.proxy_connection = socks5.SOCKS5Connection()
+        self.proxy_credentials = proxy_credentials
+
+    async def connect(
+        self,
+        socket: AsyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> None:
+        await self._auth_if_required(socket, timeout)
+
+        is_connected = await self._connect_to_remote_host(
+            socket, hostname, port, timeout
+        )
+
+        if not is_connected:
+            raise ProxyError("Cannot connect through the proxy.")
+
+    async def _auth_if_required(
+        self, socket: AsyncSocketStream, timeout: TimeoutDict
+    ) -> None:
+        is_auth_required = await self._check_for_authentication(socket, timeout)
+
+        if is_auth_required:
+            if self.proxy_credentials is None:
+                raise ProxyError(
+                    "This proxy requires auth, but you didn't set user/password"
+                )
+
+            user, password = (
+                self.proxy_credentials.username,
+                self.proxy_credentials.password,
+            )
+
+            await self._auth_using_login_and_password(socket, user, password, timeout)
+
+    async def _check_for_authentication(
+        self, socket: AsyncSocketStream, timeout: TimeoutDict
+    ) -> bool:
+        auth_request = socks5.SOCKS5AuthMethodsRequest(
+            [
+                socks5.SOCKS5AuthMethod.NO_AUTH_REQUIRED,
+                socks5.SOCKS5AuthMethod.USERNAME_PASSWORD,
+            ]
+        )
+
+        self.proxy_connection.send(auth_request)
+
+        bytes_to_send = self.proxy_connection.data_to_send()
+        await socket.write(bytes_to_send, timeout)
+
+        data = await socket.read(1024, timeout)
+        auth_ev = self.proxy_connection.receive_data(data)
+
+        return (
+            auth_ev.method == socks5.SOCKS5AuthMethod.USERNAME_PASSWORD  # type: ignore
+        )
+
+    async def _auth_using_login_and_password(
+        self,
+        socket: AsyncSocketStream,
+        user: bytes,
+        password: bytes,
+        timeout: TimeoutDict,
+    ) -> None:
+        user_password_request = socks5.SOCKS5UsernamePasswordRequest(user, password)
+        self.proxy_connection.send(user_password_request)
+
+        await socket.write(self.proxy_connection.data_to_send(), timeout)
+        user_password_response = await socket.read(2048, timeout)
+
+        user_password_event = self.proxy_connection.receive_data(user_password_response)
+
+        if not user_password_event.success:  # type: ignore
+            raise ProxyError("Invalid user/password provided to proxy auth")
+
+    async def _connect_to_remote_host(
+        self,
+        socket: AsyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> bool:
+        connect_request = socks5.SOCKS5CommandRequest.from_address(
+            socks5.SOCKS5Command.CONNECT, (hostname, port)
+        )
+
+        self.proxy_connection.send(connect_request)
+        bytes_to_send = self.proxy_connection.data_to_send()
+
+        await socket.write(bytes_to_send, timeout)
+        data = await socket.read(1024, timeout)
+        event = self.proxy_connection.receive_data(data)
+
+        return event.reply_code == socks5.SOCKS5ReplyCode.SUCCEEDED  # type: ignore
+
+
+class AsyncSocksProxy(AsyncConnectionPool):
+    def __init__(
+        self,
+        proxy_origin: Origin,
+        proxy_mode: str = "socks5",
+        proxy_credentials: SocksProxyCredentials = None,
+        ssl_context: SSLContext = None,
+        max_connections: int = None,
+        max_keepalive_connections: int = None,
+        keepalive_expiry: float = None,
+        http2: bool = False,
+        uds: str = None,
+        local_address: str = None,
+        max_keepalive: int = None,
+        backend: str = "auto",
+    ):
+        assert proxy_mode in ("socks5",)
+
+        super().__init__(
+            ssl_context=ssl_context,
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections,
+            keepalive_expiry=keepalive_expiry,
+            http2=http2,
+            uds=uds,
+            local_address=local_address,
+            max_keepalive=max_keepalive,
+            backend=backend,
+        )
+
+        self._proxy_mode = proxy_mode
+        self._proxy_origin = proxy_origin
+        self._proxy_protocol = AsyncSocks5ProxyProtocol(proxy_credentials)
+
+    async def arequest(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: AsyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+        if self._keepalive_expiry is not None:
+            await self._keepalive_sweep()
+
+        if self._proxy_mode == "socks5":
+            return await self._socks5_arequest(method, url, headers, stream, ext)
+
+        raise NotImplementedError
+
+    async def _socks5_arequest(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: AsyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+
+        ext = {} if ext is None else ext
+        timeout = cast(TimeoutDict, ext.get("timeout", {}))
+        scheme, host, port, path = url
+        origin = (scheme, host, port)
+        connection = await self._get_connection_from_pool(origin)
+
+        if connection is None:
+            _, hostname, port = self._proxy_origin
+            socket = await self._backend.open_tcp_stream(
+                hostname,
+                port,
+                None,
+                timeout,
+                local_address=self._local_address,
+            )
+
+            await self._proxy_protocol.connect(socket, hostname, port, timeout)
+
+            connection = AsyncHTTPConnection(
+                origin, http2=self._http2, ssl_context=self._ssl_context, socket=socket
+            )
+
+            await self._add_to_pool(connection, timeout)
+
+        return await connection.arequest(method, url, headers, stream, ext)

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -1,0 +1,207 @@
+from ssl import SSLContext
+from typing import Tuple, cast
+
+from socksio import socks5
+
+from .. import SyncByteStream, ProxyError
+from .._backends.base import SyncSocketStream
+from .._types import URL, Headers, Origin, SocksProxyCredentials, TimeoutDict
+from .connection import SyncHTTPConnection
+from .connection_pool import SyncConnectionPool
+
+
+class SyncSocksProxyProtocol:
+    def connect(
+        self,
+        socket: SyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> None:
+        raise NotImplementedError
+
+
+class SyncSocks5ProxyProtocol(SyncSocksProxyProtocol):
+    def __init__(self, proxy_credentials: SocksProxyCredentials = None):
+        self.proxy_connection = socks5.SOCKS5Connection()
+        self.proxy_credentials = proxy_credentials
+
+    def connect(
+        self,
+        socket: SyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> None:
+        self._auth_if_required(socket, timeout)
+
+        is_connected = self._connect_to_remote_host(
+            socket, hostname, port, timeout
+        )
+
+        if not is_connected:
+            raise ProxyError("Cannot connect through the proxy.")
+
+    def _auth_if_required(
+        self, socket: SyncSocketStream, timeout: TimeoutDict
+    ) -> None:
+        is_auth_required = self._check_for_authentication(socket, timeout)
+
+        if is_auth_required:
+            if self.proxy_credentials is None:
+                raise ProxyError(
+                    "This proxy requires auth, but you didn't set user/password"
+                )
+
+            user, password = (
+                self.proxy_credentials.username,
+                self.proxy_credentials.password,
+            )
+
+            self._auth_using_login_and_password(socket, user, password, timeout)
+
+    def _check_for_authentication(
+        self, socket: SyncSocketStream, timeout: TimeoutDict
+    ) -> bool:
+        auth_request = socks5.SOCKS5AuthMethodsRequest(
+            [
+                socks5.SOCKS5AuthMethod.NO_AUTH_REQUIRED,
+                socks5.SOCKS5AuthMethod.USERNAME_PASSWORD,
+            ]
+        )
+
+        self.proxy_connection.send(auth_request)
+
+        bytes_to_send = self.proxy_connection.data_to_send()
+        socket.write(bytes_to_send, timeout)
+
+        data = socket.read(1024, timeout)
+        auth_ev = self.proxy_connection.receive_data(data)
+
+        return (
+            auth_ev.method == socks5.SOCKS5AuthMethod.USERNAME_PASSWORD  # type: ignore
+        )
+
+    def _auth_using_login_and_password(
+        self,
+        socket: SyncSocketStream,
+        user: bytes,
+        password: bytes,
+        timeout: TimeoutDict,
+    ) -> None:
+        user_password_request = socks5.SOCKS5UsernamePasswordRequest(user, password)
+        self.proxy_connection.send(user_password_request)
+
+        socket.write(self.proxy_connection.data_to_send(), timeout)
+        user_password_response = socket.read(2048, timeout)
+
+        user_password_event = self.proxy_connection.receive_data(user_password_response)
+
+        if not user_password_event.success:  # type: ignore
+            raise ProxyError("Invalid user/password provided to proxy auth")
+
+    def _connect_to_remote_host(
+        self,
+        socket: SyncSocketStream,
+        hostname: bytes,
+        port: int,
+        timeout: TimeoutDict,
+    ) -> bool:
+        connect_request = socks5.SOCKS5CommandRequest.from_address(
+            socks5.SOCKS5Command.CONNECT, (hostname, port)
+        )
+
+        self.proxy_connection.send(connect_request)
+        bytes_to_send = self.proxy_connection.data_to_send()
+
+        socket.write(bytes_to_send, timeout)
+        data = socket.read(1024, timeout)
+        event = self.proxy_connection.receive_data(data)
+
+        return event.reply_code == socks5.SOCKS5ReplyCode.SUCCEEDED  # type: ignore
+
+
+class SyncSocksProxy(SyncConnectionPool):
+    def __init__(
+        self,
+        proxy_origin: Origin,
+        proxy_mode: str = "socks5",
+        proxy_credentials: SocksProxyCredentials = None,
+        ssl_context: SSLContext = None,
+        max_connections: int = None,
+        max_keepalive_connections: int = None,
+        keepalive_expiry: float = None,
+        http2: bool = False,
+        uds: str = None,
+        local_address: str = None,
+        max_keepalive: int = None,
+        backend: str = "sync",
+    ):
+        assert proxy_mode in ("socks5",)
+
+        super().__init__(
+            ssl_context=ssl_context,
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections,
+            keepalive_expiry=keepalive_expiry,
+            http2=http2,
+            uds=uds,
+            local_address=local_address,
+            max_keepalive=max_keepalive,
+            backend=backend,
+        )
+
+        self._proxy_mode = proxy_mode
+        self._proxy_origin = proxy_origin
+        self._proxy_protocol = SyncSocks5ProxyProtocol(proxy_credentials)
+
+    def request(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: SyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+        if self._keepalive_expiry is not None:
+            self._keepalive_sweep()
+
+        if self._proxy_mode == "socks5":
+            return self._socks5_arequest(method, url, headers, stream, ext)
+
+        raise NotImplementedError
+
+    def _socks5_arequest(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: SyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+
+        ext = {} if ext is None else ext
+        timeout = cast(TimeoutDict, ext.get("timeout", {}))
+        scheme, host, port, path = url
+        origin = (scheme, host, port)
+        connection = self._get_connection_from_pool(origin)
+
+        if connection is None:
+            _, hostname, port = self._proxy_origin
+            socket = self._backend.open_tcp_stream(
+                hostname,
+                port,
+                None,
+                timeout,
+                local_address=self._local_address,
+            )
+
+            self._proxy_protocol.connect(socket, hostname, port, timeout)
+
+            connection = SyncHTTPConnection(
+                origin, http2=self._http2, ssl_context=self._ssl_context, socket=socket
+            )
+
+            self._add_to_pool(connection, timeout)
+
+        return connection.request(method, url, headers, stream, ext)

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -49,7 +49,11 @@ class SyncSocks5ProxyProtocol(SyncSocksProxyProtocol):
         is_auth_required = self._check_for_authentication(socket, timeout)
 
         if is_auth_required:
-            if self.proxy_credentials is None:
+            if (
+                self.proxy_credentials is None
+                or self.proxy_credentials.username is None
+                or self.proxy_credentials.password is None
+            ):
                 raise ProxyError(
                     "This proxy requires auth, but you didn't set user/password"
                 )
@@ -184,7 +188,12 @@ class SyncSocksProxy(SyncConnectionPool):
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
         scheme, remote_host, remote_port, path = url
+
+        if remote_port is None:
+            remote_port = 443 if scheme == b"https" else 80
+
         remote_origin = (scheme, remote_host, remote_port)
+        ssl_context = self._ssl_context if scheme == b"https" else None
         connection = self._get_connection_from_pool(remote_origin)
 
         if connection is None:
@@ -200,6 +209,9 @@ class SyncSocksProxy(SyncConnectionPool):
             self._proxy_protocol.connect(
                 socket, remote_host, remote_port, timeout
             )
+
+            if ssl_context:
+                socket = socket.start_tls(remote_host, ssl_context, timeout)
 
             connection = SyncHTTPConnection(
                 remote_origin,

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -3,7 +3,7 @@ from typing import Tuple, cast
 
 from socksio import socks5
 
-from .._backends.base import SyncSocketStream
+from .._backends.sync import SyncSocketStream
 from .._exceptions import ProxyError
 from .._types import URL, Headers, Origin, SocksProxyCredentials, TimeoutDict
 from .base import SyncByteStream

--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -2,7 +2,7 @@
 Type definitions for type checking purposes.
 """
 
-from typing import List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import List, Mapping, NamedTuple, Optional, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 StrOrBytes = Union[str, bytes]
@@ -10,3 +10,9 @@ Origin = Tuple[bytes, bytes, int]
 URL = Tuple[bytes, bytes, Optional[int], bytes]
 Headers = List[Tuple[bytes, bytes]]
 TimeoutDict = Mapping[str, Optional[float]]
+
+
+class SocksProxyCredentials(NamedTuple):
+    username: bytes = None
+    password: bytes = None
+    userid: bytes = None

--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -13,6 +13,6 @@ TimeoutDict = Mapping[str, Optional[float]]
 
 
 class SocksProxyCredentials(NamedTuple):
-    username: bytes = None
-    password: bytes = None
-    userid: bytes = None
+    username: Optional[bytes] = None
+    password: Optional[bytes] = None
+    userid: Optional[bytes] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
 isort==5.5.4
-mitmproxy==5.2
 mypy==0.782
+pproxy==2.3.5
 pytest==6.1.0
 pytest-trio==0.6.0
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,6 @@ pproxy==2.3.5
 pytest==6.1.0
 pytest-trio==0.6.0
 pytest-cov==2.10.1
+socksio==1.0.0
 trustme==0.6.0
 uvicorn==0.12.1

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -367,9 +367,9 @@ async def test_explicit_backend_name() -> None:
     "http2",
     [True, False],
 )
-async def test_socks_proxy_connection_without_auth(url, http2):
+async def test_socks_proxy_connection_without_auth(socks_proxy, url, http2):
     (_, hostname, *_) = url
-    proxy_origin = (b"socks5", b"localhost", 1085)
+    proxy_origin = socks_proxy.without_auth
     headers = [(b"host", hostname)]
     method = b"GET"
 
@@ -395,17 +395,14 @@ async def test_socks_proxy_connection_without_auth(url, http2):
     ],
 )
 @pytest.mark.parametrize("http2", [True, False])
-async def test_socks5_proxy_connection_with_auth(url, http2):
+async def test_socks5_proxy_connection_with_auth(socks_proxy, url, http2):
     (_, hostname, *_) = url
-    proxy_origin = (b"socks5", b"localhost", 1086)
+    proxy_origin, credentials = socks_proxy.with_auth
     headers = [(b"host", hostname)]
     method = b"GET"
 
     async with httpcore.AsyncSocksProxy(
-        proxy_origin,
-        "socks5",
-        SocksProxyCredentials(username=b"username", password=b"password"),
-        http2=http2,
+        proxy_origin, "socks5", credentials, http2=http2
     ) as connection:
         (
             status_code,

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -4,7 +4,7 @@ import ssl
 import pytest
 
 import httpcore
-from httpcore._types import SocksProxyCredentials, URL
+from httpcore._types import URL
 from tests.conftest import Server
 from tests.utils import lookup_async_backend
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-import asyncio
 import contextlib
 import os
+import shlex
+import socket
 import ssl
+import subprocess
 import threading
 import time
 import typing
@@ -9,53 +11,8 @@ import typing
 import pytest
 import trustme
 import uvicorn
-from mitmproxy import options, proxy
-from mitmproxy.tools.dump import DumpMaster
 
 from httpcore._types import URL
-
-PROXY_HOST = "127.0.0.1"
-PROXY_PORT = 8080
-
-
-class RunNotify:
-    """A mitmproxy addon wrapping an event to notify us when the server is running."""
-
-    def __init__(self) -> None:
-        self.started = threading.Event()
-
-    def running(self) -> None:
-        self.started.set()
-
-
-class ProxyWrapper(threading.Thread):
-    """Runs an mitmproxy in a separate thread."""
-
-    def __init__(self, host: str, port: int, **kwargs: typing.Any) -> None:
-        self.host = host
-        self.port = port
-        self.options = kwargs
-        super().__init__()
-        self.notify = RunNotify()
-
-    def run(self) -> None:
-        # mitmproxy uses asyncio internally but the default loop policy
-        # will only create event loops for the main thread, create one
-        # as part of the thread startup
-        asyncio.set_event_loop(asyncio.new_event_loop())
-        opts = options.Options(
-            listen_host=self.host, listen_port=self.port, **self.options
-        )
-        pconf = proxy.config.ProxyConfig(opts)
-
-        self.master = DumpMaster(opts)
-        self.master.server = proxy.server.ProxyServer(pconf)
-        self.master.addons.add(self.notify)
-        self.master.run()
-
-    def join(self, timeout: float = None) -> None:
-        self.master.shutdown()
-        super().join()
 
 
 @pytest.fixture(scope="session")
@@ -70,36 +27,36 @@ def ca_ssl_context(cert_authority: trustme.CA) -> ssl.SSLContext:
     return ctx
 
 
-@pytest.fixture(scope="session")
-def example_org_cert(cert_authority: trustme.CA) -> trustme.LeafCert:
-    return cert_authority.issue_cert("example.org")
+def wait_until_pproxy_serve_on_port(host: str, port: int):
+    while True:
+        try:
+            sock = socket.create_connection((host, port))
+        except ConnectionRefusedError:
+            time.sleep(0.25)
+        else:
+            sock.close()
+            break
 
 
 @pytest.fixture(scope="session")
-def example_org_cert_path(example_org_cert: trustme.LeafCert) -> typing.Iterator[str]:
-    with example_org_cert.private_key_and_cert_chain_pem.tempfile() as tmp:
-        yield tmp
+def proxy_server() -> typing.Iterator[URL]:
+    http_proxy_host = "127.0.0.1"
+    http_proxy_port = 8080
 
-
-@pytest.fixture()
-def proxy_server(example_org_cert_path: str) -> typing.Iterator[URL]:
-    """Starts a proxy server on a different thread and yields its origin tuple.
-
-    The server is configured to use a trustme CA and key, this will allow our
-    test client to make HTTPS requests when using the ca_ssl_context fixture
-    above.
-
-    Note this is only required because mitmproxy's main purpose is to analyse
-    traffic. Other proxy servers do not need this but mitmproxy is easier to
-    integrate in our tests.
-    """
+    proc = None
     try:
-        thread = ProxyWrapper(PROXY_HOST, PROXY_PORT, certs=[example_org_cert_path])
-        thread.start()
-        thread.notify.started.wait()
-        yield (b"http", PROXY_HOST.encode(), PROXY_PORT, b"/")
+        command_str = f"pproxy -l http://{http_proxy_host}:{http_proxy_port}/"
+        command = shlex.split(command_str)
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        wait_until_pproxy_serve_on_port(http_proxy_host, http_proxy_port)
+
+        print(f"HTTP proxy started on http://{http_proxy_host}:{http_proxy_port}/")
+
+        yield b"http", http_proxy_host.encode(), http_proxy_port, b"/"
     finally:
-        thread.join()
+        if proc is not None:
+            proc.kill()
 
 
 class Server(uvicorn.Server):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 import trustme
 import uvicorn
 
-from httpcore._types import Origin, SocksProxyCredentials, URL
+from httpcore._types import URL, Origin, SocksProxyCredentials
 
 
 @pytest.fixture(scope="session")

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -353,3 +353,37 @@ def test_explicit_backend_name() -> None:
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
+
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        (b"http", b"example.com", 80, b"/"),
+        # (b"https", b"example.com", 443, b"/"),
+    ],
+)
+@pytest.mark.parametrize(
+    "http2",
+    [
+        # True,
+        False,
+    ],
+)
+def test_socks_proxy_connection_without_auth(url, http2):
+    (_, hostname, *_) = url
+    proxy_origin = (b"socks5", b"localhost", 1085)
+    headers = [(b"host", hostname)]
+    method = b"GET"
+
+    with httpcore.SyncSocksProxy(
+        proxy_origin, "socks5", None, http2=http2
+    ) as connection:
+        (
+            status_code,
+            headers,
+            stream,
+            ext,
+        ) = connection.request(method, url, headers)
+
+        assert status_code == 200

--- a/unasync.py
+++ b/unasync.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 SUBS = [
+    ('from .._backends.base import AsyncSocketStream', 'from .._backends.sync import SyncSocketStream'),
     ('AsyncIteratorByteStream', 'IteratorByteStream'),
     ('AsyncIterator', 'Iterator'),
     ('AutoBackend', 'SyncBackend'),


### PR DESCRIPTION
The final draft PR for https://github.com/encode/httpx/issues/203 (I closed previous). It's based on https://github.com/encode/httpcore/pull/51, I added @yeraydiazdiaz to co-authored-by

What I did:
1. added `pproxy` as a dev. dependency to have a local socks proxy server
1. added `AsyncSOCKSConnection` and `SyncSOCKSConnection`. For now it handles only socks5-without-auth connections