### PR TITLE
Abstract away example.org in interface tests

### DIFF
--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -5,8 +5,8 @@ import pytest
 
 import httpcore
 from httpcore._types import URL
-from tests.conftest import Server
-from tests.utils import lookup_async_backend
+from tests.conftest import HTTPS_SERVER_URL, UvicornServer
+from tests.utils import Server, lookup_async_backend
 
 
 @pytest.fixture(params=["auto", "anyio"])
@@ -25,11 +25,11 @@ async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
 
 
 @pytest.mark.anyio
-async def test_http_request(backend: str) -> None:
+async def test_http_request(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -39,11 +39,11 @@ async def test_http_request(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_https_request(backend: str) -> None:
+async def test_https_request(backend: str, https_server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -63,11 +63,11 @@ async def test_request_unsupported_protocol(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_http2_request(backend: str) -> None:
+async def test_http2_request(backend: str, https_server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend, http2=True) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -77,11 +77,11 @@ async def test_http2_request(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_closing_http_request(backend: str) -> None:
+async def test_closing_http_request(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org"), (b"connection", b"close")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header, (b"connection", b"close")]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -91,11 +91,11 @@ async def test_closing_http_request(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_http_request_reuse_connection(backend: str) -> None:
+async def test_http_request_reuse_connection(backend: str, server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -104,8 +104,8 @@ async def test_http_request_reuse_connection(backend: str) -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -115,11 +115,13 @@ async def test_http_request_reuse_connection(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_https_request_reuse_connection(backend: str) -> None:
+async def test_https_request_reuse_connection(
+    backend: str, https_server: Server
+) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -128,8 +130,8 @@ async def test_https_request_reuse_connection(backend: str) -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -139,11 +141,13 @@ async def test_https_request_reuse_connection(backend: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_http_request_cannot_reuse_dropped_connection(backend: str) -> None:
+async def test_http_request_cannot_reuse_dropped_connection(
+    backend: str, server: Server
+) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -156,8 +160,8 @@ async def test_http_request_cannot_reuse_dropped_connection(backend: str) -> Non
         connection.is_connection_dropped = lambda: True  # type: ignore
 
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -168,10 +172,12 @@ async def test_http_request_cannot_reuse_dropped_connection(backend: str) -> Non
 
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.anyio
-async def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> None:
+async def test_http_proxy(
+    proxy_server: URL, proxy_mode: str, backend: str, server: Server
+) -> None:
     method = b"GET"
-    url = (b"http", b"example.org", 80, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
     max_connections = 1
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
@@ -187,7 +193,7 @@ async def test_http_proxy(proxy_server: URL, proxy_mode: str, backend: str) -> N
 
 
 @pytest.mark.anyio
-async def test_http_request_local_address(backend: str) -> None:
+async def test_http_request_local_address(backend: str, server: Server) -> None:
     if backend == "auto" and lookup_async_backend() == "trio":
         pytest.skip("The trio backend does not support local_address")
 
@@ -195,8 +201,8 @@ async def test_http_request_local_address(backend: str) -> None:
         backend=backend, local_address="0.0.0.0"
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 
@@ -210,11 +216,15 @@ async def test_http_request_local_address(backend: str) -> None:
 @pytest.mark.parametrize("http2", [False, True])
 @pytest.mark.anyio
 async def test_proxy_https_requests(
-    proxy_server: URL, ca_ssl_context: ssl.SSLContext, proxy_mode: str, http2: bool
+    proxy_server: URL,
+    ca_ssl_context: ssl.SSLContext,
+    proxy_mode: str,
+    http2: bool,
+    https_server: Server,
 ) -> None:
     method = b"GET"
-    url = (b"https", b"example.org", 443, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (b"https", *https_server.netloc, b"/")
+    headers = [https_server.host_header]
     max_connections = 1
     async with httpcore.AsyncHTTPProxy(
         proxy_server,
@@ -237,25 +247,25 @@ async def test_proxy_https_requests(
         (
             False,
             60.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
-            {"https://example.org": ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
+            {HTTPS_SERVER_URL: ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {HTTPS_SERVER_URL: ["HTTP/1.1, IDLE", "HTTP/1.1, IDLE"]},
         ),
         (
             True,
             60.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
-            {"https://example.org": ["HTTP/2, IDLE, 0 streams"]},
+            {HTTPS_SERVER_URL: ["HTTP/2, ACTIVE, 2 streams"]},
+            {HTTPS_SERVER_URL: ["HTTP/2, IDLE, 0 streams"]},
         ),
         (
             False,
             0.0,
-            {"https://example.org": ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
+            {HTTPS_SERVER_URL: ["HTTP/1.1, ACTIVE", "HTTP/1.1, ACTIVE"]},
             {},
         ),
         (
             True,
             0.0,
-            {"https://example.org": ["HTTP/2, ACTIVE, 2 streams"]},
+            {HTTPS_SERVER_URL: ["HTTP/2, ACTIVE, 2 streams"]},
             {},
         ),
     ],
@@ -267,13 +277,14 @@ async def test_connection_pool_get_connection_info(
     expected_during_active: dict,
     expected_during_idle: dict,
     backend: str,
+    https_server: Server,
 ) -> None:
     async with httpcore.AsyncConnectionPool(
         http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"https", b"example.org", 443, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"https", *https_server.netloc, b"/")
+        headers = [https_server.host_header]
 
         _, _, stream_1, _ = await http.arequest(method, url, headers)
         _, _, stream_2, _ = await http.arequest(method, url, headers)
@@ -298,7 +309,7 @@ async def test_connection_pool_get_connection_info(
 )
 @pytest.mark.anyio
 async def test_http_request_unix_domain_socket(
-    uds_server: Server, backend: str
+    uds_server: UvicornServer, backend: str
 ) -> None:
     uds = uds_server.config.uds
     assert uds is not None
@@ -317,14 +328,14 @@ async def test_http_request_unix_domain_socket(
 @pytest.mark.parametrize("connections_number", [4])
 @pytest.mark.anyio
 async def test_max_keepalive_connections_handled_correctly(
-    max_keepalive: int, connections_number: int, backend: str
+    max_keepalive: int, connections_number: int, backend: str, server: Server
 ) -> None:
     async with httpcore.AsyncConnectionPool(
         max_keepalive_connections=max_keepalive, keepalive_expiry=60, backend=backend
     ) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
 
         connections_streams = []
         for _ in range(connections_number):
@@ -342,11 +353,11 @@ async def test_max_keepalive_connections_handled_correctly(
 
 
 @pytest.mark.anyio
-async def test_explicit_backend_name() -> None:
+async def test_explicit_backend_name(server: Server) -> None:
     async with httpcore.AsyncConnectionPool(backend=lookup_async_backend()) as http:
         method = b"GET"
-        url = (b"http", b"example.org", 80, b"/")
-        headers = [(b"host", b"example.org")]
+        url = (b"http", *server.netloc, b"/")
+        headers = [server.host_header]
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         await read_body(stream)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import sniffio
 
 
@@ -7,3 +9,21 @@ def lookup_async_backend():
 
 def lookup_sync_backend():
     return "sync"
+
+
+class Server:
+    """
+    Represents the server we're testing against.
+    """
+
+    def __init__(self, host: str, port: int) -> None:
+        self._host = host
+        self._port = port
+
+    @property
+    def netloc(self) -> Tuple[bytes, int]:
+        return (self._host.encode("ascii"), self._port)
+
+    @property
+    def host_header(self) -> Tuple[bytes, bytes]:
+        return (b"host", self._host.encode("utf-8"))


### PR DESCRIPTION
Attempt at reducing the scope of #194: as a first step, make our tests agnostic to which "live" endpoint we're hitting, by adding a small `Server` class and using it in `test_interfaces.py` (i.e. where we're actually hitting `example.org`).

Next step would be to add Hypercorn, switch `Server`'s properties so that it points to `localhost:<port>`, instead of `example.org`, and use that updated version in fixtures.

Diff size is still not negligible, but hopefully this is a non-controversial and easily reviewable change.