### PR TITLE
Version 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.12.1 (November 4th, 2020)
+
+### Added
+
+- Add connect retries. (Pull #221)
+
+### Fixed
+
+- Tweak detection of dropped connections, resolving an issue with open files limits on Linux. (Pull #185)
+- Avoid leaking connections when establishing an HTTP tunnel to a proxy has failed. (Pull #223)
+- Properly wrap OS errors when using `trio`. (Pull #225)
+
 ## 0.12.0 (October 6th, 2020)
 
 ### Changed

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
     "WriteError",
     "WriteTimeout",
 ]
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __locals = locals()
 


### PR DESCRIPTION
Figured the connect retries addition wasn't warranting a minor bump (HTTPX is pinned to `httpcore==0.12.*`), and there's precedent to that (eg when we added UDS support back), but happy to reconsider.

---

## 0.12.1 (November 4th, 2020)

### Added

- Add connect retries. (Pull #221)

### Fixed

- Tweak detection of dropped connections, resolving an issue with open files limits on Linux. (Pull #185)
- Avoid leaking connections when establishing an HTTP tunnel to a proxy has failed. (Pull #223)
- Properly wrap OS errors when using `trio`. (Pull #225)
