### PR TITLE
Add local test server, using Hypercorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,10 +23,10 @@ black==20.8b1
 flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
+hypercorn==0.10.2
 isort==5.5.2
 mitmproxy==5.2
 mypy==0.782
 pytest==6.0.2
 pytest-cov==2.10.1
 trustme==0.6.0
-uvicorn==0.11.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ black==20.8b1
 flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
-hypercorn==0.10.2
+hypercorn==0.10.2; python_version >= '3.7'
 isort==5.5.2
 mitmproxy==5.2
 mypy==0.782

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -5,8 +5,7 @@ import pytest
 
 import httpcore
 from httpcore._types import URL
-from tests.conftest import Server
-from tests.utils import lookup_async_backend
+from tests.utils import Server, lookup_async_backend
 
 
 @pytest.fixture(params=["auto", "anyio"])
@@ -25,30 +24,30 @@ async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
 
 
 @pytest.mark.anyio
-async def test_http_request(backend: str) -> None:
+async def test_http_request(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 @pytest.mark.anyio
-async def test_https_request(backend: str) -> None:
+async def test_https_request(backend: str, https_server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -63,11 +62,11 @@ async def test_request_unsupported_protocol(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_http2_request(backend: str) -> None:
+async def test_http2_request(backend: str, https_server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend, http2=True) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -77,78 +76,82 @@ async def test_http2_request(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_closing_http_request(backend: str) -> None:
+async def test_closing_http_request(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org"), (b"connection", b"close")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header(), (b"connection", b"close")]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert url[:3] not in http._connections  # type: ignore
 
 
 @pytest.mark.anyio
-async def test_http_request_reuse_connection(backend: str) -> None:
+async def test_http_request_reuse_connection(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 @pytest.mark.anyio
-async def test_https_request_reuse_connection(backend: str) -> None:
+async def test_https_request_reuse_connection(
+    backend: str, https_server: Server
+) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 @pytest.mark.anyio
-async def test_http_request_cannot_reuse_dropped_connection(backend: str) -> None:
+async def test_http_request_cannot_reuse_dropped_connection(
+    backend: str, server: Server
+) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         # Mock the connection as having been dropped.
@@ -156,22 +159,24 @@ async def test_http_request_cannot_reuse_dropped_connection(backend: str) -> Non
         connection.is_connection_dropped = lambda: True  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.anyio
-async def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> None:
+async def test_http_proxy(
+    proxy_server: URL, proxy_mode: str, backend: str, server: Server
+) -> None:
     method = b"GET"
-    url = (b"http", b"example.org", 80, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header()]
     max_connections = 1
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
@@ -183,11 +188,11 @@ async def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> N
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
 
 
 @pytest.mark.anyio
-async def test_http_request_local_address(backend: str) -> None:
+async def test_http_request_local_address(backend: str, server: Server) -> None:
     if backend == "auto" and lookup_async_backend() == "trio":
         pytest.skip("The trio backend does not support local_address")
 
@@ -195,13 +200,13 @@ async def test_http_request_local_address(backend: str) -> None:
         backend=backend, local_address="0.0.0.0"
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -237,25 +242,25 @@ async def test_proxy_https_requests(
         (
             False,
             60.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
-            {"https://example.org": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
+            {"https://localhost:8003": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://localhost:8003": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
         ),
         (
             True,
             60.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
-            {"https://example.org": ["HTTP/2, IDLE, 0 streams"]},
+            {"https://localhost:8003": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://localhost:8003": ["HTTP/2, IDLE, 0 streams"]},
         ),
         (
             False,
             0.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://localhost:8003": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
             {},
         ),
         (
             True,
             0.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://localhost:8003": ["HTTP/2, ACTIVE, 2 streams"]},
             {},
         ),
     ],
@@ -267,13 +272,14 @@ async def test_connection_pool_get_connection_info(
     expected_during_active: dict,
     expected_during_idle: dict,
     backend: str,
+    https_server: Server,
 ) -> None:
     async with httpcore.AsyncConnectionPool(
         http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
 
         _, _, stream_1, _ = await http.arequest(method, url, headers)
         _, _, stream_2, _ = await http.arequest(method, url, headers)
@@ -300,7 +306,7 @@ async def test_connection_pool_get_connection_info(
 async def test_http_request_unix_domain_socket(
     uds_server: Server, backend: str
 ) -> None:
-    uds = uds_server.config.uds
+    uds = uds_server.host
     assert uds is not None
     async with httpcore.AsyncConnectionPool(uds=uds, backend=backend) as http:
         method = b"GET"
@@ -308,7 +314,7 @@ async def test_http_request_unix_domain_socket(
         headers = [(b"host", b"localhost")]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         body = await read_body(stream)
         assert body == b"Hello, world!"
 
@@ -317,14 +323,14 @@ async def test_http_request_unix_domain_socket(
 @pytest.mark.parametrize("connections_number", [4])
 @pytest.mark.anyio
 async def test_max_keepalive_connections_handled_correctly(
-    max_keepalive: int, connections_number: int, backend: str
+    max_keepalive: int, connections_number: int, backend: str, server: Server
 ) -> None:
     async with httpcore.AsyncConnectionPool(
         max_keepalive_connections=max_keepalive, keepalive_expiry=60, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
 
         connections_streams = []
         for _ in range(connections_number):
@@ -342,14 +348,14 @@ async def test_max_keepalive_connections_handled_correctly(
 
 
 @pytest.mark.anyio
-async def test_explicit_backend_name() -> None:
+async def test_explicit_backend_name(server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=lookup_async_backend()) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -5,8 +5,7 @@ import pytest
 
 import httpcore
 from httpcore._types import URL
-from tests.conftest import Server
-from tests.utils import lookup_sync_backend
+from tests.utils import Server, lookup_sync_backend
 
 
 @pytest.fixture(params=["sync"])
@@ -25,30 +24,30 @@ def read_body(stream: httpcore.SyncByteStream) -> bytes:
 
 
 
-def test_http_request(backend: str) -> None:
+def test_http_request(backend: str, server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 
-def test_https_request(backend: str) -> None:
+def test_https_request(backend: str, https_server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -63,11 +62,11 @@ def test_request_unsupported_protocol(backend: str) -> None:
 
 
 
-def test_http2_request(backend: str) -> None:
+def test_http2_request(backend: str, https_server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=backend, http2=True) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
@@ -77,78 +76,82 @@ def test_http2_request(backend: str) -> None:
 
 
 
-def test_closing_http_request(backend: str) -> None:
+def test_closing_http_request(backend: str, server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org"), (b"connection", b"close")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header(), (b"connection", b"close")]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert url[:3] not in http._connections  # type: ignore
 
 
 
-def test_http_request_reuse_connection(backend: str) -> None:
+def test_http_request_reuse_connection(backend: str, server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 
-def test_https_request_reuse_connection(backend: str) -> None:
+def test_https_request_reuse_connection(
+    backend: str, https_server: Server
+) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 
-def test_http_request_cannot_reuse_dropped_connection(backend: str) -> None:
+def test_http_request_cannot_reuse_dropped_connection(
+    backend: str, server: Server
+) -> None:
     with httpcore.SyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         # Mock the connection as having been dropped.
@@ -156,22 +159,24 @@ def test_http_request_cannot_reuse_dropped_connection(backend: str) -> None:
         connection.is_connection_dropped = lambda: True  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 
-def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> None:
+def test_http_proxy(
+    proxy_server: URL, proxy_mode: str, backend: str, server: Server
+) -> None:
     method = b"GET"
-    url = (b"http", b"example.org", 80, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header()]
     max_connections = 1
     with httpcore.SyncHTTPProxy(
         proxy_server,
@@ -183,11 +188,11 @@ def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
 
 
 
-def test_http_request_local_address(backend: str) -> None:
+def test_http_request_local_address(backend: str, server: Server) -> None:
     if backend == "sync" and lookup_sync_backend() == "trio":
         pytest.skip("The trio backend does not support local_address")
 
@@ -195,13 +200,13 @@ def test_http_request_local_address(backend: str) -> None:
         backend=backend, local_address="0.0.0.0"
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -237,25 +242,25 @@ def test_proxy_https_requests(
         (
             False,
             60.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
-            {"https://example.org": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
+            {"https://localhost:8003": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://localhost:8003": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
         ),
         (
             True,
             60.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
-            {"https://example.org": ["HTTP/2, IDLE, 0 streams"]},
+            {"https://localhost:8003": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://localhost:8003": ["HTTP/2, IDLE, 0 streams"]},
         ),
         (
             False,
             0.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {"https://localhost:8003": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
             {},
         ),
         (
             True,
             0.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
+            {"https://localhost:8003": ["HTTP/2, ACTIVE, 2 streams"]},
             {},
         ),
     ],
@@ -267,13 +272,14 @@ def test_connection_pool_get_connection_info(
     expected_during_active: dict,
     expected_during_idle: dict,
     backend: str,
+    https_server: Server,
 ) -> None:
     with httpcore.SyncConnectionPool(
         http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header()]
 
         _, _, stream_1, _ = http.request(method, url, headers)
         _, _, stream_2, _ = http.request(method, url, headers)
@@ -300,7 +306,8 @@ def test_connection_pool_get_connection_info(
 def test_http_request_unix_domain_socket(
     uds_server: Server, backend: str
 ) -> None:
-    uds = uds_server.config.uds
+    uds = uds_server.host
+    print(uds)
     assert uds is not None
     with httpcore.SyncConnectionPool(uds=uds, backend=backend) as http:
         method = b"GET"
@@ -308,7 +315,7 @@ def test_http_request_unix_domain_socket(
         headers = [(b"host", b"localhost")]
         status_code, headers, stream, ext = http.request(method, url, headers)
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         body = read_body(stream)
         assert body == b"Hello, world!"
 
@@ -317,14 +324,14 @@ def test_http_request_unix_domain_socket(
 @pytest.mark.parametrize("connections_number", [4])
 
 def test_max_keepalive_connections_handled_correctly(
-    max_keepalive: int, connections_number: int, backend: str
+    max_keepalive: int, connections_number: int, backend: str, server: Server
 ) -> None:
     with httpcore.SyncConnectionPool(
         max_keepalive_connections=max_keepalive, keepalive_expiry=60, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
 
         connections_streams = []
         for _ in range(connections_number):
@@ -342,14 +349,14 @@ def test_max_keepalive_connections_handled_correctly(
 
 
 
-def test_explicit_backend_name() -> None:
+def test_explicit_backend_name(server: Server) -> None:
     with httpcore.SyncConnectionPool(backend=lookup_sync_backend()) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header()]
         status_code, headers, stream, ext = http.request(method, url, headers)
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        assert ext == {"http_version": "HTTP/1.1", "reason": ""}
         assert len(http._connections[url[:3]]) == 1  # type: ignore

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,10 +4,15 @@ import threading
 import time
 from typing import Callable, Iterator, Tuple
 
-import hypercorn.config
-import hypercorn.trio
 import sniffio
 import trio
+
+try:
+    from hypercorn import config as hypercorn_config, trio as hypercorn_trio
+except ImportError:
+    # Python 3.6.
+    hypercorn_config = None  # type: ignore
+    hypercorn_trio = None  # type: ignore
 
 
 def lookup_async_backend():
@@ -38,7 +43,7 @@ class Server:
         self.app = app
         self.host = host
         self.port = port
-        self.config = hypercorn.config.Config()
+        self.config = hypercorn_config.Config()
         self.config.bind = [bind]
         self.config.certfile = certfile
         self.config.keyfile = keyfile
@@ -59,7 +64,7 @@ class Server:
                 await trio.sleep(0.01)
 
         serve = functools.partial(
-            hypercorn.trio.serve, shutdown_trigger=shutdown_trigger
+            hypercorn_trio.serve, shutdown_trigger=shutdown_trigger
         )
 
         async def main() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,13 @@
+import contextlib
+import functools
+import threading
+import time
+from typing import Callable, Iterator, Tuple
+
+import hypercorn.config
+import hypercorn.trio
 import sniffio
+import trio
 
 
 def lookup_async_backend():
@@ -7,3 +16,67 @@ def lookup_async_backend():
 
 def lookup_sync_backend():
     return "sync"
+
+
+class Server:
+    """
+    A local ASGI server, using Hypercorn.
+    """
+
+    def __init__(
+        self,
+        app: Callable,
+        host: str,
+        port: int,
+        bind: str = None,
+        certfile: str = None,
+        keyfile: str = None,
+    ) -> None:
+        if bind is None:
+            bind = f"{host}:{port}"
+
+        self.app = app
+        self.host = host
+        self.port = port
+        self.config = hypercorn.config.Config()
+        self.config.bind = [bind]
+        self.config.certfile = certfile
+        self.config.keyfile = keyfile
+        self.config.worker_class = "trio"
+        self.started = False
+        self.should_exit = False
+
+    @property
+    def netloc(self) -> Tuple[bytes, int]:
+        return (self.host.encode("utf-8"), self.port)
+
+    def host_header(self) -> Tuple[bytes, bytes]:
+        return (b"host", self.host.encode("utf-8"))
+
+    def run(self) -> None:
+        async def shutdown_trigger() -> None:
+            while not self.should_exit:
+                await trio.sleep(0.01)
+
+        serve = functools.partial(
+            hypercorn.trio.serve, shutdown_trigger=shutdown_trigger
+        )
+
+        async def main() -> None:
+            async with trio.open_nursery() as nursery:
+                await nursery.start(serve, self.app, self.config)
+                self.started = True
+
+        trio.run(main)
+
+    @contextlib.contextmanager
+    def serve_in_thread(self) -> Iterator[None]:
+        thread = threading.Thread(target=self.run)
+        thread.start()
+        try:
+            while not self.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = True
+            thread.join()


### PR DESCRIPTION
Closes #109, inspred by https://github.com/encode/httpx/pull/412, as well as the Uvicorn setup in the HTTPX repo.

* Switch almost all tests to using a local test server (using Hypercorn). Also use Hypercorn for UDS tests, so that we drop Uvicorn completely as a dev dependency. I left the HTTPS proxy test as-is, because there's some non-trivial-to-me local SSL configuration to do so that the proxy knows how to use and recognize certs of the local server.
* Hypercorn is 3.7+ only, so we'd be skipping most tests on 3.6. To make up for this I kept some of the existing tests against `example.org`, marked as "live" tests.