### PR TITLE
Turn transport.request() into a context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,13 @@ Here's an example of making an HTTP GET request using `httpcore`...
 
 ```python
 with httpcore.SyncConnectionPool() as http:
-    status_code, headers, stream, ext = http.request(
+    with http.request(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    )
-
-    try:
+    ) as response:
+        status_code, headers, stream, ext = respnose
         body = b''.join([chunk for chunk in stream])
-    finally:
-        stream.close()
 
     print(status_code, body)
 ```
@@ -61,16 +58,13 @@ Or, using async...
 
 ```python
 async with httpcore.AsyncConnectionPool() as http:
-    status_code, headers, stream, ext = await http.arequest(
+    async with http.arequest(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    )
-
-    try:
+    ) as response:
+        status_code, headers, stream, ext = response
         body = b''.join([chunk async for chunk in stream])
-    finally:
-        await stream.aclose()
 
     print(status_code, body)
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ with httpcore.SyncConnectionPool() as http:
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
     ) as response:
-        status_code, headers, stream, ext = respnose
+        status_code, headers, stream, ext = response
         body = b''.join([chunk for chunk in stream])
 
     print(status_code, body)

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ interface which transport classes need to implement.
 
 ::: httpcore.AsyncByteStream
     :docstring:
-    :members: __aiter__ aclose
+    :members: __aiter__
 
 The `AsyncConnectionPool` class is a concrete implementation of `AsyncHTTPTransport`.
 
@@ -40,7 +40,7 @@ interface which transport classes need to implement.
 
 ::: httpcore.SyncByteStream
     :docstring:
-    :members: __iter__ close
+    :members: __iter__
 
 The `SyncConnectionPool` class is a concrete implementation of `SyncHTTPTransport`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,55 +2,38 @@
 
 ## Async API Overview
 
-The `AsyncHTTPTransport` and `AsyncByteStream` classes provide the base
-interface which transport classes need to implement.
+The `AsyncHTTPTransport` class provides the base interface which transport classes need to implement.
 
 ::: httpcore.AsyncHTTPTransport
     :docstring:
     :members: arequest aclose
-
-::: httpcore.AsyncByteStream
-    :docstring:
-    :members: __aiter__
 
 The `AsyncConnectionPool` class is a concrete implementation of `AsyncHTTPTransport`.
 
 ::: httpcore.AsyncConnectionPool
     :docstring:
 
-
-The `PlainByteStream` and `AsyncIteratorByteStream` classes are concrete implementations of `AsyncByteStream`.
-
-::: httpcore.PlainByteStream
-    :docstring:
-
-::: httpcore.AsyncIteratorByteStream
-    :docstring:
-
 ---
 
 ## Sync API Overview
 
-The `SyncHTTPTransport` and `SyncByteStream` classes provide the base
-interface which transport classes need to implement.
+The `SyncHTTPTransport` class provides the base interface which transport classes need to implement.
 
 ::: httpcore.SyncHTTPTransport
     :docstring:
     :members: request close
-
-::: httpcore.SyncByteStream
-    :docstring:
-    :members: __iter__
 
 The `SyncConnectionPool` class is a concrete implementation of `SyncHTTPTransport`.
 
 ::: httpcore.SyncConnectionPool
     :docstring:
 
-The `PlainByteStream` and `IteratorByteStream` classes are concrete implementations of `SyncByteStream`.
+---
+
+## Utilities
+
+The `PlainByteStream` can be used to return a bytestring with both bytes iterable
+and async bytes iterable iterfaces.
 
 ::: httpcore.PlainByteStream
-    :docstring:
-
-::: httpcore.IteratorByteStream
     :docstring:

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,8 @@ with httpcore.SyncConnectionPool() as http:
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    ) as (status_code, headers, stream, ext):
+    ) as response:
+        status_code, headers, stream, ext = response
         body = b''.join([chunk for chunk in stream])
 
     print(status_code, body)
@@ -61,7 +62,8 @@ async with httpcore.AsyncConnectionPool() as http:
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    ) as (status_code, headers, stream, ext):
+    ) as response:
+        status_code, headers, stream, ext = response
         body = b''.join([chunk async for chunk in stream])
 
     print(status_code, body)

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,16 +43,12 @@ Here's an example of making an HTTP GET request using `httpcore`...
 
 ```python
 with httpcore.SyncConnectionPool() as http:
-    status_code, headers, stream, ext = http.request(
+    with http.request(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    )
-
-    try:
+    ) as (status_code, headers, stream, ext):
         body = b''.join([chunk for chunk in stream])
-    finally:
-        stream.close()
 
     print(status_code, body)
 ```
@@ -61,16 +57,12 @@ Or, using async...
 
 ```python
 async with httpcore.AsyncConnectionPool() as http:
-    status_code, headers, stream, ext = await http.arequest(
+    async with http.arequest(
         method=b'GET',
         url=(b'https', b'example.org', 443, b'/'),
         headers=[(b'host', b'example.org'), (b'user-agent', 'httpcore')]
-    )
-
-    try:
+    ) as (status_code, headers, stream, ext):
         body = b''.join([chunk async for chunk in stream])
