### PR TITLE
Fixed the problem with socket, which might leak when tunnel proxy connection couldn't be establish

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -237,21 +237,21 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 # We assume the target speaks TLS on the specified port
                 if scheme == b"https":
                     await proxy_connection.start_tls(host, timeout)
-
-                # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
-                # This means the proxy connection is now unusable, and we must create
-                # a new one for regular requests, making sure to use the same socket to
-                # retain the tunnel.
-                connection = AsyncHTTPConnection(
-                    origin=origin,
-                    http2=self._http2,
-                    ssl_context=self._ssl_context,
-                    socket=proxy_connection.socket,
-                )
-                await self._add_to_pool(connection, timeout)
             except Exception as exc:
                 await proxy_connection.aclose()
                 raise ProxyError(exc)
+
+            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+            # This means the proxy connection is now unusable, and we must create
+            # a new one for regular requests, making sure to use the same socket to
+            # retain the tunnel.
+            connection = AsyncHTTPConnection(
+                origin=origin,
+                http2=self._http2,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            await self._add_to_pool(connection, timeout)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -207,41 +207,51 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             connect_url = self.proxy_origin + (target,)
             connect_headers = [(b"Host", target), (b"Accept", b"*/*")]
             connect_headers = merge_headers(connect_headers, self.proxy_headers)
-            (proxy_status_code, _, proxy_stream, _) = await proxy_connection.arequest(
-                b"CONNECT", connect_url, headers=connect_headers, ext=ext
-            )
 
-            proxy_reason = get_reason_phrase(proxy_status_code)
-            logger.trace(
-                "tunnel_response proxy_status_code=%r proxy_reason=%r ",
-                proxy_status_code,
-                proxy_reason,
-            )
-            # Read the response data without closing the socket
-            async for _ in proxy_stream:
-                pass
+            try:
+                (
+                    proxy_status_code,
+                    _,
+                    proxy_stream,
+                    _,
+                ) = await proxy_connection.arequest(
+                    b"CONNECT", connect_url, headers=connect_headers, ext=ext
+                )
 
-            # See if the tunnel was successfully established.
-            if proxy_status_code < 200 or proxy_status_code > 299:
-                msg = "%d %s" % (proxy_status_code, proxy_reason)
-                raise ProxyError(msg)
+                proxy_reason = get_reason_phrase(proxy_status_code)
+                logger.trace(
+                    "tunnel_response proxy_status_code=%r proxy_reason=%r ",
+                    proxy_status_code,
+                    proxy_reason,
+                )
+                # Read the response data without closing the socket
+                async for _ in proxy_stream:
+                    pass
 
-            # Upgrade to TLS if required
-            # We assume the target speaks TLS on the specified port
-            if scheme == b"https":
-                await proxy_connection.start_tls(host, timeout)
+                # See if the tunnel was successfully established.
+                if proxy_status_code < 200 or proxy_status_code > 299:
+                    msg = "%d %s" % (proxy_status_code, proxy_reason)
+                    raise ProxyError(msg)
 
-            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
-            # This means the proxy connection is now unusable, and we must create
-            # a new one for regular requests, making sure to use the same socket to
-            # retain the tunnel.
-            connection = AsyncHTTPConnection(
-                origin=origin,
-                http2=self._http2,
-                ssl_context=self._ssl_context,
-                socket=proxy_connection.socket,
-            )
-            await self._add_to_pool(connection, timeout)
+                # Upgrade to TLS if required
+                # We assume the target speaks TLS on the specified port
+                if scheme == b"https":
+                    await proxy_connection.start_tls(host, timeout)
+
+                # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+                # This means the proxy connection is now unusable, and we must create
+                # a new one for regular requests, making sure to use the same socket to
+                # retain the tunnel.
+                connection = AsyncHTTPConnection(
+                    origin=origin,
+                    http2=self._http2,
+                    ssl_context=self._ssl_context,
+                    socket=proxy_connection.socket,
+                )
+                await self._add_to_pool(connection, timeout)
+            except Exception:
+                await proxy_connection.aclose()
+                raise
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -249,9 +249,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                     socket=proxy_connection.socket,
                 )
                 await self._add_to_pool(connection, timeout)
