### PR TITLE
Update examples after 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here's an example of making an HTTP GET request using `httpcore`...
 
 ```python
 with httpcore.SyncConnectionPool() as http:
-    http_version, status_code, reason_phrase, headers, stream = http.request(
+    status_code, headers, stream, ext = http.request(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
@@ -61,7 +61,7 @@ Or, using async...
 
 ```python
 async with httpcore.AsyncConnectionPool() as http:
-    http_version, status_code, reason_phrase, headers, stream = await http.arequest(
+    status_code, headers, stream, ext = await http.arequest(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Here's an example of making an HTTP GET request using `httpcore`...
 
 ```python
 with httpcore.SyncConnectionPool() as http:
-    http_version, status_code, reason_phrase, headers, stream = http.request(
+    status_code, headers, stream, ext = http.request(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
@@ -61,7 +61,7 @@ Or, using async...
 
 ```python
 async with httpcore.AsyncConnectionPool() as http:
-    http_version, status_code, reason_phrase, headers, stream = await http.arequest(
+    status_code, headers, stream, ext = await http.arequest(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]


### PR DESCRIPTION
in 0.11.0 the return tuple of `request()` changed: https://github.com/encode/httpcore/blob/master/CHANGELOG.md#0110-september-22nd-2020

examples needed to be adapted to it