### PR TITLE
Preserve HTTP header casing

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -133,8 +133,17 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
             event = await self._receive_event(timeout)
             if isinstance(event, h11.Response):
                 break
+
         http_version = b"HTTP/" + event.http_version
-        return http_version, event.status_code, event.reason, event.headers
+
+        if hasattr(event.headers, "raw_items"):
+            # h11 version 0.11+ supports a `raw_items` interface to get the
+            # raw header casing, rather than the enforced lowercase headers.
+            headers = event.headers.raw_items()
+        else:
+            headers = event.headers
+
+        return http_version, event.status_code, event.reason, headers
 
     async def _receive_response_data(
         self, timeout: TimeoutDict

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -133,8 +133,17 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
             event = self._receive_event(timeout)
             if isinstance(event, h11.Response):
                 break
+
         http_version = b"HTTP/" + event.http_version
-        return http_version, event.status_code, event.reason, event.headers
+
+        if hasattr(event.headers, "raw_items"):
+            # h11 version 0.11+ supports a `raw_items` interface to get the
+            # raw header casing, rather than the enforced lowercase headers.
+            headers = event.headers.raw_items()
+        else:
+            headers = event.headers
+
+        return http_version, event.status_code, event.reason, headers
 
     def _receive_response_data(
         self, timeout: TimeoutDict

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11>=0.8,<0.11", "sniffio==1.*"],
+    install_requires=["h11==0.*", "sniffio==1.*"],
     extras_require={
         "http2": ["h2>=3,<5"],
     },


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/538

Update `h11` and expose raw HTTP header casing, rather than forced-lowercase.