### PR TITLE
Increase dependabot's schedule interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
+
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
As agreed in the comments of https://github.com/encode/httpcore/pull/212, switching to monthly updates to lower the noise.

Docs: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#scheduleinterval