-            except Exception:
+            except Exception as exc:
                 await proxy_connection.aclose()
-                raise
+                raise ProxyError(exc)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -237,21 +237,21 @@ class SyncHTTPProxy(SyncConnectionPool):
                 # We assume the target speaks TLS on the specified port
                 if scheme == b"https":
                     proxy_connection.start_tls(host, timeout)
-
-                # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
-                # This means the proxy connection is now unusable, and we must create
-                # a new one for regular requests, making sure to use the same socket to
-                # retain the tunnel.
-                connection = SyncHTTPConnection(
-                    origin=origin,
-                    http2=self._http2,
-                    ssl_context=self._ssl_context,
-                    socket=proxy_connection.socket,
-                )
-                self._add_to_pool(connection, timeout)
             except Exception as exc:
                 proxy_connection.close()
                 raise ProxyError(exc)
+
+            # The CONNECT request is successful, so we have now SWITCHED PROTOCOLS.
+            # This means the proxy connection is now unusable, and we must create
+            # a new one for regular requests, making sure to use the same socket to
+            # retain the tunnel.
+            connection = SyncHTTPConnection(
+                origin=origin,
+                http2=self._http2,
+                ssl_context=self._ssl_context,
+                socket=proxy_connection.socket,
+            )
+            self._add_to_pool(connection, timeout)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -249,9 +249,9 @@ class SyncHTTPProxy(SyncConnectionPool):
                     socket=proxy_connection.socket,
                 )
                 self._add_to_pool(connection, timeout)
-            except Exception:
+            except Exception as exc:
                 proxy_connection.close()
-                raise
+                raise ProxyError(exc)
 
         # Once the connection has been established we can send requests on
         # it as normal.

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -210,7 +210,7 @@ async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_t
             for _ in range(100):
                 try:
                     _ = await http.arequest(method, url, headers)
-                except httpcore.RemoteProtocolError:
+                except (httpcore.ProxyError, httpcore.RemoteProtocolError):
                     pass
 
     # have to filter out https://github.com/encode/httpx/issues/825 from other tests

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -214,11 +214,11 @@ async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_t
                     pass
 
     # have to filter out https://github.com/encode/httpx/issues/825 from other tests
-    warnings_list = [
+    warnings = [
         *filter(lambda warn: "asyncio" not in warn.filename, recorded_warnings.list)
     ]
 
-    assert len(warnings_list) == 0
+    assert len(warnings) == 0
 
 
 @pytest.mark.anyio

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -202,8 +202,8 @@ async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_t
     port: int,
 ):
     method = b"GET"
-    url = (protocol, b"example.com", port, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (protocol, b"blockedhost.example.com", port, b"/")
+    headers = [(b"host", b"blockedhost.example.com")]
 
     with pytest.warns(None) as recorded_warnings:
         async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -202,8 +202,8 @@ def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool
     port: int,
 ):
     method = b"GET"
