### PR TITLE
Treat asyncio `resume_reading` error as a closed connection

### DIFF
--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -135,16 +135,15 @@ class SocketStream(AsyncSocketStream):
                     return await asyncio.wait_for(
                         self.stream_reader.read(n), timeout.get("read")
                     )
-                except AttributeError as ex:  # pragma: nocover
-                    if "resume_reading" in str(ex):
-                        # We have to return empty string there,
-                        # due to one ugly bug in asyncio
-                        # More information you can find in this issue:
-                        # https://github.com/encode/httpx/issues/1213
+                except AttributeError as exc:  # pragma: nocover
+                    if "resume_reading" in str(exc):
+                        # Python's asyncio has a bug that can occur when a
+                        # connection has been closed, while it is paused.
+                        # See: https://github.com/encode/httpx/issues/1213
                         #
-                        # Returning an empty byte-string will eventually raise
-                        # an httpcore.RemoteProtocolError to the user when this
-                        # goes through our HTTP parsing layer.
+                        # Returning an empty byte-string to indicate connection
+                        # close will eventually raise an httpcore.RemoteProtocolError
+                        # to the user when this goes through our HTTP parsing layer.
                         return b""
                     raise
 

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -138,7 +138,7 @@ class SocketStream(AsyncSocketStream):
                 except AttributeError as exc:  # pragma: nocover
                     if "resume_reading" in str(exc):
                         # Python's asyncio has a bug that can occur when a
-                        # connection has been closed, while it is paused.
+                        # connection has been closed, while it is paused.
                         # See: https://github.com/encode/httpx/issues/1213
                         #
                         # Returning an empty byte-string to indicate connection

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -138,12 +138,13 @@ class SocketStream(AsyncSocketStream):
                 except AttributeError as ex:  # pragma: nocover
                     if "resume_reading" in str(ex):
                         # We have to return empty string there,
-                        #     due to one ugly bug in asyncio
+                        # due to one ugly bug in asyncio
                         # More information you can find in this issue:
-                        #     https://github.com/encode/httpx/issues/1213
+                        # https://github.com/encode/httpx/issues/1213
                         #
-                        # The empty byte-string returned from there caused
-                        #     httpcore.RemoteProtocolError at the top level
+                        # Returning an empty byte-string will eventually raise
+                        # an httpcore.RemoteProtocolError to the user when this
+                        # goes through our HTTP parsing layer.
                         return b""
                     raise
 

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -135,16 +135,17 @@ class SocketStream(AsyncSocketStream):
                     return await asyncio.wait_for(
                         self.stream_reader.read(n), timeout.get("read")
                     )
-                except AttributeError:  # pragma: nocover
-                    """
-                    We have to return empty string there due to one ugly bug in asyncio
-                    More information you can find in this issue:
-                        https://github.com/encode/httpx/issues/1213
-
-                    The empty byte-string returned from there caused
-                    httpcore.RemoteProtocolError at the top level
-                    """
-                    return b""
+                except AttributeError as ex:  # pragma: nocover
+                    if "resume_reading" in str(ex):
+                        # We have to return empty string there,
+                        #     due to one ugly bug in asyncio
+                        # More information you can find in this issue:
+                        #     https://github.com/encode/httpx/issues/1213
+                        #
+                        # The empty byte-string returned from there caused
+                        #     httpcore.RemoteProtocolError at the top level
+                        return b""
+                    raise
 
     async def write(self, data: bytes, timeout: TimeoutDict) -> None:
         if not data:


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/1213

There is a gist in the issue, which can help you reproduce the error: [link](https://gist.github.com/cdeler/f43704721829e6ed3c799ddc7d443d5c) . You can also switch the async backend and check, that the error appears only when we `asyncio` backend.

The introduced fix mends the error, so that the error message caused by the exception looks like:

> httpcore.RemoteProtocolError: peer closed connection without sending complete message body (received 917504 bytes, expected 1000000)

instead of the original stacktrace from the issue

**There is a problem:**
I cannot figure out how to make a unit test for this error