### PR TITLE
Replacing pytest-cov by coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ wheel==0.35.1
 anyio==2.0.2
 autoflake==1.4
 black==20.8b1
+coverage==5.3
 flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pie==0.6.1
@@ -26,5 +27,4 @@ mypy==0.782
 pproxy==2.3.7
 pytest==6.1.1
 pytest-trio==0.6.0
-pytest-cov==2.10.1
 uvicorn==0.12.1

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
-${PREFIX}pytest $@
+${PREFIX}coverage run --debug config -m pytest
 
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/coverage

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
-${PREFIX}coverage run --debug config -m pytest
+${PREFIX}coverage run -m pytest
 
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,pytes
 skip = httpcore/_sync/,tests/sync_tests/
 
 [tool:pytest]
-addopts = --cov-report= --cov=httpcore --cov=tests -rxXs
+addopts = -rxXs
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
+
+[coverage:run]
+omit = venv/*
+include = httpcore/*, tests/*


### PR DESCRIPTION
After https://github.com/encode/uvicorn/pull/809 it would be great to introduce the same changes in `httpcore`

Pros:

1. `pytest-cov` makes work in IDE harder, suppressing breakpoints ([link](https://pytest-cov.readthedocs.io/en/latest/debuggers.html))
1. `pytest-cov` overwrites some `coverage` flags (probably to be compatible with other plugins e.g. `pytest-xdist`)

