### PR TITLE
Add some basic connection-pool-specific tests

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -2,7 +2,7 @@ import warnings
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple, cast
 
-from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore
+from .._backends.auto import AsyncLock, AsyncSemaphore
 from .._backends.base import lookup_async_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
@@ -150,11 +150,6 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     def _create_connection(
         self,
         origin: Tuple[bytes, bytes, int],
-        backend: AsyncBackend,
-        http2: bool = False,
-        uds: str = None,
-        ssl_context: SSLContext = None,
-        local_address: str = None,
     ) -> AsyncHTTPConnection:
         return AsyncHTTPConnection(
             origin=origin,
@@ -195,14 +190,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                 connection = await self._get_connection_from_pool(origin)
 
                 if connection is None:
-                    connection = self._create_connection(
-                        origin=origin,
-                        http2=self._http2,
-                        uds=self._uds,
-                        ssl_context=self._ssl_context,
-                        local_address=self._local_address,
-                        backend=self._backend,
-                    )
+                    connection = self._create_connection(origin=origin)
                     logger.trace("created connection=%r", connection)
                     await self._add_to_pool(connection, timeout=timeout)
                 else:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -2,7 +2,7 @@ import warnings
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple, cast
 
-from .._backends.sync import SyncBackend, SyncLock, SyncSemaphore
+from .._backends.sync import SyncLock, SyncSemaphore
 from .._backends.base import lookup_sync_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
@@ -150,11 +150,6 @@ class SyncConnectionPool(SyncHTTPTransport):
     def _create_connection(
         self,
         origin: Tuple[bytes, bytes, int],
-        backend: SyncBackend,
-        http2: bool = False,
-        uds: str = None,
-        ssl_context: SSLContext = None,
-        local_address: str = None,
     ) -> SyncHTTPConnection:
         return SyncHTTPConnection(
             origin=origin,
@@ -195,14 +190,7 @@ class SyncConnectionPool(SyncHTTPTransport):
                 connection = self._get_connection_from_pool(origin)
 
                 if connection is None:
-                    connection = self._create_connection(
-                        origin=origin,
-                        http2=self._http2,
-                        uds=self._uds,
-                        ssl_context=self._ssl_context,
-                        local_address=self._local_address,
-                        backend=self._backend,
-                    )
+                    connection = self._create_connection(origin=origin)
                     logger.trace("created connection=%r", connection)
                     self._add_to_pool(connection, timeout=timeout)
                 else:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -2,7 +2,7 @@ import warnings
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple, cast
 
-from .._backends.sync import SyncLock, SyncSemaphore
+from .._backends.sync import SyncBackend, SyncLock, SyncSemaphore
 from .._backends.base import lookup_sync_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
@@ -147,6 +147,24 @@ class SyncConnectionPool(SyncHTTPTransport):
             self._internal_connection_acquiry_lock = self._backend.create_lock()
         return self._internal_connection_acquiry_lock
 
+    def _create_connection(
+        self,
+        origin: Tuple[bytes, bytes, int],
+        backend: SyncBackend,
+        http2: bool = False,
+        uds: str = None,
+        ssl_context: SSLContext = None,
+        local_address: str = None,
+    ) -> SyncHTTPConnection:
+        return SyncHTTPConnection(
+            origin=origin,
+            http2=self._http2,
+            uds=self._uds,
+            ssl_context=self._ssl_context,
+            local_address=self._local_address,
+            backend=self._backend,
+        )
+
     def request(
         self,
         method: bytes,
@@ -177,7 +195,7 @@ class SyncConnectionPool(SyncHTTPTransport):
                 connection = self._get_connection_from_pool(origin)
 
                 if connection is None:
-                    connection = SyncHTTPConnection(
+                    connection = self._create_connection(
                         origin=origin,
                         http2=self._http2,
                         uds=self._uds,
@@ -351,7 +369,7 @@ class SyncConnectionPool(SyncHTTPTransport):
 
         stats = {}
         for origin, connections in self._connections.items():
-            stats[origin_to_url_string(origin)] = [
-                connection.info() for connection in connections
-            ]
+            stats[origin_to_url_string(origin)] = sorted(
+                [connection.info() for connection in connections]
+            )
         return stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ isort==5.5.2
 mitmproxy==5.2
 mypy==0.782
 pytest==6.0.2
+pytest-trio==0.5.2
 pytest-cov==2.10.1
 trustme==0.6.0
 uvicorn==0.11.8

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,0 +1,179 @@
+from typing import AsyncIterator, Tuple
+
+import pytest
+
+import httpcore
+from httpcore._async.base import ConnectionState
+from httpcore._types import URL, Headers
+
+
+class MockConnection(object):
+    def __init__(self, http_version):
+        self.origin = (b"http", b"example.org", 80)
+        self.state = ConnectionState.PENDING
+        self.is_http11 = http_version == "HTTP/1.1"
+        self.is_http2 = http_version == "HTTP/2"
+        self.stream_count = 0
+
+    async def arequest(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: httpcore.AsyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, httpcore.AsyncByteStream, dict]:
+        self.state = ConnectionState.ACTIVE
+        self.stream_count += 1
+
+        async def on_close():
+            self.stream_count -= 1
+            if self.stream_count == 0:
+                self.state = ConnectionState.IDLE
+
+        async def aiterator() -> AsyncIterator[bytes]:
+            yield b""
+
+        stream = httpcore.AsyncIteratorByteStream(
+            aiterator=aiterator(), aclose_func=on_close
+        )
+
+        return 200, [], stream, {}
+
+    async def aclose(self):
+        pass
+
+    def info(self) -> str:
+        return str(self.state)
+
+    def mark_as_ready(self) -> None:
+        self.state = ConnectionState.READY
+
+    def is_connection_dropped(self) -> bool:
+        return False
+
+
+class ConnectionPool(httpcore.AsyncConnectionPool):
+    def __init__(self, http_version: str):
+        super().__init__()
+        self.http_version = http_version
+        assert http_version in ("HTTP/1.1", "HTTP/2")
+
+    def _create_connection(self, **kwargs):
+        return MockConnection(self.http_version)
+
+
+async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
+    try:
+        body = []
+        async for chunk in stream:
+            body.append(chunk)
+        return b"".join(body)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.trio
+async def test_sequential_requests_h11() -> None:
+    async with ConnectionPool(http_version="HTTP/1.1") as http:
+        info = await http.get_connection_info()
+        assert info == {}
+
+        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+
+@pytest.mark.trio
+async def test_sequential_requests_h2() -> None:
+    async with ConnectionPool(http_version="HTTP/2") as http:
+        info = await http.get_connection_info()
+        assert info == {}
+
+        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+
+@pytest.mark.trio
+async def test_concurrent_requests_h11() -> None:
+    async with ConnectionPool(http_version="HTTP/1.1") as http:
+        info = await http.get_connection_info()
+        assert info == {}
+
+        response_1 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_1, headers_1, stream_1, ext_1 = response_1
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        response_2 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_2, headers_2, stream_2, ext_2 = response_2
+        info = await http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.ACTIVE"]
+        }
+
+        await read_body(stream_1)
+        info = await http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.IDLE"]
+        }
+
+        await read_body(stream_2)
+        info = await http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.IDLE", "ConnectionState.IDLE"]
+        }
+
+
+@pytest.mark.trio
+async def test_concurrent_requests_h2() -> None:
+    async with ConnectionPool(http_version="HTTP/2") as http:
+        info = await http.get_connection_info()
+        assert info == {}
+
+        response_1 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_1, headers_1, stream_1, ext_1 = response_1
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        response_2 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_2, headers_2, stream_2, ext_2 = response_2
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream_1)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        await read_body(stream_2)
+        info = await http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -74,33 +74,9 @@ async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
 
 
 @pytest.mark.trio
-async def test_sequential_requests_h11() -> None:
-    async with ConnectionPool(http_version="HTTP/1.1") as http:
-        info = await http.get_connection_info()
-        assert info == {}
-
-        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
-
-        await read_body(stream)
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
-
-        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
-
-        await read_body(stream)
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
-
-
-@pytest.mark.trio
-async def test_sequential_requests_h2() -> None:
-    async with ConnectionPool(http_version="HTTP/2") as http:
+@pytest.mark.parametrize("http_version", ["HTTP/1.1", "HTTP/2"])
+async def test_sequential_requests(http_version) -> None:
+    async with ConnectionPool(http_version=http_version) as http:
         info = await http.get_connection_info()
         assert info == {}
 

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -1,0 +1,179 @@
+from typing import Iterator, Tuple
+
+import pytest
+
+import httpcore
+from httpcore._async.base import ConnectionState
+from httpcore._types import URL, Headers
+
+
+class MockConnection(object):
+    def __init__(self, http_version):
+        self.origin = (b"http", b"example.org", 80)
+        self.state = ConnectionState.PENDING
+        self.is_http11 = http_version == "HTTP/1.1"
+        self.is_http2 = http_version == "HTTP/2"
+        self.stream_count = 0
+
+    def request(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers = None,
+        stream: httpcore.SyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, Headers, httpcore.SyncByteStream, dict]:
+        self.state = ConnectionState.ACTIVE
+        self.stream_count += 1
+
+        def on_close():
+            self.stream_count -= 1
+            if self.stream_count == 0:
+                self.state = ConnectionState.IDLE
+
+        def iterator() -> Iterator[bytes]:
+            yield b""
+
+        stream = httpcore.IteratorByteStream(
+            iterator=iterator(), close_func=on_close
+        )
+
+        return 200, [], stream, {}
+
+    def close(self):
+        pass
+
+    def info(self) -> str:
+        return str(self.state)
+
+    def mark_as_ready(self) -> None:
+        self.state = ConnectionState.READY
+
+    def is_connection_dropped(self) -> bool:
+        return False
+
+
+class ConnectionPool(httpcore.SyncConnectionPool):
+    def __init__(self, http_version: str):
+        super().__init__()
+        self.http_version = http_version
+        assert http_version in ("HTTP/1.1", "HTTP/2")
+
+    def _create_connection(self, **kwargs):
+        return MockConnection(self.http_version)
+
+
+def read_body(stream: httpcore.SyncByteStream) -> bytes:
+    try:
+        body = []
+        for chunk in stream:
+            body.append(chunk)
+        return b"".join(body)
+    finally:
+        stream.close()
+
+
+
+def test_sequential_requests_h11() -> None:
+    with ConnectionPool(http_version="HTTP/1.1") as http:
+        info = http.get_connection_info()
+        assert info == {}
+
+        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+
+
+def test_sequential_requests_h2() -> None:
+    with ConnectionPool(http_version="HTTP/2") as http:
+        info = http.get_connection_info()
+        assert info == {}
+
+        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code, headers, stream, ext = response
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
+
+
+
+def test_concurrent_requests_h11() -> None:
+    with ConnectionPool(http_version="HTTP/1.1") as http:
+        info = http.get_connection_info()
+        assert info == {}
+
+        response_1 = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_1, headers_1, stream_1, ext_1 = response_1
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        response_2 = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_2, headers_2, stream_2, ext_2 = response_2
+        info = http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.ACTIVE"]
+        }
+
+        read_body(stream_1)
+        info = http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.IDLE"]
+        }
+
+        read_body(stream_2)
+        info = http.get_connection_info()
+        assert info == {
+            "http://example.org": ["ConnectionState.IDLE", "ConnectionState.IDLE"]
+        }
+
+
+
+def test_concurrent_requests_h2() -> None:
+    with ConnectionPool(http_version="HTTP/2") as http:
+        info = http.get_connection_info()
+        assert info == {}
+
+        response_1 = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_1, headers_1, stream_1, ext_1 = response_1
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        response_2 = http.request(b"GET", (b"http", b"example.org", None, b"/"))
+        status_code_2, headers_2, stream_2, ext_2 = response_2
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream_1)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+        read_body(stream_2)
+        info = http.get_connection_info()
+        assert info == {"http://example.org": ["ConnectionState.IDLE"]}

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -74,33 +74,9 @@ def read_body(stream: httpcore.SyncByteStream) -> bytes:
 
 
 