-    finally:
-        await stream.aclose()
 
     print(status_code, body)
 ```

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -1,7 +1,7 @@
 from ._async.base import AsyncByteStream, AsyncHTTPTransport
 from ._async.connection_pool import AsyncConnectionPool
 from ._async.http_proxy import AsyncHTTPProxy
-from ._bytestreams import AsyncIteratorByteStream, IteratorByteStream, PlainByteStream
+from ._bytestreams import PlainByteStream
 from ._exceptions import (
     CloseError,
     ConnectError,
@@ -28,11 +28,9 @@ __all__ = [
     "AsyncConnectionPool",
     "AsyncHTTPProxy",
     "AsyncHTTPTransport",
-    "AsyncIteratorByteStream",
     "CloseError",
     "ConnectError",
     "ConnectTimeout",
-    "IteratorByteStream",
     "LocalProtocolError",
     "NetworkError",
     "PlainByteStream",

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -1,4 +1,4 @@
-from ._async.base import AsyncByteStream, AsyncHTTPTransport
+from ._async.base import AsyncHTTPTransport
 from ._async.connection_pool import AsyncConnectionPool
 from ._async.http_proxy import AsyncHTTPProxy
 from ._bytestreams import PlainByteStream
@@ -19,12 +19,11 @@ from ._exceptions import (
     WriteError,
     WriteTimeout,
 )
-from ._sync.base import SyncByteStream, SyncHTTPTransport
+from ._sync.base import SyncHTTPTransport
 from ._sync.connection_pool import SyncConnectionPool
 from ._sync.http_proxy import SyncHTTPProxy
 
 __all__ = [
-    "AsyncByteStream",
     "AsyncConnectionPool",
     "AsyncHTTPProxy",
     "AsyncHTTPTransport",
@@ -40,7 +39,6 @@ __all__ = [
     "ReadError",
     "ReadTimeout",
     "RemoteProtocolError",
-    "SyncByteStream",
     "SyncConnectionPool",
     "SyncHTTPProxy",
     "SyncHTTPTransport",

--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import AsyncIterator, Tuple, Type
+from typing import AsyncContextManager, AsyncIterator, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -57,18 +57,18 @@ class AsyncHTTPTransport:
     """
     The base interface for sending HTTP requests.
 
-    Concete implementations should subclass this class, and implement
+    Concrete implementations should subclass this class, and implement
     the `request` method, and optionally the `close` method.
     """
 
-    async def arequest(
+    def arequest(
         self,
         method: bytes,
         url: URL,
         headers: Headers = None,
         stream: AsyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+    ) -> AsyncContextManager[Tuple[int, Headers, AsyncByteStream, dict]]:
         """
         The interface for sending a single HTTP request, and returning a response.
 
@@ -84,7 +84,7 @@ class AsyncHTTPTransport:
 
         ** Returns:**
 
-        A four-tuple of:
+        A context manager yielding a four-tuple of:
 
         * **status_code** - `int` - The HTTP status code, such as `200`.
         * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included

--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -46,12 +46,6 @@ class AsyncByteStream:
         """
         yield b""  # pragma: nocover
 
-    async def aclose(self) -> None:
-        """
-        Must be called by the client to indicate that the stream has been closed.
-        """
-        pass  # pragma: nocover
-
 
 class AsyncHTTPTransport:
     """

--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import AsyncContextManager, AsyncIterator, Tuple, Type
+from typing import AsyncContextManager, AsyncIterable, AsyncIterator, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -60,9 +60,9 @@ class AsyncHTTPTransport:
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncContextManager[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncContextManager[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         """
         The interface for sending a single HTTP request, and returning a response.
 
@@ -73,7 +73,7 @@ class AsyncHTTPTransport:
         of (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers
         to send with the request.
-        * **stream** - `Optional[AsyncByteStream]` - The body of the HTTP request.
+        * **stream** - `Optional[AsyncIterable[bytes]]` - The body of the HTTP request.
         * **ext** - `Optional[dict]` - A dictionary of optional extensions.
 
         ** Returns:**
@@ -83,7 +83,7 @@ class AsyncHTTPTransport:
         * **status_code** - `int` - The HTTP status code, such as `200`.
         * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included
         on the response.
-        * **stream** - `AsyncByteStream` - The body of the HTTP response.
+        * **stream** - `AsyncIterable[bytes]` - The body of the HTTP response.
         * **ext** - `dict` - A dictionary of optional extensions.
         """
         raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import AsyncContextManager, AsyncIterable, AsyncIterator, Tuple, Type
+from typing import AsyncContextManager, AsyncIterable, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -30,21 +30,6 @@ class ConnectionState(enum.IntEnum):
     FULL = 3  # Active requests, no more stream IDs available.
     IDLE = 4  # No active requests.
     CLOSED = 5  # Connection closed.
-
-
-class AsyncByteStream:
-    """
-    The base interface for request and response bodies.
-
-    Concrete implementations should subclass this class, and implement
-    the `\\__aiter__` method, and optionally the `aclose` method.
-    """
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        """
-        Yield bytes representing the request or response body.
-        """
-        yield b""  # pragma: nocover
 
 
 class AsyncHTTPTransport:

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,17 +1,12 @@
 from ssl import SSLContext
-from typing import AsyncIterator, Optional, Tuple, cast
+from typing import AsyncIterable, AsyncIterator, Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
 from .._compat import asynccontextmanager
 from .._exceptions import ConnectError, ConnectTimeout
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import exponential_backoff, get_logger, url_to_origin
-from .base import (
-    AsyncByteStream,
-    AsyncHTTPTransport,
-    ConnectionState,
-    NewConnectionRequired,
-)
+from .base import AsyncHTTPTransport, ConnectionState, NewConnectionRequired
 from .http import AsyncBaseHTTPConnection
 
 logger = get_logger(__name__)
@@ -78,9 +73,9 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         assert url_to_origin(url) == self.origin
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,11 +1,10 @@
 import warnings
-from functools import partial
 from ssl import SSLContext
 from typing import AsyncIterator, Dict, List, Optional, Set, Tuple, cast
 
 from .._backends.auto import AsyncLock, AsyncSemaphore
 from .._backends.base import lookup_async_backend
-from .._compat import AsyncExitStack, asynccontextmanager
+from .._compat import asynccontextmanager
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
@@ -150,45 +149,34 @@ class AsyncConnectionPool(AsyncHTTPTransport):
 
         await self._keepalive_sweep()
 
-        async with AsyncExitStack() as exit_stack:
-            connection: Optional[AsyncHTTPConnection] = None
-            while connection is None:
-                async with self._connection_acquiry_lock:
-                    # We get-or-create a connection as an atomic operation, to ensure
-                    # that HTTP/2 requests issued in close concurrency will end up
-                    # on the same connection.
-                    logger.trace("get_connection_from_pool=%r", origin)
-                    connection = await self._get_connection_from_pool(origin)
+        connection: Optional[AsyncHTTPConnection] = None
+        while connection is None:
+            async with self._connection_acquiry_lock:
+                # We get-or-create a connection as an atomic operation, to ensure
+                # that HTTP/2 requests issued in close concurrency will end up
+                # on the same connection.
+                logger.trace("get_connection_from_pool=%r", origin)
+                connection = await self._get_connection_from_pool(origin)
 
-                    if connection is None:
-                        connection = self._create_connection(origin=origin)
-                        logger.trace("created connection=%r", connection)
-                        await self._add_to_pool(connection, timeout=timeout)
-                    else:
-                        logger.trace("reuse connection=%r", connection)
+                if connection is None:
+                    connection = self._create_connection(origin=origin)
+                    logger.trace("created connection=%r", connection)
+                    await self._add_to_pool(connection, timeout=timeout)
+                else:
+                    logger.trace("reuse connection=%r", connection)
 
-                try:
-                    # Push this callback onto the stack *before* making the request,
-                    # so that it's effectively executed *after* the response is closed.
-                    exit_stack.push_async_callback(
-                        partial(self._response_closed, connection)
-                    )
+            try:
+                async with connection.arequest(
+                    method, url, headers=headers, stream=stream, ext=ext
+                ) as response:
+                    yield response
+            except NewConnectionRequired:
+                connection = None
+            except Exception:  # noqa: PIE786
+                logger.trace("remove from pool connection=%r", connection)
+                await self._remove_from_pool(connection)
 
-                    response = await exit_stack.enter_async_context(
-                        connection.arequest(
-                            method, url, headers=headers, stream=stream, ext=ext
-                        )
-                    )
-                except NewConnectionRequired:
-                    exit_stack.pop_all()  # Drop any registered callbacks.
-                    connection = None
-                except Exception:  # noqa: PIE786
-                    logger.trace("remove from pool connection=%r", connection)
-                    exit_stack.pop_all()  # Drop any registered callbacks.
-                    await self._remove_from_pool(connection)
-                    raise
-
-            yield response
+        await self._response_closed(connection)
 
     async def _get_connection_from_pool(
         self, origin: Origin

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,6 +1,16 @@
 import warnings
 from ssl import SSLContext
-from typing import AsyncIterator, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore
 from .._backends.base import lookup_async_backend
@@ -9,12 +19,7 @@ from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
-from .base import (
-    AsyncByteStream,
-    AsyncHTTPTransport,
-    ConnectionState,
-    NewConnectionRequired,
-)
+from .base import AsyncHTTPTransport, ConnectionState, NewConnectionRequired
 from .connection import AsyncHTTPConnection
 
 logger = get_logger(__name__)
@@ -142,9 +147,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
             raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -74,16 +74,13 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
         ) = await self._receive_response(timeout)
         response_stream = AsyncIteratorByteStream(
             aiterator=self._receive_response_data(timeout),
-            aclose_func=self._response_closed,
         )
         ext = {
             "http_version": http_version.decode("ascii", errors="ignore"),
             "reason": reason_phrase.decode("ascii", errors="ignore"),
         }
-        try:
-            yield (status_code, headers, response_stream, ext)
-        finally:
-            await response_stream.aclose()
+        yield (status_code, headers, response_stream, ext)
+        await self._response_closed()
 
     async def start_tls(
         self, hostname: bytes, timeout: TimeoutDict = None

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -79,8 +79,10 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
             "http_version": http_version.decode("ascii", errors="ignore"),
             "reason": reason_phrase.decode("ascii", errors="ignore"),
         }
-        yield (status_code, headers, response_stream, ext)
-        await self._response_closed()
+        try:
+            yield (status_code, headers, response_stream, ext)
+        finally:
+            await self._response_closed()
 
     async def start_tls(
         self, hostname: bytes, timeout: TimeoutDict = None

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -301,18 +301,14 @@ class AsyncHTTP2Stream:
 
         # Receive the response.
         status_code, headers = await self.receive_response(timeout)
-        response_stream = AsyncIteratorByteStream(
-            aiterator=self.body_iter(timeout), aclose_func=self._response_closed
-        )
+        response_stream = AsyncIteratorByteStream(aiterator=self.body_iter(timeout))
 
         ext = {
             "http_version": "HTTP/2",
         }
 
-        try:
-            yield (status_code, headers, response_stream, ext)
-        finally:
-            await response_stream.aclose()
+        yield (status_code, headers, response_stream, ext)
+        await self._response_closed()
 
     async def send_headers(
         self,

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -9,6 +9,7 @@ from h2.settings import SettingCodes, Settings
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 from .._bytestreams import AsyncIteratorByteStream, PlainByteStream
+from .._compat import asynccontextmanager
 from .._exceptions import PoolTimeout, RemoteProtocolError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
@@ -85,6 +86,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         if self.state == ConnectionState.IDLE:
             self.state = ConnectionState.READY
 
+    @asynccontextmanager
     async def arequest(
         self,
         method: bytes,
@@ -92,7 +94,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         headers: Headers = None,
         stream: AsyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
 
@@ -116,7 +118,10 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
             h2_stream = AsyncHTTP2Stream(stream_id=stream_id, connection=self)
             self.streams[stream_id] = h2_stream
             self.events[stream_id] = []
-            return await h2_stream.arequest(method, url, headers, stream, ext)
+            async with h2_stream.arequest(
+                method, url, headers, stream, ext
+            ) as response:
+                yield response
         except Exception:  # noqa: PIE786
             await self.max_streams_semaphore.release()
             raise
@@ -270,6 +275,7 @@ class AsyncHTTP2Stream:
         self.stream_id = stream_id
         self.connection = connection
 
+    @asynccontextmanager
     async def arequest(
         self,
         method: bytes,
@@ -277,7 +283,7 @@ class AsyncHTTP2Stream:
         headers: Headers = None,
         stream: AsyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
         headers = [] if headers is None else [(k.lower(), v) for (k, v) in headers]
         stream = PlainByteStream(b"") if stream is None else stream
         ext = {} if ext is None else ext
@@ -302,7 +308,11 @@ class AsyncHTTP2Stream:
         ext = {
             "http_version": "HTTP/2",
         }
-        return (status_code, headers, response_stream, ext)
+
+        try:
+            yield (status_code, headers, response_stream, ext)
+        finally:
+            await response_stream.aclose()
 
     async def send_headers(
         self,

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -307,8 +307,10 @@ class AsyncHTTP2Stream:
             "http_version": "HTTP/2",
         }
 
-        yield (status_code, headers, response_stream, ext)
-        await self._response_closed()
+        try:
+            yield (status_code, headers, response_stream, ext)
+        finally:
+            await self._response_closed()
 
     async def send_headers(
         self,

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -167,13 +167,13 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         url = self.proxy_origin + (target,)
         headers = merge_headers(self.proxy_headers, headers)
 
-        async with connection.arequest(
-            method, url, headers=headers, stream=stream, ext=ext
-        ) as response:
-            try:
+        try:
+            async with connection.arequest(
+                method, url, headers=headers, stream=stream, ext=ext
+            ) as response:
                 yield response
-            finally:
-                await self._response_closed(connection)
+        finally:
+            await self._response_closed(connection)
 
     @asynccontextmanager
     async def _tunnel_request(
@@ -253,17 +253,14 @@ class AsyncHTTPProxy(AsyncConnectionPool):
 
             # Once the connection has been established we can send requests on
             # it as normal.
-            response = await exit_stack.enter_async_context(
-                connection.arequest(
+            try:
+                async with connection.arequest(
                     method,
                     url,
                     headers=headers,
                     stream=stream,
                     ext=ext,
-                )
-            )
-
-            try:
-                yield response
+                ) as response:
+                    yield response
             finally:
                 await self._response_closed(connection)

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -1,12 +1,11 @@
 from http import HTTPStatus
 from ssl import SSLContext
-from typing import AsyncIterator, Tuple, cast
+from typing import AsyncIterable, AsyncIterator, Tuple, cast
 
 from .._compat import AsyncExitStack, asynccontextmanager
 from .._exceptions import ProxyError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger, url_to_origin
-from .base import AsyncByteStream
 from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool
 
@@ -94,9 +93,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         if self._keepalive_expiry is not None:
             await self._keepalive_sweep()
 
@@ -135,9 +134,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         """
         Forwarded proxy requests include the entire URL as the HTTP target,
         rather than just the path.
@@ -181,9 +180,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         """
         Tunnelled proxy requests require an initial CONNECT request to
         establish the connection, and then send regular requests.

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -96,6 +96,17 @@ class AsyncSemaphore:
     Abstracts away any asyncio-specific interfaces.
     """
 
+    async def __aenter__(self) -> None:
+        await self.acquire()
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        await self.release()
+
     async def acquire(self, timeout: float = None) -> None:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -109,6 +109,17 @@ class SyncSemaphore:
         self.exc_class = exc_class
         self._semaphore = threading.Semaphore(max_value)
 
+    def __enter__(self) -> None:
+        self.acquire()
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        self.release()
+
     def acquire(self, timeout: float = None) -> None:
         if not self._semaphore.acquire(timeout=timeout):  # type: ignore
             raise self.exc_class()

--- a/httpcore/_bytestreams.py
+++ b/httpcore/_bytestreams.py
@@ -1,10 +1,7 @@
 from typing import AsyncIterator, Iterator
 
-from ._async.base import AsyncByteStream
-from ._sync.base import SyncByteStream
 
-
-class PlainByteStream(AsyncByteStream, SyncByteStream):
+class PlainByteStream:
     """
     A concrete implementation for either sync or async byte streams.
     Just handles a plain byte string as the content of the stream.
@@ -22,45 +19,3 @@ class PlainByteStream(AsyncByteStream, SyncByteStream):
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         yield self._content
-
-
-class IteratorByteStream(SyncByteStream):
-    """
-    A concrete implementation for sync byte streams.
-    Handles a byte iterator as the content of the stream.
-
-    ```
-    def generate_content():
-        ...
-
-    stream = httpcore.IteratorByteStream(generate_content())
-    ```
-    """
-
-    def __init__(self, iterator: Iterator[bytes]) -> None:
-        self._iterator = iterator
-
-    def __iter__(self) -> Iterator[bytes]:
-        for chunk in self._iterator:
-            yield chunk
-
-
-class AsyncIteratorByteStream(AsyncByteStream):
-    """
-    A concrete implementation for async byte streams.
-    Handles an async byte iterator as the content of the stream.
-
-    ```
-    async def generate_content():
-        ...
-
-    stream = httpcore.AsyncIteratorByteStream(generate_content())
-    ```
-    """
-
-    def __init__(self, aiterator: AsyncIterator[bytes]) -> None:
-        self._aiterator = aiterator
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        async for chunk in self._aiterator:
-            yield chunk

--- a/httpcore/_bytestreams.py
+++ b/httpcore/_bytestreams.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Callable, Iterator
+from typing import AsyncIterator, Iterator
 
 from ._async.base import AsyncByteStream
 from ._sync.base import SyncByteStream
@@ -37,17 +37,12 @@ class IteratorByteStream(SyncByteStream):
     ```
     """
 
-    def __init__(self, iterator: Iterator[bytes], close_func: Callable = None) -> None:
+    def __init__(self, iterator: Iterator[bytes]) -> None:
         self._iterator = iterator
-        self._close_func = close_func
 
     def __iter__(self) -> Iterator[bytes]:
         for chunk in self._iterator:
             yield chunk
-
-    def close(self) -> None:
-        if self._close_func is not None:
-            self._close_func()
 
 
 class AsyncIteratorByteStream(AsyncByteStream):
@@ -63,16 +58,9 @@ class AsyncIteratorByteStream(AsyncByteStream):
     ```
     """
 