-    url = (protocol, b"example.com", port, b"/")
-    headers = [(b"host", b"example.org")]
+    url = (protocol, b"blockedhost.example.com", port, b"/")
+    headers = [(b"host", b"blockedhost.example.com")]
 
     with pytest.warns(None) as recorded_warnings:
         with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -191,6 +191,36 @@ def test_http_proxy(
         assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
 
 
+@pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
+@pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
+
+def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(
+    proxy_server: URL,
+    server: Server,
+    proxy_mode: str,
+    protocol: bytes,
+    port: int,
+):
+    method = b"GET"
+    url = (protocol, b"example.com", port, b"/")
+    headers = [(b"host", b"example.org")]
+
+    with pytest.warns(None) as recorded_warnings:
+        with httpcore.SyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
+            for _ in range(100):
+                try:
+                    _ = http.request(method, url, headers)
+                except httpcore.RemoteProtocolError:
+                    pass
+
+    # have to filter out https://github.com/encode/httpx/issues/825 from other tests
+    warnings_list = [
+        *filter(lambda warn: "asyncio" not in warn.filename, recorded_warnings.list)
+    ]
+
+    assert len(warnings_list) == 0
+
+
 
 def test_http_request_local_address(backend: str, server: Server) -> None:
     if backend == "sync" and lookup_sync_backend() == "trio":

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -214,11 +214,11 @@ def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool
                     pass
 
     # have to filter out https://github.com/encode/httpx/issues/825 from other tests
-    warnings_list = [
+    warnings = [
         *filter(lambda warn: "asyncio" not in warn.filename, recorded_warnings.list)
     ]
 
-    assert len(warnings_list) == 0
+    assert len(warnings) == 0
 
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -210,7 +210,7 @@ def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool
             for _ in range(100):
                 try:
                     _ = http.request(method, url, headers)
-                except httpcore.RemoteProtocolError:
+                except (httpcore.ProxyError, httpcore.RemoteProtocolError):
                     pass
 
     # have to filter out https://github.com/encode/httpx/issues/825 from other tests

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,9 @@
 import contextlib
 import socket
 import subprocess
+import tempfile
 import time
-from typing import Tuple
+from typing import List, Tuple
 
 import sniffio
 
@@ -48,13 +49,34 @@ class Server:
 def http_proxy_server(proxy_host: str, proxy_port: int):
 
     proc = None
-    try:
-        command = ["pproxy", "-l", f"http://{proxy_host}:{proxy_port}/"]
-        proc = subprocess.Popen(command)
 
-        _wait_can_connect(proxy_host, proxy_port)
+    with create_proxy_block_file(["example.com"]) as block_file_name:
+        try:
+            command = [
+                "pproxy",
+                "-b",
+                block_file_name,
+                "-l",
+                f"http://{proxy_host}:{proxy_port}/",
+            ]
+            proc = subprocess.Popen(command)
 
-        yield b"http", proxy_host.encode(), proxy_port, b"/"
-    finally:
-        if proc is not None:
-            proc.kill()
+            _wait_can_connect(proxy_host, proxy_port)
+
+            yield b"http", proxy_host.encode(), proxy_port, b"/"
+        finally:
+            if proc is not None:
+                proc.kill()
+
+
+@contextlib.contextmanager
+def create_proxy_block_file(blocked_domains: List[str]):
+    with tempfile.NamedTemporaryFile(delete=True, mode="w+") as file:
+
+        for domain in blocked_domains:
+            file.write(domain)
+            file.write("\n")
+
+        file.flush()
+
+        yield file.name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,10 +47,19 @@ class Server:
 
 @contextlib.contextmanager
 def http_proxy_server(proxy_host: str, proxy_port: int):
+    """
+    This function launches pproxy process like this:
+    $ pproxy -b <blocked_hosts_file> -l http://127.0.0.1:8080
+    What does it mean?
+    It runs HTTP proxy on 127.0.0.1:8080 and blocks access to some external hosts,
+        specified in blocked_hosts_file
 
+    Relevant pproxy docs could be found in their github repo:
+        https://github.com/qwj/python-proxy
+    """
     proc = None
 
-    with create_proxy_block_file(["example.com"]) as block_file_name:
+    with create_proxy_block_file(["blockedhost.example.com"]) as block_file_name:
         try:
             command = [
                 "pproxy",
@@ -71,6 +80,11 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
 
 @contextlib.contextmanager
 def create_proxy_block_file(blocked_domains: List[str]):
+    """
+    The context manager yields pproxy block file.
+    This file should contain line delimited hostnames. We use it in the following test:
+        test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool
+    """
     with tempfile.NamedTemporaryFile(delete=True, mode="w+") as file:
 
         for domain in blocked_domains:


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/issues/1360

I extracted a tunnel proxy connection establishing into the separated method, and wrapped it by `try`-`except` statement, closing the `proxy_connection` if it's necessary.

Also I added the unit test and a test fixture from https://github.com/encode/httpx/issues/1360 comments