### PR TITLE
Added await to async semaphore release() coroutine

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -118,7 +118,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
             self.events[stream_id] = []
             return await h2_stream.arequest(method, url, headers, stream, ext)
         except Exception:  # noqa: PIE786
-            self.max_streams_semaphore.release()
+            await self.max_streams_semaphore.release()
             raise
 
     async def send_connection_init(self, timeout: TimeoutDict) -> None:


### PR DESCRIPTION
Working with `httpcore` I found that I missed one `await` in https://github.com/encode/httpcore/pull/170

I double checked the rest changes from the https://github.com/encode/httpcore/pull/170, everything apart from this semaphore `release` is ok