-    def __init__(
-        self, aiterator: AsyncIterator[bytes], aclose_func: Callable = None
-    ) -> None:
+    def __init__(self, aiterator: AsyncIterator[bytes]) -> None:
         self._aiterator = aiterator
-        self._aclose_func = aclose_func
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         async for chunk in self._aiterator:
             yield chunk
-
-    async def aclose(self) -> None:
-        if self._aclose_func is not None:
-            await self._aclose_func()

--- a/httpcore/_compat.py
+++ b/httpcore/_compat.py
@@ -1,5 +1,5 @@
 try:
-    from contextlib import AsyncExitStack, asynccontextmanager
+    from contextlib import AsyncExitStack, asynccontextmanager  # type: ignore  # Py3.6
 except ImportError:  # pragma: no cover
     # Python 3.6
     from async_exit_stack import AsyncExitStack  # type: ignore  # noqa: F401

--- a/httpcore/_compat.py
+++ b/httpcore/_compat.py
@@ -1,0 +1,9 @@
+try:
+    from contextlib import AsyncExitStack, asynccontextmanager
+except ImportError:  # pragma: no cover
+    # Python 3.6
+    from async_exit_stack import AsyncExitStack  # type: ignore  # noqa: F401
+    from async_generator import asynccontextmanager  # type: ignore  # noqa: F401
+
+# These will be imported by the unasynced code.
+from contextlib import ExitStack, contextmanager  # noqa: F401

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import Iterator, Tuple, Type
+from typing import ContextManager, Iterator, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -57,7 +57,7 @@ class SyncHTTPTransport:
     """
     The base interface for sending HTTP requests.
 
-    Concete implementations should subclass this class, and implement
+    Concrete implementations should subclass this class, and implement
     the `request` method, and optionally the `close` method.
     """
 
