### PR TITLE
Added pproxy test fixture, which allows to test requesting through socks proxy

### DIFF
--- a/httpcore/_types.py
+++ b/httpcore/_types.py
@@ -1,8 +1,8 @@
 """
 Type definitions for type checking purposes.
 """
-
-from typing import List, Mapping, Optional, Tuple, TypeVar, Union
+import enum
+from typing import List, Mapping, NamedTuple, Optional, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 StrOrBytes = Union[str, bytes]
@@ -10,3 +10,29 @@ Origin = Tuple[bytes, bytes, int]
 URL = Tuple[bytes, bytes, Optional[int], bytes]
 Headers = List[Tuple[bytes, bytes]]
 TimeoutDict = Mapping[str, Optional[float]]
+
+SocksProxyOrigin = Tuple[bytes, int]
+
+
+class SocksProxyType(enum.Enum):
+    socks5 = "socks5"
+    socks4a = "socks4a"
+    socks4 = "socks4"
+
+
+class Socks4ProxyCredentials(NamedTuple):
+    user_id: bytes
+
+
+class Socks5ProxyCredentials(NamedTuple):
+    username: bytes
+    password: bytes
+
+
+SocksProxyCredentials = Union[Socks4ProxyCredentials, Socks5ProxyCredentials, None]
+
+
+class SocksProxyConfig(NamedTuple):
+    proxy_type: SocksProxyType
+    origin: SocksProxyOrigin
+    auth_credentials: SocksProxyCredentials = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ flake8-pie==0.6.1
 isort==5.5.2
 mitmproxy==5.2
 mypy==0.782
+pproxy==2.3.5
 pytest==6.0.2
 pytest-trio==0.5.2
 pytest-cov==2.10.1


### PR DESCRIPTION
As a part of https://github.com/encode/httpx/issues/203 (draft pr is https://github.com/encode/httpcore/pull/188) I'd like to introduce the `"socks"` test fixture.

Using `pproxy` it starts a subprocess with `socks4` and `socks5` (with auth and without auth) proxies on localhost.

Also the PR contains some new types, required in the fixture  

**There is a problem**: this server doesn't support `socks4a` proxy (may be it's not so important)