### PR TITLE
Add connect retries

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -2,8 +2,9 @@ from ssl import SSLContext
 from typing import Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
+from .._exceptions import ConnectError, ConnectTimeout
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger, url_to_origin
+from .._utils import exponential_backoff, get_logger, url_to_origin
 from .base import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -13,6 +14,8 @@ from .base import (
 from .http import AsyncBaseHTTPConnection
 
 logger = get_logger(__name__)
+
+RETRIES_BACKOFF_FACTOR = 0.5  # 0s, 0.5s, 1s, 2s, 4s, etc.
 
 
 class AsyncHTTPConnection(AsyncHTTPTransport):
@@ -24,6 +27,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         ssl_context: SSLContext = None,
         socket: AsyncSocketStream = None,
         local_address: str = None,
+        retries: int = 0,
         backend: AsyncBackend = None,
     ):
         self.origin = origin
@@ -32,6 +36,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
         self.local_address = local_address
+        self.retries = retries
 
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
@@ -103,22 +108,34 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
-        try:
-            if self.uds is None:
-                return await self.backend.open_tcp_stream(
-                    hostname,
-                    port,
-                    ssl_context,
-                    timeout,
-                    local_address=self.local_address,
-                )
-            else:
-                return await self.backend.open_uds_stream(
-                    self.uds, hostname, ssl_context, timeout
-                )
-        except Exception:  # noqa: PIE786
-            self.connect_failed = True
-            raise
+
+        retries_left = self.retries
+        delays = exponential_backoff(factor=RETRIES_BACKOFF_FACTOR)
+
+        while True:
+            try:
+                if self.uds is None:
+                    return await self.backend.open_tcp_stream(
+                        hostname,
+                        port,
+                        ssl_context,
+                        timeout,
+                        local_address=self.local_address,
+                    )
+                else:
+                    return await self.backend.open_uds_stream(
+                        self.uds, hostname, ssl_context, timeout
+                    )
+            except (ConnectError, ConnectTimeout):
+                if retries_left <= 0:
+                    self.connect_failed = True
+                    raise
+                retries_left -= 1
+                delay = next(delays)
+                await self.backend.sleep(delay)
+            except Exception:  # noqa: PIE786
+                self.connect_failed = True
+                raise
 
     def _create_connection(self, socket: AsyncSocketStream) -> None:
         http_version = socket.get_http_version()

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,8 +1,18 @@
 import warnings
 from ssl import SSLContext