@@ -68,7 +68,7 @@ class SyncHTTPTransport:
         headers: Headers = None,
         stream: SyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+    ) -> ContextManager[Tuple[int, Headers, SyncByteStream, dict]]:
         """
         The interface for sending a single HTTP request, and returning a response.
 
@@ -84,7 +84,7 @@ class SyncHTTPTransport:
 
         ** Returns:**
 
-        A four-tuple of:
+        A context manager yielding a four-tuple of:
 
         * **status_code** - `int` - The HTTP status code, such as `200`.
         * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import ContextManager, Iterable, Iterator, Tuple, Type
+from typing import ContextManager, Iterable, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -32,21 +32,6 @@ class ConnectionState(enum.IntEnum):
     CLOSED = 5  # Connection closed.
 
 
-class SyncByteStream:
-    """
-    The base interface for request and response bodies.
-
-    Concrete implementations should subclass this class, and implement
-    the `\\__iter__` method, and optionally the `close` method.
-    """
-
-    def __iter__(self) -> Iterator[bytes]:
-        """
-        Yield bytes representing the request or response body.
-        """
-        yield b""  # pragma: nocover
-
-
 class SyncHTTPTransport:
     """
     The base interface for sending HTTP requests.
@@ -73,7 +58,7 @@ class SyncHTTPTransport:
         of (scheme, host, port, path).
         * **headers** - `Optional[List[Tuple[bytes, bytes]]]` - Any HTTP headers
         to send with the request.
-        * **stream** - `Optional[SyncByteStream]` - The body of the HTTP request.
+        * **stream** - `Optional[Iterable[bytes]]` - The body of the HTTP request.
         * **ext** - `Optional[dict]` - A dictionary of optional extensions.
 
         ** Returns:**
@@ -83,7 +68,7 @@ class SyncHTTPTransport:
         * **status_code** - `int` - The HTTP status code, such as `200`.
         * **headers** - `List[Tuple[bytes, bytes]]` - Any HTTP headers included
         on the response.
-        * **stream** - `SyncByteStream` - The body of the HTTP response.
+        * **stream** - `Iterable[bytes]` - The body of the HTTP response.
         * **ext** - `dict` - A dictionary of optional extensions.
         """
         raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -1,6 +1,6 @@
 import enum
 from types import TracebackType
-from typing import ContextManager, Iterator, Tuple, Type
+from typing import ContextManager, Iterable, Iterator, Tuple, Type
 
 from .._types import URL, Headers, T
 
@@ -60,9 +60,9 @@ class SyncHTTPTransport:
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> ContextManager[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> ContextManager[Tuple[int, Headers, Iterable[bytes], dict]]:
         """
         The interface for sending a single HTTP request, and returning a response.
 

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -46,12 +46,6 @@ class SyncByteStream:
         """
         yield b""  # pragma: nocover
 
-    def close(self) -> None:
-        """
-        Must be called by the client to indicate that the stream has been closed.
-        """
-        pass  # pragma: nocover
-
 
 class SyncHTTPTransport:
     """

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,17 +1,12 @@
 from ssl import SSLContext
-from typing import Iterator, Optional, Tuple, cast
+from typing import Iterable, Iterator, Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
 from .._compat import contextmanager
 from .._exceptions import ConnectError, ConnectTimeout
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import exponential_backoff, get_logger, url_to_origin
-from .base import (
-    SyncByteStream,
-    SyncHTTPTransport,
-    ConnectionState,
-    NewConnectionRequired,
-)
+from .base import SyncHTTPTransport, ConnectionState, NewConnectionRequired
 from .http import SyncBaseHTTPConnection
 
 logger = get_logger(__name__)
