### PR TITLE
Detect broken connections using socket peeking

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -86,8 +86,8 @@ class SocketStream(AsyncSocketStream):
                 raise CloseError from exc
 
     def is_connection_dropped(self) -> bool:
-        raw_socket = self.stream.extra(SocketAttribute.raw_socket)
-        return is_socket_at_eof(raw_socket.fileno())
+        sock = self.stream.extra(SocketAttribute.raw_socket)
+        return is_socket_at_eof(sock.fileno(), sock.family, sock.type)
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -1,4 +1,3 @@
-import select
 from ssl import SSLContext
 from typing import Optional
 
@@ -17,6 +16,7 @@ from .._exceptions import (
     WriteTimeout,
 )
 from .._types import TimeoutDict
+from .._utils import is_socket_at_eof
 from .base import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 
 
@@ -87,8 +87,7 @@ class SocketStream(AsyncSocketStream):
 
     def is_connection_dropped(self) -> bool:
         raw_socket = self.stream.extra(SocketAttribute.raw_socket)
-        rready, _wready, _xready = select.select([raw_socket], [], [], 0)
-        return bool(rready)
+        return is_socket_at_eof(raw_socket)
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -87,7 +87,7 @@ class SocketStream(AsyncSocketStream):
 
     def is_connection_dropped(self) -> bool:
         raw_socket = self.stream.extra(SocketAttribute.raw_socket)
-        return is_socket_at_eof(raw_socket)
+        return is_socket_at_eof(raw_socket.fileno())
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -164,7 +164,7 @@ class SocketStream(AsyncSocketStream):
     def is_connection_dropped(self) -> bool:
         transport = self.stream_reader._transport  # type: ignore
         sock: socket.socket = transport.get_extra_info("socket")
-        return is_socket_at_eof(sock.fileno())
+        return is_socket_at_eof(sock.fileno(), sock.family, sock.type)
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 from ssl import SSLContext
 from typing import Optional
 
@@ -13,6 +14,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._types import TimeoutDict
+from .._utils import is_socket_at_eof
 from .base import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 
 SSL_MONKEY_PATCH_APPLIED = False
@@ -160,20 +162,9 @@ class SocketStream(AsyncSocketStream):
                 self.stream_writer.close()
 
     def is_connection_dropped(self) -> bool:
-        # Counter-intuitively, what we really want to know here is whether the socket is
-        # *readable*, i.e. whether it would return immediately with empty bytes if we
-        # called `.recv()` on it, indicating that the other end has closed the socket.
-        # See: https://github.com/encode/httpx/pull/143#issuecomment-515181778
-        #
-        # As it turns out, asyncio checks for readability in the background
-        # (see: https://github.com/encode/httpx/pull/276#discussion_r322000402),
-        # so checking for EOF or readability here would yield the same result.
-        #
-        # At the cost of rigour, we check for EOF instead of readability because asyncio
-        # does not expose any public API to check for readability.
-        # (For a solution that uses private asyncio APIs, see:
-        # https://github.com/encode/httpx/pull/143#issuecomment-515202982)
-        return self.stream_reader.at_eof()
+        transport = self.stream_reader._transport  # type: ignore
+        sock: socket.socket = transport.get_extra_info("socket")
+        return is_socket_at_eof(sock.fileno())
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -132,7 +132,7 @@ class SocketStream(AsyncSocketStream):
         await self.socket.close()
 
     def is_connection_dropped(self) -> bool:
-        return is_socket_at_eof(self.socket._socket)
+        return is_socket_at_eof(self.socket.fileno())
 
 
 class CurioBackend(AsyncBackend):

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -1,4 +1,3 @@
-import select
 from ssl import SSLContext, SSLSocket
 from typing import Optional
 
@@ -15,7 +14,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._types import TimeoutDict
-from .._utils import get_logger
+from .._utils import get_logger, is_socket_at_eof
 from .base import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 
 logger = get_logger(__name__)