-from typing import AsyncIterator, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import (
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
-from .._backends.auto import AsyncLock, AsyncSemaphore
+from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore
 from .._backends.base import lookup_async_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
 from .._threadlock import ThreadLock
@@ -84,6 +94,8 @@ class AsyncConnectionPool(AsyncHTTPTransport):
     `local_address="0.0.0.0"` will connect using an `AF_INET` address (IPv4),
     while using `local_address="::"` will connect using an `AF_INET6` address
     (IPv6).
+    * **retries** - `int` - The maximum number of retries when trying to establish a
+    connection.
     * **backend** - `str` - A name indicating which concurrency backend to use.
     """
 
@@ -96,8 +108,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         http2: bool = False,
         uds: str = None,
         local_address: str = None,
+        retries: int = 0,
         max_keepalive: int = None,
-        backend: str = "auto",
+        backend: Union[AsyncBackend, str] = "auto",
     ):
         if max_keepalive is not None:
             warnings.warn(
@@ -106,6 +119,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             )
             max_keepalive_connections = max_keepalive
 
+        if isinstance(backend, str):
+            backend = lookup_async_backend(backend)
+
         self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
@@ -113,9 +129,10 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         self._http2 = http2
         self._uds = uds
         self._local_address = local_address
+        self._retries = retries
         self._connections: Dict[Origin, Set[AsyncHTTPConnection]] = {}
         self._thread_lock = ThreadLock()
-        self._backend = lookup_async_backend(backend)
+        self._backend = backend
         self._next_keepalive_check = 0.0
 
         if http2:
@@ -157,6 +174,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             uds=self._uds,
             ssl_context=self._ssl_context,
             local_address=self._local_address,
+            retries=self._retries,
             backend=self._backend,
         )
 

--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -192,3 +192,6 @@ class AnyIOBackend(AsyncBackend):
 
     async def time(self) -> float:
         return await anyio.current_time()
+
+    async def sleep(self, seconds: float) -> None:
+        await anyio.sleep(seconds)

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -282,3 +282,6 @@ class AsyncioBackend(AsyncBackend):
     async def time(self) -> float:
         loop = asyncio.get_event_loop()
         return loop.time()
+
+    async def sleep(self, seconds: float) -> None:
+        await asyncio.sleep(seconds)

--- a/httpcore/_backends/auto.py
+++ b/httpcore/_backends/auto.py
@@ -62,3 +62,6 @@ class AutoBackend(AsyncBackend):
 
     async def time(self) -> float:
         return await self.backend.time()
+
+    async def sleep(self, seconds: float) -> None:
+        await self.backend.sleep(seconds)

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -132,3 +132,6 @@ class AsyncBackend:
 
     async def time(self) -> float:
         raise NotImplementedError()  # pragma: no cover
+
+    async def sleep(self, seconds: float) -> None:
+        raise NotImplementedError()  # pragma: no cover

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -204,3 +204,6 @@ class CurioBackend(AsyncBackend):
 
     async def time(self) -> float:
         return await curio.clock()
+
+    async def sleep(self, seconds: float) -> None:
+        await curio.sleep(seconds)

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -173,3 +173,6 @@ class SyncBackend:
 
     def time(self) -> float:
         return time.monotonic()
+
+    def sleep(self, seconds: float) -> None:
+        time.sleep(seconds)

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -200,3 +200,6 @@ class TrioBackend(AsyncBackend):
 
     async def time(self) -> float:
         return trio.current_time()
+
+    async def sleep(self, seconds: float) -> None:
+        await trio.sleep(seconds)

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -2,8 +2,9 @@ from ssl import SSLContext
 from typing import Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
+from .._exceptions import ConnectError, ConnectTimeout
 from .._types import URL, Headers, Origin, TimeoutDict
-from .._utils import get_logger, url_to_origin
+from .._utils import exponential_backoff, get_logger, url_to_origin
 from .base import (
     SyncByteStream,
     SyncHTTPTransport,
@@ -13,6 +14,8 @@ from .base import (
 from .http import SyncBaseHTTPConnection
 
 logger = get_logger(__name__)
+
+RETRIES_BACKOFF_FACTOR = 0.5  # 0s, 0.5s, 1s, 2s, 4s, etc.
 
 
 class SyncHTTPConnection(SyncHTTPTransport):
@@ -24,6 +27,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         ssl_context: SSLContext = None,
         socket: SyncSocketStream = None,
         local_address: str = None,
+        retries: int = 0,
         backend: SyncBackend = None,
     ):
         self.origin = origin
@@ -32,6 +36,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
         self.local_address = local_address
+        self.retries = retries
 
         if self.http2:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
@@ -103,22 +108,34 @@ class SyncHTTPConnection(SyncHTTPTransport):
         scheme, hostname, port = self.origin
         timeout = {} if timeout is None else timeout
         ssl_context = self.ssl_context if scheme == b"https" else None
-        try:
-            if self.uds is None:
-                return self.backend.open_tcp_stream(
-                    hostname,
-                    port,
-                    ssl_context,
-                    timeout,
-                    local_address=self.local_address,
-                )
-            else:
-                return self.backend.open_uds_stream(
-                    self.uds, hostname, ssl_context, timeout
-                )
-        except Exception:  # noqa: PIE786
-            self.connect_failed = True
-            raise
+
+        retries_left = self.retries
+        delays = exponential_backoff(factor=RETRIES_BACKOFF_FACTOR)
+
+        while True:
+            try:
+                if self.uds is None:
+                    return self.backend.open_tcp_stream(
+                        hostname,
+                        port,
+                        ssl_context,
+                        timeout,
+                        local_address=self.local_address,
+                    )
+                else:
+                    return self.backend.open_uds_stream(
+                        self.uds, hostname, ssl_context, timeout
+                    )
+            except (ConnectError, ConnectTimeout):
+                if retries_left <= 0:
+                    self.connect_failed = True
+                    raise
+                retries_left -= 1
+                delay = next(delays)
+                self.backend.sleep(delay)
+            except Exception:  # noqa: PIE786
+                self.connect_failed = True
+                raise
 
     def _create_connection(self, socket: SyncSocketStream) -> None:
         http_version = socket.get_http_version()

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os
 import sys
@@ -63,3 +64,9 @@ def origin_to_url_string(origin: Origin) -> str:
     scheme, host, explicit_port = origin
     port = f":{explicit_port}" if explicit_port != DEFAULT_PORTS[scheme] else ""
     return f"{scheme.decode('ascii')}://{host.decode('ascii')}{port}"
+
+
+def exponential_backoff(factor: float) -> typing.Iterator[float]:
+    yield 0
+    for n in itertools.count(2):
+        yield factor * (2 ** (n - 2))

--- a/tests/async_tests/test_retries.py
+++ b/tests/async_tests/test_retries.py
@@ -34,10 +34,7 @@ class AsyncMockBackend(AutoBackend):
 
 async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
     try:
-        body = []
-        async for chunk in stream:
-            body.append(chunk)
-        return b"".join(body)
+        return b"".join([chunk async for chunk in stream])
     finally:
         await stream.aclose()
 

--- a/tests/async_tests/test_retries.py
+++ b/tests/async_tests/test_retries.py
@@ -1,0 +1,152 @@
+import queue
+import time
+from typing import Any, List, Optional
+
+import pytest
+
+import httpcore
+from httpcore._backends.auto import AsyncSocketStream, AutoBackend
+from tests.utils import Server
+
+
+class AsyncMockBackend(AutoBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self._exceptions: queue.Queue[Optional[Exception]] = queue.Queue()
+        self._timestamps: List[float] = []
+
+    def push(self, *exceptions: Optional[Exception]) -> None:
+        for exc in exceptions:
+            self._exceptions.put(exc)
+
+    def pop_open_tcp_stream_intervals(self) -> list:
+        intervals = [b - a for a, b in zip(self._timestamps, self._timestamps[1:])]
+        self._timestamps.clear()
+        return intervals
+
+    async def open_tcp_stream(self, *args: Any, **kwargs: Any) -> AsyncSocketStream:
+        self._timestamps.append(time.time())
+        exc = None if self._exceptions.empty() else self._exceptions.get_nowait()
+        if exc is not None:
+            raise exc
+        return await super().open_tcp_stream(*args, **kwargs)
+
+
+async def read_body(stream: httpcore.AsyncByteStream) -> bytes:
+    try:
+        body = []
+        async for chunk in stream:
+            body.append(chunk)
+        return b"".join(body)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_no_retries(server: Server) -> None:
+    """
+    By default, connection failures are not retried on.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = AsyncMockBackend()
+
+    async with httpcore.AsyncConnectionPool(
+        max_keepalive_connections=0, backend=backend
+    ) as http:
+        response = await http.arequest(method, url, headers)
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        await read_body(stream)
+
+        backend.push(httpcore.ConnectTimeout(), httpcore.ConnectError())
+
+        with pytest.raises(httpcore.ConnectTimeout):
+            await http.arequest(method, url, headers)
+
+        with pytest.raises(httpcore.ConnectError):
+            await http.arequest(method, url, headers)
+
+
+@pytest.mark.anyio
+async def test_retries_enabled(server: Server) -> None:
+    """
+    When retries are enabled, connection failures are retried on with
+    a fixed exponential backoff.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = AsyncMockBackend()
+    retries = 10  # Large enough to not run out of retries within this test.
+
+    async with httpcore.AsyncConnectionPool(
+        retries=retries, max_keepalive_connections=0, backend=backend
+    ) as http:
+        # Standard case, no failures.
+        response = await http.arequest(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == []
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        await read_body(stream)
+
+        # One failure, then success.
+        backend.push(httpcore.ConnectError(), None)
+        response = await http.arequest(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == [
+            pytest.approx(0, abs=1e-3),  # Retry immediately.
+        ]
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        await read_body(stream)
+
+        # Three failures, then success.
+        backend.push(
+            httpcore.ConnectError(),
+            httpcore.ConnectTimeout(),
+            httpcore.ConnectTimeout(),
+            None,
+        )
+        response = await http.arequest(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == [
+            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0.5, rel=0.1),  # First backoff.
+            pytest.approx(1.0, rel=0.1),  # Second (increased) backoff.
+        ]
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        await read_body(stream)
+
+        # Non-connect exceptions are not retried on.
+        backend.push(httpcore.ReadTimeout(), httpcore.NetworkError())
+        with pytest.raises(httpcore.ReadTimeout):
+            await http.arequest(method, url, headers)
+        with pytest.raises(httpcore.NetworkError):
+            await http.arequest(method, url, headers)
+
+
+@pytest.mark.anyio
+async def test_retries_exceeded(server: Server) -> None:
+    """
+    When retries are enabled and connecting failures more than the configured number
+    of retries, connect exceptions are raised.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = AsyncMockBackend()
+    retries = 1
+
+    async with httpcore.AsyncConnectionPool(
+        retries=retries, max_keepalive_connections=0, backend=backend
+    ) as http:
+        response = await http.arequest(method, url, headers)
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        await read_body(stream)
+
+        # First failure is retried on, second one isn't.
+        backend.push(httpcore.ConnectError(), httpcore.ConnectTimeout())
+        with pytest.raises(httpcore.ConnectTimeout):
+            await http.arequest(method, url, headers)

--- a/tests/sync_tests/test_retries.py
+++ b/tests/sync_tests/test_retries.py
@@ -34,10 +34,7 @@ class SyncMockBackend(SyncBackend):
 
 def read_body(stream: httpcore.SyncByteStream) -> bytes:
     try:
-        body = []
-        for chunk in stream:
-            body.append(chunk)
-        return b"".join(body)
+        return b"".join([chunk for chunk in stream])
     finally:
         stream.close()
 

--- a/tests/sync_tests/test_retries.py
+++ b/tests/sync_tests/test_retries.py
@@ -1,0 +1,152 @@
+import queue
+import time
+from typing import Any, List, Optional
+
+import pytest
+
+import httpcore
+from httpcore._backends.sync import SyncSocketStream, SyncBackend
+from tests.utils import Server
+
+
+class SyncMockBackend(SyncBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self._exceptions: queue.Queue[Optional[Exception]] = queue.Queue()
+        self._timestamps: List[float] = []
+
+    def push(self, *exceptions: Optional[Exception]) -> None:
+        for exc in exceptions:
+            self._exceptions.put(exc)
+
+    def pop_open_tcp_stream_intervals(self) -> list:
+        intervals = [b - a for a, b in zip(self._timestamps, self._timestamps[1:])]
+        self._timestamps.clear()
+        return intervals
+
+    def open_tcp_stream(self, *args: Any, **kwargs: Any) -> SyncSocketStream:
+        self._timestamps.append(time.time())
+        exc = None if self._exceptions.empty() else self._exceptions.get_nowait()
+        if exc is not None:
+            raise exc
+        return super().open_tcp_stream(*args, **kwargs)
+
+
+def read_body(stream: httpcore.SyncByteStream) -> bytes:
+    try:
+        body = []
+        for chunk in stream:
+            body.append(chunk)
+        return b"".join(body)
+    finally:
+        stream.close()
+
+
+
+def test_no_retries(server: Server) -> None:
+    """
+    By default, connection failures are not retried on.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = SyncMockBackend()
+
+    with httpcore.SyncConnectionPool(
+        max_keepalive_connections=0, backend=backend
+    ) as http:
+        response = http.request(method, url, headers)
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        read_body(stream)
+
+        backend.push(httpcore.ConnectTimeout(), httpcore.ConnectError())
+
+        with pytest.raises(httpcore.ConnectTimeout):
+            http.request(method, url, headers)
+
+        with pytest.raises(httpcore.ConnectError):
+            http.request(method, url, headers)
+
+
+
+def test_retries_enabled(server: Server) -> None:
+    """
+    When retries are enabled, connection failures are retried on with
+    a fixed exponential backoff.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = SyncMockBackend()
+    retries = 10  # Large enough to not run out of retries within this test.
+
+    with httpcore.SyncConnectionPool(
+        retries=retries, max_keepalive_connections=0, backend=backend
+    ) as http:
+        # Standard case, no failures.
+        response = http.request(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == []
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        read_body(stream)
+
+        # One failure, then success.
+        backend.push(httpcore.ConnectError(), None)
+        response = http.request(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == [
+            pytest.approx(0, abs=1e-3),  # Retry immediately.
+        ]
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        read_body(stream)
+
+        # Three failures, then success.
+        backend.push(
+            httpcore.ConnectError(),
+            httpcore.ConnectTimeout(),
+            httpcore.ConnectTimeout(),
+            None,
+        )
+        response = http.request(method, url, headers)
+        assert backend.pop_open_tcp_stream_intervals() == [
+            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0.5, rel=0.1),  # First backoff.
+            pytest.approx(1.0, rel=0.1),  # Second (increased) backoff.
+        ]
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        read_body(stream)
+
+        # Non-connect exceptions are not retried on.
+        backend.push(httpcore.ReadTimeout(), httpcore.NetworkError())
+        with pytest.raises(httpcore.ReadTimeout):
+            http.request(method, url, headers)
+        with pytest.raises(httpcore.NetworkError):
+            http.request(method, url, headers)
+
+
+
+def test_retries_exceeded(server: Server) -> None:
+    """
+    When retries are enabled and connecting failures more than the configured number
+    of retries, connect exceptions are raised.
+    """
+    method = b"GET"
+    url = (b"http", *server.netloc, b"/")
+    headers = [server.host_header]
+    backend = SyncMockBackend()
+    retries = 1
+
+    with httpcore.SyncConnectionPool(
+        retries=retries, max_keepalive_connections=0, backend=backend
+    ) as http:
+        response = http.request(method, url, headers)
+        status_code, _, stream, _ = response
+        assert status_code == 200
+        read_body(stream)
+
+        # First failure is retried on, second one isn't.
+        backend.push(httpcore.ConnectError(), httpcore.ConnectTimeout())
+        with pytest.raises(httpcore.ConnectTimeout):
+            http.request(method, url, headers)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import itertools
+from typing import List
+
+import pytest
+
+from httpcore._utils import exponential_backoff
+
+
+@pytest.mark.parametrize(
+    "factor, expected",
+    [
+        (0.1, [0, 0.1, 0.2, 0.4, 0.8]),
+        (0.2, [0, 0.2, 0.4, 0.8, 1.6]),
+        (0.5, [0, 0.5, 1.0, 2.0, 4.0]),
+    ],
+)
+def test_exponential_backoff(factor: float, expected: List[int]) -> None:
+    delays = list(itertools.islice(exponential_backoff(factor), 5))
+    assert delays == expected


### PR DESCRIPTION
Alternative to https://github.com/encode/httpx/pull/1196, prompted by https://github.com/encode/httpx/pull/1196#issuecomment-690148589

Closes https://github.com/encode/httpx/issues/1141

This PR adds off-by-default "retry on connection failure" capability to the connection pool, using a `retries=<int>` option. Also includes an exponential backoff mechanism, with a fixed backoff factor of 0.5 for now (so, 0s, 0.5s, 1.0s, 2.0s, 4.0s, etc).

We add it at the transport layer, as close to opening sockets as possible, so that connect retries don't interact with the connection pooling logic, so that we do "acquire a connection, open a socket, open a socket, …, release the connection".

(We're in a better position now to add this feature now, because we have a `backend` option on the connection pool transport. This PR tweaks it a bit so we can pass a full-fledged backend instance, rather than only a backend name. Then we build and provide a mock backend that raises exception on-demand, for testing purposes.)

(The diff looks quite big, but everything is unasynced, so duplicated, and test code is a bit large too, so…)

Once merged, we'll be able to document this on the HTTPX side, in a new "Retries" section in "Advanced Usage". For now usage will be a bit involved, but once `httpx.HTTPTransport()` lands (https://github.com/encode/httpx/issues/1302) things will be easier UX-wise.