@@ -78,9 +73,9 @@ class SyncHTTPConnection(SyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         assert url_to_origin(url) == self.origin
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,6 +1,16 @@
 import warnings
 from ssl import SSLContext
-from typing import Iterator, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import (
+    Iterable,
+    Iterator,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSemaphore
 from .._backends.base import lookup_sync_backend
@@ -9,12 +19,7 @@ from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
-from .base import (
-    SyncByteStream,
-    SyncHTTPTransport,
-    ConnectionState,
-    NewConnectionRequired,
-)
+from .base import SyncHTTPTransport, ConnectionState, NewConnectionRequired
 from .connection import SyncHTTPConnection
 
 logger = get_logger(__name__)
@@ -142,9 +147,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         if url[0] not in (b"http", b"https"):
             scheme = url[0].decode("latin-1")
             raise UnsupportedProtocol(f"Unsupported URL protocol {scheme!r}")

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -74,16 +74,13 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
         ) = self._receive_response(timeout)
         response_stream = IteratorByteStream(
             iterator=self._receive_response_data(timeout),
-            close_func=self._response_closed,
         )
         ext = {
             "http_version": http_version.decode("ascii", errors="ignore"),
             "reason": reason_phrase.decode("ascii", errors="ignore"),
         }
-        try:
-            yield (status_code, headers, response_stream, ext)
-        finally:
-            response_stream.close()
+        yield (status_code, headers, response_stream, ext)
+        self._response_closed()
 
     def start_tls(
         self, hostname: bytes, timeout: TimeoutDict = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -79,8 +79,10 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
             "http_version": http_version.decode("ascii", errors="ignore"),
             "reason": reason_phrase.decode("ascii", errors="ignore"),
         }
-        yield (status_code, headers, response_stream, ext)
-        self._response_closed()
+        try:
+            yield (status_code, headers, response_stream, ext)
+        finally:
+            self._response_closed()
 
     def start_tls(
         self, hostname: bytes, timeout: TimeoutDict = None

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -307,8 +307,10 @@ class SyncHTTP2Stream:
             "http_version": "HTTP/2",
         }
 
-        yield (status_code, headers, response_stream, ext)
-        self._response_closed()
+        try:
+            yield (status_code, headers, response_stream, ext)
+        finally:
+            self._response_closed()
 
     def send_headers(
         self,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -301,18 +301,14 @@ class SyncHTTP2Stream:
 
         # Receive the response.
         status_code, headers = self.receive_response(timeout)
-        response_stream = IteratorByteStream(
-            iterator=self.body_iter(timeout), close_func=self._response_closed
-        )
+        response_stream = IteratorByteStream(iterator=self.body_iter(timeout))
 
         ext = {
             "http_version": "HTTP/2",
         }
 
-        try:
-            yield (status_code, headers, response_stream, ext)
-        finally:
-            response_stream.close()
+        yield (status_code, headers, response_stream, ext)
+        self._response_closed()
 
     def send_headers(
         self,

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -1,12 +1,11 @@
 from http import HTTPStatus
 from ssl import SSLContext
-from typing import Iterator, Tuple, cast
+from typing import Iterable, Iterator, Tuple, cast
 
 from .._compat import ExitStack, contextmanager
 from .._exceptions import ProxyError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger, url_to_origin
-from .base import SyncByteStream
 from .connection import SyncHTTPConnection
 from .connection_pool import SyncConnectionPool
 
@@ -94,9 +93,9 @@ class SyncHTTPProxy(SyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         if self._keepalive_expiry is not None:
             self._keepalive_sweep()
 
@@ -135,9 +134,9 @@ class SyncHTTPProxy(SyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         """
         Forwarded proxy requests include the entire URL as the HTTP target,
         rather than just the path.
@@ -181,9 +180,9 @@ class SyncHTTPProxy(SyncConnectionPool):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         """
         Tunnelled proxy requests require an initial CONNECT request to
         establish the connection, and then send regular requests.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -167,13 +167,13 @@ class SyncHTTPProxy(SyncConnectionPool):
         url = self.proxy_origin + (target,)
         headers = merge_headers(self.proxy_headers, headers)
 
-        with connection.request(
-            method, url, headers=headers, stream=stream, ext=ext
-        ) as response:
-            try:
+        try:
+            with connection.request(
+                method, url, headers=headers, stream=stream, ext=ext
+            ) as response:
                 yield response
-            finally:
-                self._response_closed(connection)
+        finally:
+            self._response_closed(connection)
 
     @contextmanager
     def _tunnel_request(
@@ -253,17 +253,14 @@ class SyncHTTPProxy(SyncConnectionPool):
 
             # Once the connection has been established we can send requests on
             # it as normal.
-            response = exit_stack.enter_context(
-                connection.request(
+            try:
+                with connection.request(
                     method,
                     url,
                     headers=headers,
                     stream=stream,
                     ext=ext,
-                )
-            )
-
-            try:
-                yield response
+                ) as response:
+                    yield response
             finally:
                 self._response_closed(connection)

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -1,13 +1,14 @@
 from http import HTTPStatus
 from ssl import SSLContext
-from typing import Tuple, cast
+from typing import Iterator, Tuple, cast
 
+from .._compat import ExitStack, contextmanager
 from .._exceptions import ProxyError
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger, url_to_origin
 from .base import SyncByteStream
 from .connection import SyncHTTPConnection
-from .connection_pool import SyncConnectionPool, ResponseByteStream
+from .connection_pool import SyncConnectionPool
 
 logger = get_logger(__name__)
 
@@ -87,6 +88,7 @@ class SyncHTTPProxy(SyncConnectionPool):
             max_keepalive=max_keepalive,
         )
 
+    @contextmanager
     def request(
         self,
         method: bytes,
@@ -94,7 +96,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         headers: Headers = None,
         stream: SyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
         if self._keepalive_expiry is not None:
             self._keepalive_sweep()
 
@@ -109,9 +111,10 @@ class SyncHTTPProxy(SyncConnectionPool):
                 method,
                 url,
             )
-            return self._forward_request(
+            with self._forward_request(
                 method, url, headers=headers, stream=stream, ext=ext
-            )
+            ) as response:
+                yield response
         else:
             # By default HTTPS should be tunnelled.
             logger.trace(
@@ -121,10 +124,12 @@ class SyncHTTPProxy(SyncConnectionPool):
                 method,
                 url,
             )
-            return self._tunnel_request(
+            with self._tunnel_request(
                 method, url, headers=headers, stream=stream, ext=ext
-            )
+            ) as response:
+                yield response
 
+    @contextmanager
     def _forward_request(
         self,
         method: bytes,
@@ -132,7 +137,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         headers: Headers = None,
         stream: SyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
         """
         Forwarded proxy requests include the entire URL as the HTTP target,
         rather than just the path.
@@ -162,16 +167,15 @@ class SyncHTTPProxy(SyncConnectionPool):
         url = self.proxy_origin + (target,)
         headers = merge_headers(self.proxy_headers, headers)
 
-        (status_code, headers, stream, ext) = connection.request(
+        with connection.request(
             method, url, headers=headers, stream=stream, ext=ext
-        )
+        ) as response:
+            try:
+                yield response
+            finally:
+                self._response_closed(connection)
 
-        wrapped_stream = ResponseByteStream(
-            stream, connection=connection, callback=self._response_closed
-        )
-
-        return status_code, headers, wrapped_stream, ext
-
+    @contextmanager
     def _tunnel_request(
         self,
         method: bytes,
@@ -179,7 +183,7 @@ class SyncHTTPProxy(SyncConnectionPool):
         headers: Headers = None,
         stream: SyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, SyncByteStream, dict]:
+    ) -> Iterator[Tuple[int, Headers, SyncByteStream, dict]]:
         """
         Tunnelled proxy requests require an initial CONNECT request to
         establish the connection, and then send regular requests.
@@ -189,72 +193,77 @@ class SyncHTTPProxy(SyncConnectionPool):
         origin = url_to_origin(url)
         connection = self._get_connection_from_pool(origin)
 
-        if connection is None:
-            scheme, host, port = origin
+        with ExitStack() as exit_stack:
+            if connection is None:
+                scheme, host, port = origin
 
-            # First, create a connection to the proxy server
-            proxy_connection = SyncHTTPConnection(
-                origin=self.proxy_origin,
-                http2=self._http2,
-                ssl_context=self._ssl_context,
+                # First, create a connection to the proxy server
+                proxy_connection = SyncHTTPConnection(
+                    origin=self.proxy_origin,
+                    http2=self._http2,
+                    ssl_context=self._ssl_context,
+                )
+
+                # Issue a CONNECT request...
+
+                # CONNECT www.example.org:80 HTTP/1.1
+                # [proxy-headers]
+                target = b"%b:%d" % (host, port)
+                connect_url = self.proxy_origin + (target,)
+                connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
+                connect_headers = merge_headers(connect_headers, self.proxy_headers)
+
+                proxy_response = exit_stack.enter_context(
+                    proxy_connection.request(
+                        b"CONNECT", connect_url, headers=connect_headers, ext=ext
+                    )
+                )
+                proxy_status_code, _, proxy_stream, _ = proxy_response
+                proxy_reason = get_reason_phrase(proxy_status_code)
+                logger.trace(
+                    "tunnel_response proxy_status_code=%r proxy_reason=%r ",
+                    proxy_status_code,
+                    proxy_reason,
+                )
+                # Read the response data without closing the socket
+                for _ in proxy_stream:
+                    pass
+
+                # See if the tunnel was successfully established.
+                if proxy_status_code < 200 or proxy_status_code > 299:
+                    msg = "%d %s" % (proxy_status_code, proxy_reason)
+                    raise ProxyError(msg)
+
+                # Upgrade to TLS if required
+                # We assume the target speaks TLS on the specified port
+                if scheme == b"https":
+                    proxy_connection.start_tls(host, timeout)
+
+                # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+                # This means the proxy connection is now unusable, and we must create
+                # a new one for regular requests, making sure to use the same socket to
+                # retain the tunnel.
+                connection = SyncHTTPConnection(
+                    origin=origin,
+                    http2=self._http2,
+                    ssl_context=self._ssl_context,
+                    socket=proxy_connection.socket,
+                )
+                self._add_to_pool(connection, timeout)
+
+            # Once the connection has been established we can send requests on
+            # it as normal.
+            response = exit_stack.enter_context(
+                connection.request(
+                    method,
+                    url,
+                    headers=headers,
+                    stream=stream,
+                    ext=ext,
+                )
             )
 
-            # Issue a CONNECT request...
-
-            # CONNECT www.example.org:80 HTTP/1.1
-            # [proxy-headers]
-            target = b"%b:%d" % (host, port)
-            connect_url = self.proxy_origin + (target,)
-            connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
-            connect_headers = merge_headers(connect_headers, self.proxy_headers)
-            (proxy_status_code, _, proxy_stream, _) = proxy_connection.request(
-                b"CONNECT", connect_url, headers=connect_headers, ext=ext
-            )
-
-            proxy_reason = get_reason_phrase(proxy_status_code)
-            logger.trace(
-                "tunnel_response proxy_status_code=%r proxy_reason=%r ",
-                proxy_status_code,
-                proxy_reason,
-            )
-            # Read the response data without closing the socket
-            for _ in proxy_stream:
-                pass
-
-            # See if the tunnel was successfully established.
-            if proxy_status_code < 200 or proxy_status_code > 299:
-                msg = "%d %s" % (proxy_status_code, proxy_reason)
-                raise ProxyError(msg)
-
-            # Upgrade to TLS if required
-            # We assume the target speaks TLS on the specified port
-            if scheme == b"https":
-                proxy_connection.start_tls(host, timeout)
-
-            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
-            # This means the proxy connection is now unusable, and we must create
-            # a new one for regular requests, making sure to use the same socket to
-            # retain the tunnel.
-            connection = SyncHTTPConnection(
-                origin=origin,
-                http2=self._http2,
-                ssl_context=self._ssl_context,
-                socket=proxy_connection.socket,
-            )
-            self._add_to_pool(connection, timeout)
-
-        # Once the connection has been established we can send requests on
-        # it as normal.
-        (status_code, headers, stream, ext) = connection.request(
-            method,
-            url,
-            headers=headers,
-            stream=stream,
-            ext=ext,
-        )
-
-        wrapped_stream = ResponseByteStream(
-            stream, connection=connection, callback=self._response_closed
-        )
-
-        return status_code, headers, wrapped_stream, ext
+            try:
+                yield response
+            finally:
+                self._response_closed(connection)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,13 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11>=0.8,<0.10", "sniffio==1.*"],
+    install_requires=[
+        "h11>=0.8,<0.10",
+        "sniffio==1.*",
+        # Backports.
+        "async_generator; python_version<'3.7'",
+        "async-exit-stack; python_version<'3.7'",
+    ],
     extras_require={
         "http2": ["h2==3.*"],
     },

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Tuple
+from typing import AsyncIterable, AsyncIterator, Tuple
 
 import pytest
 
@@ -22,9 +22,9 @@ class MockConnection(httpcore.AsyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: httpcore.AsyncByteStream = None,
+        stream: AsyncIterable[bytes] = None,
         ext: dict = None,
-    ) -> AsyncIterator[Tuple[int, Headers, httpcore.AsyncByteStream, dict]]:
+    ) -> AsyncIterator[Tuple[int, Headers, AsyncIterable[bytes], dict]]:
         self.state = ConnectionState.ACTIVE
         self.stream_count += 1
 
@@ -36,7 +36,7 @@ class MockConnection(httpcore.AsyncHTTPTransport):
         async def aiterator() -> AsyncIterator[bytes]:
             yield b""
 
-        stream = httpcore.AsyncIteratorByteStream(aiterator=aiterator())
+        stream = aiterator()
 
         try:
             yield 200, [], stream, {}
@@ -66,7 +66,7 @@ class ConnectionPool(httpcore.AsyncConnectionPool):
         return MockConnection(self.http_version)
 
 
-async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
+async def read_body(stream: AsyncIterable[bytes]) -> bytes:
     return b"".join([chunk async for chunk in stream])
 
 

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,10 +1,10 @@
-from contextlib import AsyncExitStack, asynccontextmanager
 from typing import AsyncIterator, Tuple
 
 import pytest
 
 import httpcore
 from httpcore._async.base import ConnectionState
+from httpcore._compat import AsyncExitStack, asynccontextmanager
 from httpcore._types import URL, Headers
 
 

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,3 +1,4 @@
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import AsyncIterator, Tuple
 
 import pytest
@@ -7,7 +8,7 @@ from httpcore._async.base import ConnectionState
 from httpcore._types import URL, Headers
 
 
-class MockConnection(object):
+class MockConnection(httpcore.AsyncHTTPTransport):
     def __init__(self, http_version):
         self.origin = (b"http", b"example.org", 80)
         self.state = ConnectionState.PENDING
@@ -15,6 +16,7 @@ class MockConnection(object):
         self.is_http2 = http_version == "HTTP/2"
         self.stream_count = 0
 
+    @asynccontextmanager
     async def arequest(
         self,
         method: bytes,
@@ -22,7 +24,7 @@ class MockConnection(object):
         headers: Headers = None,
         stream: httpcore.AsyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, Headers, httpcore.AsyncByteStream, dict]:
+    ) -> AsyncIterator[Tuple[int, Headers, httpcore.AsyncByteStream, dict]]:
         self.state = ConnectionState.ACTIVE
         self.stream_count += 1
 
@@ -38,7 +40,10 @@ class MockConnection(object):
             aiterator=aiterator(), aclose_func=on_close
         )
 
-        return 200, [], stream, {}
+        try:
+            yield 200, [], stream, {}
+        finally:
+            await stream.aclose()
 
     async def aclose(self):
         pass
@@ -64,13 +69,7 @@ class ConnectionPool(httpcore.AsyncConnectionPool):
 
 
 async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
-    try:
-        body = []
-        async for chunk in stream:
-            body.append(chunk)
-        return b"".join(body)
-    finally:
-        await stream.aclose()
+    return b"".join([chunk async for chunk in stream])
 
 
 @pytest.mark.trio
@@ -80,21 +79,25 @@ async def test_sequential_requests(http_version) -> None:
         info = await http.get_connection_info()
         assert info == {}
 
-        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+        async with http.arequest(
+            b"GET", (b"http", b"example.org", None, b"/")
+        ) as response:
+            status_code, headers, stream, ext = response
+            info = await http.get_connection_info()
+            assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+            await read_body(stream)
 
-        await read_body(stream)
         info = await http.get_connection_info()
         assert info == {"http://example.org": ["ConnectionState.IDLE"]}
 
-        response = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code, headers, stream, ext = response
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+        async with http.arequest(
+            b"GET", (b"http", b"example.org", None, b"/")
+        ) as response:
+            status_code, headers, stream, ext = response
+            info = await http.get_connection_info()
+            assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+            await read_body(stream)
 
-        await read_body(stream)
         info = await http.get_connection_info()
         assert info == {"http://example.org": ["ConnectionState.IDLE"]}
 
@@ -105,25 +108,36 @@ async def test_concurrent_requests_h11() -> None:
         info = await http.get_connection_info()
         assert info == {}
 
-        response_1 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code_1, headers_1, stream_1, ext_1 = response_1
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+        async with AsyncExitStack() as exit_stack2:
+            async with AsyncExitStack() as exit_stack1:
+                response_1 = await exit_stack1.enter_async_context(
+                    http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+                )
+                status_code_1, headers_1, stream_1, ext_1 = response_1
+                info = await http.get_connection_info()
+                assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
 
-        response_2 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code_2, headers_2, stream_2, ext_2 = response_2
-        info = await http.get_connection_info()
-        assert info == {
-            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.ACTIVE"]
-        }
+                response_2 = await exit_stack2.enter_async_context(
+                    http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+                )
+                status_code_2, headers_2, stream_2, ext_2 = response_2
+                info = await http.get_connection_info()
+                assert info == {
+                    "http://example.org": [
+                        "ConnectionState.ACTIVE",
+                        "ConnectionState.ACTIVE",
+                    ]
+                }
 
-        await read_body(stream_1)
-        info = await http.get_connection_info()
-        assert info == {
-            "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.IDLE"]
-        }
+                await read_body(stream_1)
 
-        await read_body(stream_2)
+            info = await http.get_connection_info()
+            assert info == {
+                "http://example.org": ["ConnectionState.ACTIVE", "ConnectionState.IDLE"]
+            }
+
+            await read_body(stream_2)
+
         info = await http.get_connection_info()
         assert info == {
             "http://example.org": ["ConnectionState.IDLE", "ConnectionState.IDLE"]
@@ -136,20 +150,29 @@ async def test_concurrent_requests_h2() -> None:
         info = await http.get_connection_info()
         assert info == {}
 
-        response_1 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code_1, headers_1, stream_1, ext_1 = response_1
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+        async with AsyncExitStack() as exit_stack2:
+            async with AsyncExitStack() as exit_stack1:
+                response_1 = await exit_stack1.enter_async_context(
+                    http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+                )
+                status_code_1, headers_1, stream_1, ext_1 = response_1
+                info = await http.get_connection_info()
+                assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
 
-        response_2 = await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
-        status_code_2, headers_2, stream_2, ext_2 = response_2
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+                response_2 = await exit_stack2.enter_async_context(
+                    http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
+                )
+                status_code_2, headers_2, stream_2, ext_2 = response_2
 
-        await read_body(stream_1)
-        info = await http.get_connection_info()
-        assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+                info = await http.get_connection_info()
+                assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
 
-        await read_body(stream_2)
+                await read_body(stream_1)
+
+            info = await http.get_connection_info()
+            assert info == {"http://example.org": ["ConnectionState.ACTIVE"]}
+
+            await read_body(stream_2)
+
         info = await http.get_connection_info()
         assert info == {"http://example.org": ["ConnectionState.IDLE"]}

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -36,14 +36,12 @@ class MockConnection(httpcore.AsyncHTTPTransport):
         async def aiterator() -> AsyncIterator[bytes]:
             yield b""
 
-        stream = httpcore.AsyncIteratorByteStream(
-            aiterator=aiterator(), aclose_func=on_close
-        )
+        stream = httpcore.AsyncIteratorByteStream(aiterator=aiterator())
 
         try:
             yield 200, [], stream, {}
         finally:
-            await stream.aclose()
+            await on_close()
 
     async def aclose(self):
         pass

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -483,7 +483,8 @@ async def test_cannot_connect_uds(backend: str) -> None:
     url = (b"http", b"localhost", None, b"/")
     async with httpcore.AsyncConnectionPool(backend=backend, uds=uds) as http:
         with pytest.raises(httpcore.ConnectError):
-            await http.arequest(method, url)
+            async with http.arequest(method, url):
+                pass  # pragma: no cover
 
 
 @pytest.mark.skipif(
@@ -501,7 +502,8 @@ async def test_connection_timeout_tcp(backend: str, server: Server) -> None:
 
     async with httpcore.AsyncConnectionPool(backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
-            await http.arequest(method, url, headers, ext=ext)
+            async with http.arequest(method, url, headers, ext=ext):
+                pass  # pragma: no cover
 
 
 @pytest.mark.skipif(
@@ -521,4 +523,5 @@ async def test_connection_timeout_uds(
 
     async with httpcore.AsyncConnectionPool(uds=uds, backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
-            await http.arequest(method, url, headers, ext=ext)
+            async with http.arequest(method, url, headers, ext=ext):
+                pass  # pragma: no cover

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,11 +1,11 @@
 import platform
 import ssl
-from contextlib import AsyncExitStack
 from functools import partial
 
 import pytest
 
 import httpcore
+from httpcore._compat import AsyncExitStack
 from httpcore._types import URL
 from tests.conftest import HTTPS_SERVER_URL, UvicornServer
 from tests.utils import Server, lookup_async_backend

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,5 +1,6 @@
 import platform
 from functools import partial
+from typing import AsyncIterable
 
 import pytest
 
@@ -15,7 +16,7 @@ def backend(request):
     return request.param
 
 
-async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
+async def read_body(stream: AsyncIterable[bytes]) -> bytes:
     return b"".join([chunk async for chunk in stream])
 
 

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import ssl
 from functools import partial
 
 import pytest

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -470,7 +470,7 @@ async def test_cannot_connect_tcp(backend: str, url) -> None:
         method = b"GET"
         with pytest.raises(httpcore.ConnectError):
             async with http.arequest(method, url) as _:
-                pass
+                pass  # pragma: no cover
 
 
 @pytest.mark.anyio

--- a/tests/async_tests/test_retries.py
+++ b/tests/async_tests/test_retries.py
@@ -58,11 +58,11 @@ async def test_no_retries(server: Server) -> None:
 
         with pytest.raises(httpcore.ConnectTimeout):
             async with http.arequest(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
         with pytest.raises(httpcore.ConnectError):
             async with http.arequest(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
 
 @pytest.mark.anyio
@@ -118,11 +118,11 @@ async def test_retries_enabled(server: Server) -> None:
         backend.push(httpcore.ReadTimeout(), httpcore.NetworkError())
         with pytest.raises(httpcore.ReadTimeout):
             async with http.arequest(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
         with pytest.raises(httpcore.NetworkError):
             async with http.arequest(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
 
 @pytest.mark.anyio
@@ -149,4 +149,4 @@ async def test_retries_exceeded(server: Server) -> None:
         backend.push(httpcore.ConnectError(), httpcore.ConnectTimeout())
         with pytest.raises(httpcore.ConnectTimeout):
             async with http.arequest(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover

--- a/tests/async_tests/test_retries.py
+++ b/tests/async_tests/test_retries.py
@@ -1,6 +1,6 @@
 import queue
 import time
-from typing import Any, List, Optional
+from typing import Any, AsyncIterable, List, Optional
 
 import pytest
 
@@ -32,7 +32,7 @@ class AsyncMockBackend(AutoBackend):
         return await super().open_tcp_stream(*args, **kwargs)
 
 
-async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
+async def read_body(stream: AsyncIterable[bytes]) -> bytes:
     return b"".join([chunk async for chunk in stream])
 
 

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Tuple
+from typing import Iterable, Iterator, Tuple
 
 import pytest
 
@@ -22,9 +22,9 @@ class MockConnection(httpcore.SyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: httpcore.SyncByteStream = None,
+        stream: Iterable[bytes] = None,
         ext: dict = None,
-    ) -> Iterator[Tuple[int, Headers, httpcore.SyncByteStream, dict]]:
+    ) -> Iterator[Tuple[int, Headers, Iterable[bytes], dict]]:
         self.state = ConnectionState.ACTIVE
         self.stream_count += 1
 
@@ -36,7 +36,7 @@ class MockConnection(httpcore.SyncHTTPTransport):
         def iterator() -> Iterator[bytes]:
             yield b""
 
-        stream = httpcore.IteratorByteStream(iterator=iterator())
+        stream = iterator()
 
         try:
             yield 200, [], stream, {}
@@ -66,7 +66,7 @@ class ConnectionPool(httpcore.SyncConnectionPool):
         return MockConnection(self.http_version)
 
 
-def read_body(stream: httpcore.SyncByteStream) -> bytes:
+def read_body(stream: Iterable[bytes]) -> bytes:
     return b"".join([chunk for chunk in stream])
 
 

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -36,14 +36,12 @@ class MockConnection(httpcore.SyncHTTPTransport):
         def iterator() -> Iterator[bytes]:
             yield b""
 
-        stream = httpcore.IteratorByteStream(
-            iterator=iterator(), close_func=on_close
-        )
+        stream = httpcore.IteratorByteStream(iterator=iterator())
 
         try:
             yield 200, [], stream, {}
         finally:
-            stream.close()
+            on_close()
 
     def close(self):
         pass

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -1,10 +1,10 @@
-from contextlib import ExitStack, contextmanager
 from typing import Iterator, Tuple
 
 import pytest
 
 import httpcore
 from httpcore._async.base import ConnectionState
+from httpcore._compat import ExitStack, contextmanager
 from httpcore._types import URL, Headers
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,6 @@
 import platform
 from functools import partial
+from typing import Iterable
 
 import pytest
 
@@ -15,7 +16,7 @@ def backend(request):
     return request.param
 
 
-def read_body(stream: httpcore.SyncByteStream) -> bytes:
+def read_body(stream: Iterable[bytes]) -> bytes:
     return b"".join([chunk for chunk in stream])
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -483,7 +483,8 @@ def test_cannot_connect_uds(backend: str) -> None:
     url = (b"http", b"localhost", None, b"/")
     with httpcore.SyncConnectionPool(backend=backend, uds=uds) as http:
         with pytest.raises(httpcore.ConnectError):
-            http.request(method, url)
+            with http.request(method, url):
+                pass  # pragma: no cover
 
 
 @pytest.mark.skipif(
@@ -501,7 +502,8 @@ def test_connection_timeout_tcp(backend: str, server: Server) -> None:
 
     with httpcore.SyncConnectionPool(backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
-            http.request(method, url, headers, ext=ext)
+            with http.request(method, url, headers, ext=ext):
+                pass  # pragma: no cover
 
 
 @pytest.mark.skipif(
@@ -521,4 +523,5 @@ def test_connection_timeout_uds(
 
     with httpcore.SyncConnectionPool(uds=uds, backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
-            http.request(method, url, headers, ext=ext)
+            with http.request(method, url, headers, ext=ext):
+                pass  # pragma: no cover

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,7 @@
 import platform
 import ssl
+from contextlib import ExitStack
+from functools import partial
 
 import pytest
 
@@ -15,13 +17,7 @@ def backend(request):
 
 
 def read_body(stream: httpcore.SyncByteStream) -> bytes:
-    try:
-        body = []
-        for chunk in stream:
-            body.append(chunk)
-        return b"".join(body)
-    finally:
-        stream.close()
+    return b"".join([chunk for chunk in stream])
 
 
 
@@ -30,8 +26,9 @@ def test_http_request(backend: str, server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -44,8 +41,9 @@ def test_https_request(backend: str, https_server: Server) -> None:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -59,7 +57,8 @@ def test_request_unsupported_protocol(backend: str) -> None:
         url = (b"ftp", b"example.org", 443, b"/")
         headers = [(b"host", b"example.org")]
         with pytest.raises(httpcore.UnsupportedProtocol):
-            http.request(method, url, headers)
+            with http.request(method, url, headers):
+                pass  # pragma: no cover
 
 
 
@@ -68,8 +67,9 @@ def test_http2_request(backend: str, https_server: Server) -> None:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/2"}
@@ -82,8 +82,9 @@ def test_closing_http_request(backend: str, server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header, (b"connection", b"close")]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -96,8 +97,9 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -106,8 +108,9 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -122,8 +125,9 @@ def test_https_request_reuse_connection(
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -132,8 +136,9 @@ def test_https_request_reuse_connection(
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -148,8 +153,9 @@ def test_http_request_cannot_reuse_dropped_connection(
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -162,8 +168,9 @@ def test_http_request_cannot_reuse_dropped_connection(
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -185,8 +192,9 @@ def test_http_proxy(
         max_connections=max_connections,
         backend=backend,
     ) as http:
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -203,8 +211,9 @@ def test_http_request_local_address(backend: str, server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
@@ -233,8 +242,9 @@ def test_proxy_https_requests(
         max_connections=max_connections,
         http2=http2,
     ) as http:
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        _ = read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            _ = read_body(stream)
 
         assert status_code == 200
         assert ext["http_version"] == "HTTP/2" if http2 else "HTTP/1.1"
@@ -286,15 +296,20 @@ def test_connection_pool_get_connection_info(
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
 
-        _, _, stream_1, _ = http.request(method, url, headers)
-        _, _, stream_2, _ = http.request(method, url, headers)
+        with ExitStack() as exit_stack:
+            _, _, stream_1, _ = exit_stack.enter_context(
+                http.request(method, url, headers)
+            )
+            _, _, stream_2, _ = exit_stack.enter_context(
+                http.request(method, url, headers)
+            )
 
-        try:
-            stats = http.get_connection_info()
-            assert stats == expected_during_active
-        finally:
-            read_body(stream_1)
-            read_body(stream_2)
+            try:
+                stats = http.get_connection_info()
+                assert stats == expected_during_active
+            finally:
+                read_body(stream_1)
+                read_body(stream_2)
 
         stats = http.get_connection_info()
         assert stats == expected_during_idle
@@ -317,11 +332,12 @@ def test_http_request_unix_domain_socket(
         method = b"GET"
         url = (b"http", b"localhost", None, b"/")
         headers = [(b"host", b"localhost")]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
-        body = read_body(stream)
-        assert body == b"Hello, world!"
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            assert status_code == 200
+            assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+            body = read_body(stream)
+            assert body == b"Hello, world!"
 
 
 @pytest.mark.parametrize("max_keepalive", [1, 3, 5])
@@ -337,19 +353,17 @@ def test_max_keepalive_connections_handled_correctly(
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
 
-        connections_streams = []
-        for _ in range(connections_number):
-            _, _, stream, _ = http.request(method, url, headers)
-            connections_streams.append(stream)
+        with ExitStack() as exit_stack:
+            for _ in range(connections_number):
+                _, _, stream, _ = exit_stack.enter_context(
+                    http.request(method, url, headers)
+                )
+                exit_stack.callback(partial(read_body, stream))
 
-        try:
-            for i in range(len(connections_streams)):
-                read_body(connections_streams[i])
-        finally:
-            stats = http.get_connection_info()
+        stats = http.get_connection_info()
 
-            connections_in_pool = next(iter(stats.values()))
-            assert len(connections_in_pool) == min(connections_number, max_keepalive)
+        connections_in_pool = next(iter(stats.values()))
+        assert len(connections_in_pool) == min(connections_number, max_keepalive)
 
 
 
@@ -358,8 +372,9 @@ def test_explicit_backend_name(server: Server) -> None:
         method = b"GET"
         url = (b"http", *server.netloc, b"/")
         headers = [server.host_header]
-        status_code, headers, stream, ext = http.request(method, url, headers)
-        read_body(stream)
+        with http.request(method, url, headers) as response:
+            status_code, headers, stream, ext = response
+            read_body(stream)
 
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -470,7 +470,7 @@ def test_cannot_connect_tcp(backend: str, url) -> None:
         method = b"GET"
         with pytest.raises(httpcore.ConnectError):
             with http.request(method, url) as _:
-                pass
+                pass  # pragma: no cover
 
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,11 +1,11 @@
 import platform
 import ssl
-from contextlib import ExitStack
 from functools import partial
 
 import pytest
 
 import httpcore
+from httpcore._compat import ExitStack
 from httpcore._types import URL
 from tests.conftest import HTTPS_SERVER_URL, UvicornServer
 from tests.utils import Server, lookup_sync_backend

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import ssl
 from functools import partial
 
 import pytest

--- a/tests/sync_tests/test_retries.py
+++ b/tests/sync_tests/test_retries.py
@@ -1,6 +1,6 @@
 import queue
 import time
-from typing import Any, List, Optional
+from typing import Any, Iterable, List, Optional
 
 import pytest
 
@@ -32,7 +32,7 @@ class SyncMockBackend(SyncBackend):
         return super().open_tcp_stream(*args, **kwargs)
 
 
-def read_body(stream: httpcore.SyncByteStream) -> bytes:
+def read_body(stream: Iterable[bytes]) -> bytes:
     return b"".join([chunk for chunk in stream])
 
 

--- a/tests/sync_tests/test_retries.py
+++ b/tests/sync_tests/test_retries.py
@@ -58,11 +58,11 @@ def test_no_retries(server: Server) -> None:
 
         with pytest.raises(httpcore.ConnectTimeout):
             with http.request(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
         with pytest.raises(httpcore.ConnectError):
             with http.request(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
 
 
@@ -118,11 +118,11 @@ def test_retries_enabled(server: Server) -> None:
         backend.push(httpcore.ReadTimeout(), httpcore.NetworkError())
         with pytest.raises(httpcore.ReadTimeout):
             with http.request(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
         with pytest.raises(httpcore.NetworkError):
             with http.request(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover
 
 
 
@@ -149,4 +149,4 @@ def test_retries_exceeded(server: Server) -> None:
         backend.push(httpcore.ConnectError(), httpcore.ConnectTimeout())
         with pytest.raises(httpcore.ConnectTimeout):
             with http.request(method, url, headers) as response:
-                pass
+                pass  # pragma: no cover

--- a/unasync.py
+++ b/unasync.py
@@ -6,6 +6,7 @@ import sys
 SUBS = [
     ('AsyncIteratorByteStream', 'IteratorByteStream'),
     ('AsyncIterator', 'Iterator'),
+    ('AsyncIterable', 'Iterable'),
     ('asynccontextmanager', 'contextmanager'),
     ('AsyncContextManager', 'ContextManager'),
     ('AsyncExitStack', 'ExitStack'),

--- a/unasync.py
+++ b/unasync.py
@@ -6,6 +6,11 @@ import sys
 SUBS = [
     ('AsyncIteratorByteStream', 'IteratorByteStream'),
     ('AsyncIterator', 'Iterator'),
+    ('asynccontextmanager', 'contextmanager'),
+    ('AsyncContextManager', 'ContextManager'),
+    ('AsyncExitStack', 'ExitStack'),
+    ('enter_async_context', 'enter_context'),
+    ('push_async_callback', 'callback'),
     ('AutoBackend', 'SyncBackend'),
     ('Async([A-Z][A-Za-z0-9_]*)', r'Sync\2'),
     ('async def', 'def'),

--- a/unasync.py
+++ b/unasync.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 SUBS = [
-    ('AsyncIteratorByteStream', 'IteratorByteStream'),
     ('AsyncIterator', 'Iterator'),
     ('AsyncIterable', 'Iterable'),
     ('asynccontextmanager', 'contextmanager'),


### PR DESCRIPTION
Closes #145 

**Note**: recommend reviewing with "Hide whitespace changes" turned on.

This PR introduces a breaking change to the transport API:

Before:

```python
async with Transport() as http:
    response = await http.request(...)
    ...
```

After:

```python
async with Transport() as http:
    async with http.request(...) as response:
        ...
```

From my point of view, motivation is two-fold:

- Move towards more strictly observing principles of structured concurrency. One of the main manifestations of this is preferring to rely on a `with` syntax block, rather than using e.g. wrapper classes that hold a `close` callback. This should make the transport API _more correct_ to use, meaning less chances to shoot oneself in the foot by forgetting a callback somewhere.
- Facilitate per-request holding of I/O state, making things like supporting streaming ASGI responses not only possible, but also very easy to implement. (See https://github.com/encode/httpx/pull/998)

There are trade-offs to consider on the user side of things:

- Callback-driven clients and APIs will have to interface with HTTPCore's preference for `with` blocks. This can be done _correctly_ and _reliably_ with the help of exit stacks, which convert the syntactical scope of a `with` block into a programmatic scope (via `.enter_context()` and `.close()`), but I'd reckon this could introduce friction.
- For HTTPX, embracing the `with` syntax seems like the most promising option: https://github.com/encode/httpx/pull/1355. (For the record, keeping its callback-driven nature was also attempted: https://github.com/encode/httpx/pull/1341.)