### PR TITLE
Upgrade all dependencies for dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 -e .[http2]
 
 # Optionals
-trio==0.16.0
+trio==0.17.0
 trio-typing==0.5.0
 curio==1.4
 
 # Docs
 mkautodoc==0.1.0
 mkdocs==1.1.2
-mkdocs-material==5.5.12
+mkdocs-material==6.0.1
 
 # Packaging
 twine==3.2.0
 wheel==0.35.1
 
 # Tests & Linting
-anyio==2.0.0
+anyio==2.0.2
 autoflake==1.4
 black==20.8b1
 flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
-isort==5.5.2
+isort==5.5.4
 mitmproxy==5.2
 mypy==0.782
-pytest==6.0.2
-pytest-trio==0.5.2
+pytest==6.1.0
+pytest-trio==0.6.0
 pytest-cov==2.10.1
 trustme==0.6.0
-uvicorn==0.11.8
+uvicorn==0.12.1


### PR DESCRIPTION
I realized after merging https://github.com/encode/httpcore/pull/200 that we have a few outdated dependencies. I've bumped them to avoid getting too many PRs at the same time once dependabot checks this repo.

Here are the changelogs for the libraries:

- [trio](https://trio.readthedocs.io/en/stable/history.html#trio-0-17-0-2020-09-15): a few deprecations but nothing that we use
- [mkdocs-material](https://squidfunk.github.io/mkdocs-material/changelog/#601-_-september-26-2020): some visual changes in the search results
- [anyio](https://anyio.readthedocs.io/en/stable/versionhistory.html): some fixes
- [isort](https://github.com/PyCQA/isort/blob/develop/CHANGELOG.md#554-hotfix-september-29-2020): hotfixes
- [pytest](https://docs.pytest.org/en/stable/changelog.html#pytest-6-1-0-2020-09-26): more deprecations but again nothing that affects us
- [pytest-trio](https://pytest-trio.readthedocs.io/en/latest/history.html#pytest-trio-0-6-0-2020-05-20): new features only
- [uvicorn](https://github.com/encode/uvicorn/blob/master/CHANGELOG.md#0121---2020-09-30): new features and fixes (I'm sure you know already 😉)