### PR TITLE
Introduce Hypercorn as a local test server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coverage==5.3
 flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
-hypercorn==0.10.2; python_version >= '3.7'
+hypercorn==0.11.1; python_version >= '3.7'
 isort==5.5.4
 mypy==0.782
 pproxy==2.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,11 @@ coverage==5.3
 flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
+hypercorn==0.10.2; python_version >= '3.7'
 isort==5.5.4
 mypy==0.782
 pproxy==2.3.7
 pytest==6.1.1
 pytest-trio==0.6.0
+trustme==0.6.0
 uvicorn==0.12.1

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -33,7 +33,8 @@ async def test_http_request(backend: str, server: Server) -> None:
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -47,7 +48,8 @@ async def test_https_request(backend: str, https_server: Server) -> None:
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -85,7 +87,8 @@ async def test_closing_http_request(backend: str, server: Server) -> None:
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert url[:3] not in http._connections  # type: ignore
 
 
@@ -99,7 +102,8 @@ async def test_http_request_reuse_connection(backend: str, server: Server) -> No
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
@@ -109,7 +113,8 @@ async def test_http_request_reuse_connection(backend: str, server: Server) -> No
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -125,7 +130,8 @@ async def test_https_request_reuse_connection(
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
@@ -135,7 +141,8 @@ async def test_https_request_reuse_connection(
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -151,7 +158,8 @@ async def test_http_request_cannot_reuse_dropped_connection(
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         # Mock the connection as having been dropped.
@@ -165,7 +173,8 @@ async def test_http_request_cannot_reuse_dropped_connection(
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -188,7 +197,8 @@ async def test_http_proxy(
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
 
 
 @pytest.mark.anyio
@@ -206,7 +216,8 @@ async def test_http_request_local_address(backend: str, server: Server) -> None:
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -359,5 +370,6 @@ async def test_explicit_backend_name(server: Server) -> None:
         await read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -430,7 +430,8 @@ async def test_broken_socket_detection_many_open_files(
             await read_body(stream)
 
             assert status_code == 200
-            assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+            reason = "OK" if server.sends_reason else ""
+            assert ext == {"http_version": "HTTP/1.1", "reason": reason}
             assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def uds_server() -> typing.Iterator[UvicornServer]:
 
 
 @pytest.fixture(scope="session")
-def server() -> typing.Iterator[Server]:
+def server() -> typing.Iterator[Server]:  # pragma: no cover
     server: Server  # Please mypy.
 
     if hypercorn is None:
@@ -125,7 +125,7 @@ def localhost_cert_private_key_file(
 @pytest.fixture(scope="session")
 def https_server(
     localhost_cert_pem_file: str, localhost_cert_private_key_file: str
-) -> typing.Iterator[Server]:
+) -> typing.Iterator[Server]:  # pragma: no cover
     server: Server  # Please mypy.
 
     if hypercorn is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from .utils import HypercornServer, LiveServer, Server, http_proxy_server
 
 try:
     import hypercorn
-except ImportError:
+except ImportError:  # pragma: no cover
     # Python 3.6.
     hypercorn = None  # type: ignore
     SERVER_HOST = "example.org"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,8 @@ def uds_server() -> typing.Iterator[UvicornServer]:
 
 @pytest.fixture(scope="session")
 def server() -> typing.Iterator[Server]:
+    server: Server  # Please mypy.
+
     if hypercorn is None:
         server = LiveServer(host=SERVER_HOST, port=SERVER_HTTP_PORT)
         yield server
@@ -124,6 +126,8 @@ def localhost_cert_private_key_file(
 def https_server(
     localhost_cert_pem_file: str, localhost_cert_private_key_file: str
 ) -> typing.Iterator[Server]:
+    server: Server  # Please mypy.
+
     if hypercorn is None:
         server = LiveServer(host=SERVER_HOST, port=SERVER_HTTPS_PORT)
         yield server
@@ -136,6 +140,5 @@ def https_server(
         certfile=localhost_cert_pem_file,
         keyfile=localhost_cert_private_key_file,
     )
-
     with server.serve_in_thread():
         yield server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,7 @@ from .utils import HypercornServer, LiveServer, Server, http_proxy_server
 
 try:
     import hypercorn
-except ImportError:  # pragma: no cover
-    # Python 3.6.
+except ImportError:  # pragma: no cover  # Python 3.6
     hypercorn = None  # type: ignore
     SERVER_HOST = "example.org"
     SERVER_HTTP_PORT = 80

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,27 @@ import time
 import typing
 
 import pytest
+import trustme
 import uvicorn
 
 from httpcore._types import URL
 
-from .utils import Server, http_proxy_server
+from .utils import HypercornServer, LiveServer, Server, http_proxy_server
 
-SERVER_HOST = "example.org"
-HTTPS_SERVER_URL = "https://example.org"
+try:
+    import hypercorn
+except ImportError:
+    # Python 3.6.
+    hypercorn = None  # type: ignore
+    SERVER_HOST = "example.org"
+    SERVER_HTTP_PORT = 80
+    SERVER_HTTPS_PORT = 443
+    HTTPS_SERVER_URL = "https://example.org"
+else:
+    SERVER_HOST = "localhost"
+    SERVER_HTTP_PORT = 8002
+    SERVER_HTTPS_PORT = 8003
+    HTTPS_SERVER_URL = f"https://localhost:{SERVER_HTTPS_PORT}"
 
 
 @pytest.fixture(scope="session")
@@ -66,10 +79,63 @@ def uds_server() -> typing.Iterator[UvicornServer]:
 
 
 @pytest.fixture(scope="session")
-def server() -> Server:
-    return Server(SERVER_HOST, port=80)
+def server() -> typing.Iterator[Server]:
+    if hypercorn is None:
+        server = LiveServer(host=SERVER_HOST, port=SERVER_HTTP_PORT)
+        yield server
+        return
+
+    server = HypercornServer(app=app, host=SERVER_HOST, port=SERVER_HTTP_PORT)
+    with server.serve_in_thread():
+        yield server
 
 
 @pytest.fixture(scope="session")
-def https_server() -> Server:
-    return Server(SERVER_HOST, port=443)
+def cert_authority() -> trustme.CA:
+    return trustme.CA()
+
+
+@pytest.fixture(scope="session")
+def localhost_cert(cert_authority: trustme.CA) -> trustme.LeafCert:
+    return cert_authority.issue_cert("localhost")
+
+
+@pytest.fixture(scope="session")
+def localhost_cert_path(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
+    with localhost_cert.private_key_and_cert_chain_pem.tempfile() as tmp:
+        yield tmp
+
+
+@pytest.fixture(scope="session")
+def localhost_cert_pem_file(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
+    with localhost_cert.cert_chain_pems[0].tempfile() as tmp:
+        yield tmp
+
+
+@pytest.fixture(scope="session")
+def localhost_cert_private_key_file(
+    localhost_cert: trustme.LeafCert,
+) -> typing.Iterator[str]:
+    with localhost_cert.private_key_pem.tempfile() as tmp:
+        yield tmp
+
+
+@pytest.fixture(scope="session")
+def https_server(
+    localhost_cert_pem_file: str, localhost_cert_private_key_file: str
+) -> typing.Iterator[Server]:
+    if hypercorn is None:
+        server = LiveServer(host=SERVER_HOST, port=SERVER_HTTPS_PORT)
+        yield server
+        return
+
+    server = HypercornServer(
+        app=app,
+        host=SERVER_HOST,
+        port=SERVER_HTTPS_PORT,
+        certfile=localhost_cert_pem_file,
+        keyfile=localhost_cert_private_key_file,
+    )
+
+    with server.serve_in_thread():
+        yield server

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -430,7 +430,8 @@ def test_broken_socket_detection_many_open_files(
             read_body(stream)
 
             assert status_code == 200
-            assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+            reason = "OK" if server.sends_reason else ""
+            assert ext == {"http_version": "HTTP/1.1", "reason": reason}
             assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -33,7 +33,8 @@ def test_http_request(backend: str, server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -47,7 +48,8 @@ def test_https_request(backend: str, https_server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -85,7 +87,8 @@ def test_closing_http_request(backend: str, server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert url[:3] not in http._connections  # type: ignore
 
 
@@ -99,7 +102,8 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
@@ -109,7 +113,8 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -125,7 +130,8 @@ def test_https_request_reuse_connection(
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         method = b"GET"
@@ -135,7 +141,8 @@ def test_https_request_reuse_connection(
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if https_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -151,7 +158,8 @@ def test_http_request_cannot_reuse_dropped_connection(
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
         # Mock the connection as having been dropped.
@@ -165,7 +173,8 @@ def test_http_request_cannot_reuse_dropped_connection(
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -188,7 +197,8 @@ def test_http_proxy(
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
 
 
 
@@ -206,7 +216,8 @@ def test_http_request_local_address(backend: str, server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
@@ -359,5 +370,6 @@ def test_explicit_backend_name(server: Server) -> None:
         read_body(stream)
 
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         assert len(http._connections[url[:3]]) == 1  # type: ignore

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,7 +11,7 @@ import trio
 
 try:
     from hypercorn import config as hypercorn_config, trio as hypercorn_trio
-except ImportError:
+except ImportError:  # pragma: no cover
     # Python 3.6.
     hypercorn_config = None  # type: ignore
     hypercorn_trio = None  # type: ignore
@@ -54,7 +54,7 @@ class Server:
         raise NotImplementedError  # pragma: no cover
 
 
-class LiveServer(Server):
+class LiveServer(Server):  # pragma: no cover
     """
     A test server running on a live location.
     """
@@ -74,7 +74,7 @@ class LiveServer(Server):
         return (b"host", self._host.encode("ascii"))
 
 
-class HypercornServer(Server):
+class HypercornServer(Server):  # pragma: no cover
     """
     A test server running in-process, powered by Hypercorn.
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,20 @@
 import contextlib
+import functools
 import socket
 import subprocess
+import threading
 import time
-from typing import Tuple
+from typing import Callable, Iterator, Tuple
 
 import sniffio
+import trio
+
+try:
+    from hypercorn import config as hypercorn_config, trio as hypercorn_trio
+except ImportError:
+    # Python 3.6.
+    hypercorn_config = None  # type: ignore
+    hypercorn_trio = None  # type: ignore
 
 
 def lookup_async_backend():
@@ -28,8 +38,28 @@ def _wait_can_connect(host: str, port: int):
 
 class Server:
     """
-    Represents the server we're testing against.
+    Base interface for servers we can test against.
     """
+
+    @property
+    def sends_reason(self) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def netloc(self) -> Tuple[bytes, int]:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def host_header(self) -> Tuple[bytes, bytes]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class LiveServer(Server):
+    """
+    A test server running on a live location.
+    """
+
+    sends_reason = True
 
     def __init__(self, host: str, port: int) -> None:
         self._host = host
@@ -41,7 +71,72 @@ class Server:
 
     @property
     def host_header(self) -> Tuple[bytes, bytes]:
-        return (b"host", self._host.encode("utf-8"))
+        return (b"host", self._host.encode("ascii"))
+
+
+class HypercornServer(Server):
+    """
+    A test server running in-process, powered by Hypercorn.
+    """
+
+    sends_reason = False
+
+    def __init__(
+        self,
+        app: Callable,
+        host: str,
+        port: int,
+        bind: str = None,
+        certfile: str = None,
+        keyfile: str = None,
+    ) -> None:
+        assert hypercorn_config is not None
+        self._app = app
+        self._host = host
+        self._port = port
+        self._config = hypercorn_config.Config()
+        self._config.bind = [bind or f"{host}:{port}"]
+        self._config.certfile = certfile
+        self._config.keyfile = keyfile
+        self._config.worker_class = "asyncio"
+        self._started = False
+        self._should_exit = False
+
+    @property
+    def netloc(self) -> Tuple[bytes, int]:
+        return (self._host.encode("ascii"), self._port)
+
+    @property
+    def host_header(self) -> Tuple[bytes, bytes]:
+        return (b"host", self._host.encode("ascii"))
+
+    def _run(self) -> None:
+        async def shutdown_trigger() -> None:
+            while not self._should_exit:
+                await trio.sleep(0.01)
+
+        serve = functools.partial(
+            hypercorn_trio.serve, shutdown_trigger=shutdown_trigger
+        )
+
+        async def main() -> None:
+            async with trio.open_nursery() as nursery:
+                await nursery.start(serve, self._app, self._config)
+                self._started = True
+
+        trio.run(main)
+
+    @contextlib.contextmanager
+    def serve_in_thread(self) -> Iterator[None]:
+        thread = threading.Thread(target=self._run)
+        thread.start()
+        try:
+            while not self._started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self._should_exit = True
+            thread.join()
 
 
 @contextlib.contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,8 +12,7 @@ import trio
 
 try:
     from hypercorn import config as hypercorn_config, trio as hypercorn_trio
-except ImportError:  # pragma: no cover
-    # Python 3.6.
+except ImportError:  # pragma: no cover  # Python 3.6
     hypercorn_config = None  # type: ignore
     hypercorn_trio = None  # type: ignore
 
@@ -55,7 +54,7 @@ class Server:
         raise NotImplementedError  # pragma: no cover
 
 
-class LiveServer(Server):  # pragma: no cover
+class LiveServer(Server):  # pragma: no cover  # Python 3.6 only
     """
     A test server running on a live location.
     """
@@ -75,7 +74,7 @@ class LiveServer(Server):  # pragma: no cover
         return (b"host", self._host.encode("ascii"))
 
 
-class HypercornServer(Server):  # pragma: no cover
+class HypercornServer(Server):  # pragma: no cover  # Python 3.7+ only
     """
     A test server running in-process, powered by Hypercorn.
     """


### PR DESCRIPTION
Re-ignite of #194:

Closes #109 

100% of our tests now run locally (and switching to `pproxy` (via #196) made this possible with much less pain :-)).

Note: Hypercorn only runs on 3.7, so on 3.6 we keep testing against the `example.org` website, like we do currently. There's a bit of overhead to that, but nothing too blocking I hope, and it's actually nice that we keep some coverage against real-world websites.

Follow-ups include:

- Use Hypercorn for the UDS tests as well, so we remove can Uvicorn entirely (instead of keeping both Hypercorn and Uvicorn as this PR does for now, for ease of reviewing).