### PR TITLE
Add remove-all-unused-imports to autoflake invocation

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -8,7 +8,7 @@ export SOURCE_FILES="httpcore tests"
 
 set -x
 
-${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
+${PREFIX}autoflake --in-place --recursive --remove-all-unused-imports --ignore-init-module-imports $SOURCE_FILES
 ${PREFIX}isort --project=httpcore $SOURCE_FILES
 ${PREFIX}black $SOURCE_FILES
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,7 +8,7 @@ export SOURCE_FILES="httpcore tests"
 
 set -x
 
-${PREFIX}autoflake --in-place --recursive --remove-all-unused-imports --ignore-init-module-imports $SOURCE_FILES
+${PREFIX}autoflake --in-place --recursive --remove-all-unused-imports $SOURCE_FILES
 ${PREFIX}isort --project=httpcore $SOURCE_FILES
 ${PREFIX}black $SOURCE_FILES
 


### PR DESCRIPTION
`flake8` during `script/test` invocation raises an error if we have unused imports.

As `script/lint` already calls `autoflake`, we can add `--remove-all-unused-imports --ignore-init-module-imports` to the call, which might make development process easier