### PR TITLE
Properly wrap OS errors when using trio

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -1,4 +1,3 @@
-import socket
 from ssl import SSLContext
 from typing import Optional
 
@@ -139,7 +138,6 @@ class AnyIOBackend(AsyncBackend):
         unicode_host = hostname.decode("utf-8")
         exc_map = {
             OSError: ConnectError,
-            socket.gaierror: ConnectError,
             TimeoutError: ConnectTimeout,
             BrokenResourceError: ConnectError,
         }

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -1,4 +1,3 @@
-import socket
 from ssl import SSLContext, SSLSocket
 from typing import Optional
 
@@ -181,7 +180,6 @@ class CurioBackend(AsyncBackend):
             curio.TaskTimeout: ConnectTimeout,
             curio.CurioError: ConnectError,
             OSError: ConnectError,
-            socket.gaierror: ConnectError,
         }
         host = hostname.decode("ascii")
         kwargs = (

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -1,3 +1,4 @@
+import socket
 from ssl import SSLContext, SSLSocket
 from typing import Optional
 
@@ -180,6 +181,7 @@ class CurioBackend(AsyncBackend):
             curio.TaskTimeout: ConnectTimeout,
             curio.CurioError: ConnectError,
             OSError: ConnectError,
+            socket.gaierror: ConnectError,
         }
         host = hostname.decode("ascii")
         kwargs = (

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -1,3 +1,4 @@
+import socket
 from ssl import SSLContext
 from typing import Optional
 
@@ -145,6 +146,8 @@ class TrioBackend(AsyncBackend):
         #  argument has been passed.
         kwargs: dict = {} if local_address is None else {"local_address": local_address}
         exc_map = {
+            OSError: ConnectError,
+            socket.gaierror: ConnectError,
             trio.TooSlowError: ConnectTimeout,
             trio.BrokenResourceError: ConnectError,
         }
@@ -172,6 +175,7 @@ class TrioBackend(AsyncBackend):
     ) -> AsyncSocketStream:
         connect_timeout = none_as_inf(timeout.get("connect"))
         exc_map = {
+            OSError: ConnectError,
             trio.TooSlowError: ConnectTimeout,
             trio.BrokenResourceError: ConnectError,
         }

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -1,4 +1,3 @@
-import socket
 from ssl import SSLContext
 from typing import Optional
 
@@ -147,7 +146,6 @@ class TrioBackend(AsyncBackend):
         kwargs: dict = {} if local_address is None else {"local_address": local_address}
         exc_map = {
             OSError: ConnectError,
-            socket.gaierror: ConnectError,
             trio.TooSlowError: ConnectTimeout,
             trio.BrokenResourceError: ConnectError,
         }

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -396,7 +396,7 @@ async def test_broken_socket_detection_many_open_files(
 @pytest.mark.parametrize(
     "url",
     [
-        pytest.param((b"http", b"localhost", 123456, b"/"), id="connection-refused"),
+        pytest.param((b"http", b"localhost", 12345, b"/"), id="connection-refused"),
         pytest.param(
             (b"http", b"doesnotexistatall.org", None, b"/"), id="dns-resolution-failed"
         ),

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -398,7 +398,7 @@ async def test_broken_socket_detection_many_open_files(
     [
         pytest.param((b"http", b"localhost", 123456, b"/"), id="connection-refused"),
         pytest.param(
-            (b"http", b"doesnotexistatall.org", None, b"/"), id="nodename-not-found"
+            (b"http", b"doesnotexistatall.org", None, b"/"), id="dns-resolution-failed"
         ),
     ],
 )

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -396,7 +396,7 @@ def test_broken_socket_detection_many_open_files(
 @pytest.mark.parametrize(
     "url",
     [
-        pytest.param((b"http", b"localhost", 123456, b"/"), id="connection-refused"),
+        pytest.param((b"http", b"localhost", 12345, b"/"), id="connection-refused"),
         pytest.param(
             (b"http", b"doesnotexistatall.org", None, b"/"), id="dns-resolution-failed"
         ),

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -398,7 +398,7 @@ def test_broken_socket_detection_many_open_files(
     [
         pytest.param((b"http", b"localhost", 123456, b"/"), id="connection-refused"),
         pytest.param(
-            (b"http", b"doesnotexistatall.org", None, b"/"), id="nodename-not-found"
+            (b"http", b"doesnotexistatall.org", None, b"/"), id="dns-resolution-failed"
         ),
     ],
 )

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -390,3 +390,36 @@ def test_broken_socket_detection_many_open_files(
             assert status_code == 200
             assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
             assert len(http._connections[url[:3]]) == 1  # type: ignore
+
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param((b"http", b"localhost", 123456, b"/"), id="connection-refused"),
+        pytest.param(
+            (b"http", b"doesnotexistatall.org", None, b"/"), id="nodename-not-found"
+        ),
+    ],
+)
+def test_cannot_connect_tcp(backend: str, url) -> None:
+    """
+    A properly wrapped error is raised when connecting to the server fails.
+    """
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        method = b"GET"
+        with pytest.raises(httpcore.ConnectError):
+            http.request(method, url)
+
+
+
+def test_cannot_connect_uds(backend: str) -> None:
+    """
+    A properly wrapped error is raised when connecting to the UDS server fails.
+    """
+    uds = "/tmp/doesnotexist.sock"
+    method = b"GET"
+    url = (b"http", b"localhost", None, b"/")
+    with httpcore.SyncConnectionPool(backend=backend, uds=uds) as http:
+        with pytest.raises(httpcore.ConnectError):
+            http.request(method, url)


### PR DESCRIPTION
Closes #224 

The problem in #224 turns out to hit`trio` / `anyio+trio` for both TCP and UDS.

We were not properly mapping `OSError` in those places, and this PR fixes that, adding regression tests to our test suite to make sure the proper behavior applies everywhere.