@@ -133,9 +132,7 @@ class SocketStream(AsyncSocketStream):
         await self.socket.close()
 
     def is_connection_dropped(self) -> bool:
-        rready, _, _ = select.select([self.socket.fileno()], [], [], 0)
-
-        return bool(rready)
+        return is_socket_at_eof(self.socket._socket)
 
 
 class CurioBackend(AsyncBackend):

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -132,7 +132,8 @@ class SocketStream(AsyncSocketStream):
         await self.socket.close()
 
     def is_connection_dropped(self) -> bool:
-        return is_socket_at_eof(self.socket.fileno())
+        sock = self.socket
+        return is_socket_at_eof(sock.fileno(), sock.family, sock.type)
 
 
 class CurioBackend(AsyncBackend):

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -16,7 +16,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._types import TimeoutDict
-from .._utils import wait_for_read
+from .._utils import is_socket_at_eof
 
 
 class SyncSocketStream:
@@ -78,8 +78,7 @@ class SyncSocketStream:
                 self.sock.close()
 
     def is_connection_dropped(self) -> bool:
-        rready = wait_for_read([self.sock], timeout=0)
-        return len(rready) > 0
+        return is_socket_at_eof(self.sock)
 
 
 class SyncLock:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -78,7 +78,7 @@ class SyncSocketStream:
                 self.sock.close()
 
     def is_connection_dropped(self) -> bool:
-        return is_socket_at_eof(self.sock)
+        return is_socket_at_eof(self.sock.fileno())
 
 
 class SyncLock:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -1,4 +1,3 @@
-import select
 import socket
 import threading
 import time
@@ -17,6 +16,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._types import TimeoutDict
+from .._utils import wait_for_read
 
 
 class SyncSocketStream:
@@ -78,8 +78,8 @@ class SyncSocketStream:
                 self.sock.close()
 
     def is_connection_dropped(self) -> bool:
-        rready, _wready, _xready = select.select([self.sock], [], [], 0)
-        return bool(rready)
+        rready = wait_for_read([self.sock], timeout=0)
+        return len(rready) > 0
 
 
 class SyncLock:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -78,7 +78,8 @@ class SyncSocketStream:
                 self.sock.close()
 
     def is_connection_dropped(self) -> bool:
-        return is_socket_at_eof(self.sock.fileno())
+        sock = self.sock
+        return is_socket_at_eof(sock.fileno(), sock.family, sock.type)
 
 
 class SyncLock:

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -66,8 +66,9 @@ def origin_to_url_string(origin: Origin) -> str:
     return f"{scheme.decode('ascii')}://{host.decode('ascii')}{port}"
 
 
-def _wait_io_events(socks: list, events: int, timeout: float = None) -> list:
-    # Better cross-platform approach than low-level `select.select()` calls.
+def _wait_for_io_events(socks: list, events: int, timeout: float = None) -> list:
+    # Prefer the `selectors` module rather than the lower-level `select` module to
+    # improve cross-platform support.
     # See: https://github.com/encode/httpcore/issues/182
     sel = selectors.DefaultSelector()
     for sock in socks:
@@ -76,4 +77,4 @@ def _wait_io_events(socks: list, events: int, timeout: float = None) -> list:
 
 
 def wait_for_read(socks: list, timeout: float = None) -> list:
-    return _wait_io_events(socks, events=selectors.EVENT_READ, timeout=timeout)
+    return _wait_for_io_events(socks, events=selectors.EVENT_READ, timeout=timeout)


### PR DESCRIPTION
Fixes #182 

Attempts implementing https://github.com/encode/httpcore/pull/185#issuecomment-692229274

Attempt peeking data from the socket to detect whether the connection has reached EOF ("broken connection" / "dropped connection").

Better cross-platform support than the `selectors` alternative here: #185.

Follow-ups:

- Rename `is_connection_dropped()` to `is_at_eof()`.