### PR TITLE
Migrate http proxy tests to pproxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
 isort==5.5.4
-mitmproxy==5.2
 mypy==0.782
+pproxy==2.3.5
 pytest==6.1.0
 pytest-trio==0.6.0
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,4 @@ pproxy==2.3.5
 pytest==6.1.0
 pytest-trio==0.6.0
 pytest-cov==2.10.1
-trustme==0.6.0
 uvicorn==0.12.1

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import ssl
 
 import pytest
 
@@ -217,7 +216,6 @@ async def test_http_request_local_address(backend: str, server: Server) -> None:
 @pytest.mark.anyio
 async def test_proxy_https_requests(
     proxy_server: URL,
-    ca_ssl_context: ssl.SSLContext,
     proxy_mode: str,
     http2: bool,
     https_server: Server,
@@ -229,7 +227,6 @@ async def test_proxy_https_requests(
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
         proxy_mode=proxy_mode,
-        ssl_context=ca_ssl_context,
         max_connections=max_connections,
         http2=http2,
     ) as http:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,8 @@ def proxy_server() -> typing.Iterator[URL]:
     proxy_host = "127.0.0.1"
     proxy_port = 8080
 
-    with http_proxy_server(proxy_host, proxy_port) as proxy_server_fixture:
-        yield proxy_server_fixture
+    with http_proxy_server(proxy_host, proxy_port) as proxy_url:
+        yield proxy_url
 
 
 class UvicornServer(uvicorn.Server):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,12 @@ import contextlib
 import os
 import shlex
 import socket
-import ssl
 import subprocess
 import threading
 import time
 import typing
 
 import pytest
-import trustme
 import uvicorn
 
 from httpcore._types import URL
@@ -18,18 +16,6 @@ from .utils import Server
 
 SERVER_HOST = "example.org"
 HTTPS_SERVER_URL = "https://example.org"
-
-
-@pytest.fixture(scope="session")
-def cert_authority() -> trustme.CA:
-    return trustme.CA()
-
-
-@pytest.fixture()
-def ca_ssl_context(cert_authority: trustme.CA) -> ssl.SSLContext:
-    ctx = ssl.create_default_context()
-    cert_authority.configure_trust(ctx)
-    return ctx
 
 
 def wait_until_pproxy_serve_on_port(host: str, port: int):

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import ssl
 
 import pytest
 
@@ -217,7 +216,6 @@ def test_http_request_local_address(backend: str, server: Server) -> None:
 
 def test_proxy_https_requests(
     proxy_server: URL,
-    ca_ssl_context: ssl.SSLContext,
     proxy_mode: str,
     http2: bool,
     https_server: Server,
@@ -229,7 +227,6 @@ def test_proxy_https_requests(
     with httpcore.SyncHTTPProxy(
         proxy_server,
         proxy_mode=proxy_mode,
-        ssl_context=ca_ssl_context,
         max_connections=max_connections,
         http2=http2,
     ) as http:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,7 @@
+import contextlib
+import socket
+import subprocess
+import time
 from typing import Tuple
 
 import sniffio
@@ -9,6 +13,17 @@ def lookup_async_backend():
 
 def lookup_sync_backend():
     return "sync"
+
+
+def wait_until_pproxy_serve_on_port(host: str, port: int):
+    while True:
+        try:
+            sock = socket.create_connection((host, port))
+        except ConnectionRefusedError:
+            time.sleep(0.25)
+        else:
+            sock.close()
+            break
 
 
 class Server:
@@ -27,3 +42,19 @@ class Server:
     @property
     def host_header(self) -> Tuple[bytes, bytes]:
         return (b"host", self._host.encode("utf-8"))
+
+
+@contextlib.contextmanager
+def http_proxy_server(proxy_host: str, proxy_port: int):
+
+    proc = None
+    try:
+        command = ["pproxy", "-l", f"http://{proxy_host}:{proxy_port}/"]
+        proc = subprocess.Popen(command)
+
+        wait_until_pproxy_serve_on_port(proxy_host, proxy_port)
+
+        yield b"http", proxy_host.encode(), proxy_port, b"/"
+    finally:
+        if proc is not None:
+            proc.kill()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,7 +15,7 @@ def lookup_sync_backend():
     return "sync"
 
 
-def wait_until_pproxy_serve_on_port(host: str, port: int):
+def _wait_can_connect(host: str, port: int):
     while True:
         try:
             sock = socket.create_connection((host, port))
@@ -52,7 +52,7 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
         command = ["pproxy", "-l", f"http://{proxy_host}:{proxy_port}/"]
         proc = subprocess.Popen(command)
 
-        wait_until_pproxy_serve_on_port(proxy_host, proxy_port)
+        _wait_can_connect(proxy_host, proxy_port)
 
         yield b"http", proxy_host.encode(), proxy_port, b"/"
     finally:


### PR DESCRIPTION
In https://github.com/encode/httpcore/pull/196 comments it was mentioned that the first step of implementing `socks` proxy support might be replacing `mitmproxy` by `pproxy` (which allows us to test `http`, `socks4` and `socks5` support)

So that I rewrote the test fixtures and changed `requirement` file.

The next steps I propose to do after this PR:
1. rebase https://github.com/encode/httpcore/pull/188 draft
1. move on acroding to the comment https://gitter.im/encode/community?at=5f6db8edf41f4105e4d7a9eb