### PR TITLE
100% cover connection_pool by tests

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,3 +1,4 @@
+import importlib.util
 import warnings
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple, cast
@@ -119,9 +120,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self._next_keepalive_check = 0.0
 
         if http2:
-            try:
-                import h2  # noqa: F401
-            except ImportError:
+            http2_spec = importlib.util.find_spec("h2")
+
+            if http2_spec is None:
                 raise ImportError(
                     "Attempted to use http2=True, but the 'h2' "
                     "package is not installed. Use 'pip install httpcore[http2]'."

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -255,7 +255,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         elif self._http2 and pending_connection is not None and not seen_http11:
             # If we have a PENDING connection, and no HTTP/1.1 connections
             # on this origin, then we can attempt to share the connection.
-            logger.trace("reusing pending connection=%r", connection)
+            logger.trace("reusing pending connection=%r", pending_connection)
             reuse_connection = pending_connection
 
         # Close any dropped connections.

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -255,7 +255,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         elif self._http2 and pending_connection is not None and not seen_http11:
             # If we have a PENDING connection, and no HTTP/1.1 connections
             # on this origin, then we can attempt to share the connection.
-            logger.trace("reusing pending connection=%r", connection)
+            logger.trace("reusing pending connection=%r", pending_connection)
             reuse_connection = pending_connection
 
         # Close any dropped connections.

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,3 +1,4 @@
+import importlib.util
 import warnings
 from ssl import SSLContext
 from typing import Iterator, Callable, Dict, List, Optional, Set, Tuple, cast
@@ -119,9 +120,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         self._next_keepalive_check = 0.0
 
         if http2:
-            try:
-                import h2  # noqa: F401
-            except ImportError:
+            http2_spec = importlib.util.find_spec("h2")
+
+            if http2_spec is None:
                 raise ImportError(
                     "Attempted to use http2=True, but the 'h2' "
                     "package is not installed. Use 'pip install httpcore[http2]'."

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=93
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=94 --precision=2

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=94 --precision=2
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=94

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -70,7 +70,7 @@ class AlwaysPendingConnection(MockConnection):
         return result
 
 
-class BrokenConnection(MockConnection):
+class RefusedConnection(MockConnection):
     async def arequest(
         self,
         method: bytes,
@@ -194,7 +194,7 @@ async def test_concurrent_requests_h2() -> None:
 @pytest.mark.trio
 async def test_connection_with_exception_has_been_removed_from_pool():
     async with ConnectionPool(
-        http_version="HTTP/2", connection_class=BrokenConnection
+        http_version="HTTP/2", connection_class=RefusedConnection
     ) as http:
         with pytest.raises(ConnectionRefusedError):
             await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
@@ -203,7 +203,7 @@ async def test_connection_with_exception_has_been_removed_from_pool():
 
 
 @pytest.mark.trio
-async def test_that_we_cannot_start_http2_connection_without_h2_lib():
+async def test_that_we_cannot_create_http2_connection_pool_without_h2_lib():
     with patch_callable(importlib.util, "find_spec", lambda _: None):
         with pytest.raises(ImportError):
             async with httpcore.AsyncConnectionPool(http2=True):

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,4 +1,5 @@
 from typing import AsyncIterator, Tuple, Type
+from unittest.mock import patch
 
 import pytest
 
@@ -181,3 +182,13 @@ async def test_connection_with_exception_has_been_removed_from_pool():
             await http.arequest(b"GET", (b"http", b"example.org", None, b"/"))
 
         assert len(await http.get_connection_info()) == 0
+
+
+@patch("importlib.util.find_spec", autospec=True)
+@pytest.mark.trio
+async def test_that_we_cannot_start_http2_connection_without_h2_lib(find_spec_mock):
+    find_spec_mock.return_value = None
+
+    with pytest.raises(ImportError):
+        async with httpcore.AsyncConnectionPool(http2=True):
+            pass

--- a/tests/async_tests/test_connection_pool.py
+++ b/tests/async_tests/test_connection_pool.py
@@ -1,11 +1,13 @@
+import importlib.util
 from typing import AsyncIterator, Tuple, Type
-from unittest.mock import patch
 
 import pytest
 
 import httpcore
+from httpcore import LocalProtocolError
 from httpcore._async.base import ConnectionState
-from httpcore._types import URL, Headers
+from httpcore._types import URL, Headers, Origin
+from tests.utils import Server, patch_callable
 
 
 class MockConnection(object):
@@ -200,14 +202,12 @@ async def test_connection_with_exception_has_been_removed_from_pool():
         assert len(await http.get_connection_info()) == 0
 
 
-@patch("importlib.util.find_spec", autospec=True)
 @pytest.mark.trio
-async def test_that_we_cannot_start_http2_connection_without_h2_lib(find_spec_mock):
-    find_spec_mock.return_value = None
-
-    with pytest.raises(ImportError):
-        async with httpcore.AsyncConnectionPool(http2=True):
-            pass
+async def test_that_we_cannot_start_http2_connection_without_h2_lib():
+    with patch_callable(importlib.util, "find_spec", lambda _: None):
+        with pytest.raises(ImportError):
+            async with httpcore.AsyncConnectionPool(http2=True):
+                pass
 
 
 @pytest.mark.trio
@@ -221,3 +221,44 @@ async def test_that_we_can_reuse_pending_http2_connection():
         info = await http.get_connection_info()
 
         assert info == {"http://example.org": ["ConnectionState.PENDING"]}
+
+
+@pytest.mark.trio
+async def test_that_we_cannot_request_url_without_host():
+    async with ConnectionPool(http_version="HTTP/2") as http:
+        with pytest.raises(LocalProtocolError):
+            await http.arequest(b"GET", (b"http", b"", None, b"/"))
+
+
+async def _new_conn_from_pool(Self: httpcore.AsyncConnectionPool, origin: Origin):
+    origin_callable = Self._origin__get_connection_from_pool  # type: ignore
+    result = await origin_callable(origin)
+
+    try:
+        return result
+    finally:
+        if result is not None:
+            await result.aclose()
+
+
+@pytest.mark.trio
+async def test_that_new_connection_is_created_when_its_required(
+    https_server: Server,
+):
+    method = b"GET"
+    url = (b"https", *https_server.netloc, b"/")
+
+    headers = [https_server.host_header]
+    async with httpcore.AsyncConnectionPool(http2=False) as http:
+        with patch_callable(
+            httpcore.AsyncConnectionPool,
+            "_get_connection_from_pool",
+            _new_conn_from_pool,
+        ):
+            _, _, stream, _ = await http.arequest(method, url, headers)
+
+            await read_body(stream)
+
+            _, _, stream, _ = await http.arequest(method, url, headers)
+
+            await read_body(stream)

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -363,7 +363,7 @@ async def test_explicit_backend_name(server: Server) -> None:
         assert len(http._connections[url[:3]]) == 1  # type: ignore
 
 
-@pytest.mark.trio
+@pytest.mark.anyio
 async def test_connection_pool_warns_but_accepts_max_keepalive(server: Server):
     max_keepalive_connections = 10
     method = b"GET"

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -70,7 +70,7 @@ class AlwaysPendingConnection(MockConnection):
         return result
 
 
-class BrokenConnection(MockConnection):
+class RefusedConnection(MockConnection):
     def request(
         self,
         method: bytes,
@@ -194,7 +194,7 @@ def test_concurrent_requests_h2() -> None:
 
 def test_connection_with_exception_has_been_removed_from_pool():
     with ConnectionPool(
-        http_version="HTTP/2", connection_class=BrokenConnection
+        http_version="HTTP/2", connection_class=RefusedConnection
     ) as http:
         with pytest.raises(ConnectionRefusedError):
             http.request(b"GET", (b"http", b"example.org", None, b"/"))
@@ -203,7 +203,7 @@ def test_connection_with_exception_has_been_removed_from_pool():
 
 
 
-def test_that_we_cannot_start_http2_connection_without_h2_lib():
+def test_that_we_cannot_create_http2_connection_pool_without_h2_lib():
     with patch_callable(importlib.util, "find_spec", lambda _: None):
         with pytest.raises(ImportError):
             with httpcore.SyncConnectionPool(http2=True):

--- a/tests/sync_tests/test_connection_pool.py
+++ b/tests/sync_tests/test_connection_pool.py
@@ -1,4 +1,5 @@
 from typing import Iterator, Tuple, Type
+from unittest.mock import patch
 
 import pytest
 
@@ -181,3 +182,13 @@ def test_connection_with_exception_has_been_removed_from_pool():
             http.request(b"GET", (b"http", b"example.org", None, b"/"))
 
         assert len(http.get_connection_info()) == 0
+
+
+@patch("importlib.util.find_spec", autospec=True)
+
+def test_that_we_cannot_start_http2_connection_without_h2_lib(find_spec_mock):
+    find_spec_mock.return_value = None
+
+    with pytest.raises(ImportError):
+        with httpcore.SyncConnectionPool(http2=True):
+            pass

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -361,3 +361,30 @@ def test_explicit_backend_name(server: Server) -> None:
         assert status_code == 200
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
         assert len(http._connections[url[:3]]) == 1  # type: ignore
+
+
+
+def test_connection_pool_warns_but_accepts_max_keepalive(server: Server):
+    max_keepalive_connections = 10
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+
+    with pytest.warns(DeprecationWarning):
+        with httpcore.SyncConnectionPool(
+            max_keepalive=max_keepalive_connections, keepalive_expiry=60
+        ) as http:
+
+            connections_streams = []
+            for _ in range(max_keepalive_connections + 1):
+                _, _, stream, _ = http.request(method, url, headers)
+                connections_streams.append(stream)
+
+            try:
+                for i in range(len(connections_streams)):
+                    read_body(connections_streams[i])
+            finally:
+                stats = http.get_connection_info()
+
+                connections_in_pool = next(iter(stats.values()))
+                assert len(connections_in_pool) == max_keepalive_connections

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,16 +58,3 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
     finally:
         if proc is not None:
             proc.kill()
-
-
-@contextlib.contextmanager
-def patch_callable(klass, method, replacement):
-    origin = getattr(klass, method)
-
-    try:
-        setattr(klass, method, replacement)
-        setattr(klass, f"_origin_{method}", origin)
-        yield
-    finally:
-        setattr(klass, method, origin)
-        delattr(klass, f"_origin_{method}")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,3 +58,16 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
     finally:
         if proc is not None:
             proc.kill()
+
+
+@contextlib.contextmanager
+def patch_callable(klass, method, replacement):
+    origin = getattr(klass, method)
+
+    try:
+        setattr(klass, method, replacement)
+        setattr(klass, f"_origin_{method}", origin)
+        yield
+    finally:
+        setattr(klass, method, origin)
+        delattr(klass, f"_origin_{method}")


### PR DESCRIPTION
There is a task to cover `httpcore` by tests (https://github.com/encode/httpcore/issues/13), so that I tried to cover `connection_pool.py` by the tests.

The PR ramps up coverage to 94% 

Adding new tests, I have to change 2 place in the code (checking if `h2` exists and one tracing message)

_Some tests might look odd, so that any remarks are welcome!_