-def test_sequential_requests_h11() -> None:
-    with ConnectionPool(http_version="HTTP/1.1") as http:
-        info = http.get_connection_info()
-        assert info == {}
-
-        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
-
-        read_body(stream)
-        info = http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
-
-        response = http.request(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
-
-        read_body(stream)
-        info = http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.IDLE"]}
-
-
-
-def test_sequential_requests_h2() -> None:
-    with ConnectionPool(http_version="HTTP/2") as http:
+@pytest.mark.parametrize("http_version", ["HTTP/1.1", "HTTP/2"])
+def test_sequential_requests(http_version) -> None:
+    with ConnectionPool(http_version=http_version) as http:
         info = http.get_connection_info()
         assert info == {}
 

--- a/unasync.py
+++ b/unasync.py
@@ -20,6 +20,7 @@ SUBS = [
     ('__aexit__', '__exit__'),
     ('__aiter__', '__iter__'),
     ('@pytest.mark.anyio', ''),
+    ('@pytest.mark.trio', ''),
     (r'@pytest.fixture\(params=\["auto", "anyio"\]\)',
      '@pytest.fixture(params=["sync"])'),
     ('lookup_async_backend', "lookup_sync_backend"),


### PR DESCRIPTION
A few basic test cases for `httpcore.AsyncConnectionPool`/`httpcore.SyncConnectionPool` that work at the level of mocking out the underlying connection instances that they use.

Note that unlike `test_interfaces.py` these test cases just run against a single async backend case. Here we're not interested in the different backends, and we're not touching any backend specific code.

These tests aren't perfect but they're a great start towards us being able to test `httpcore` a bit more comprehensively by starting to add some layer-by-layer testing.

We'll also want to use them to help us start to make the contract between `ConnectionPool` and `Connection` more explicit. 