### PR TITLE
Fix dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---use-feature="2020-resolver"
-
 -e .[http2]
 
 # Optionals

--- a/scripts/install
+++ b/scripts/install
@@ -16,4 +16,4 @@ else
 fi
 
 "$PIP" install -U "pip >= 20.2" setuptools wheel
-"$PIP" install -r "$REQUIREMENTS"
+"$PIP" install --use-feature="2020-resolver" -r "$REQUIREMENTS"


### PR DESCRIPTION
It seems dependabot is not using the latest version of pip because it's failing with this error:

```
RequirementsFileParseError('Invalid requirement: --use-feature="2020-resolver"\nrun.py: error: no such option: --use-feature\n')
```

From https://github.com/encode/httpcore/network/updates/63068071