### PR TITLE
Use Hypercorn for UDS tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ pproxy==2.3.7
 pytest==6.1.2
 pytest-trio==0.7.0
 trustme==0.6.0
-uvicorn==0.12.1
+uvicorn==0.12.1; python_version < '3.7'

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -4,7 +4,7 @@ import pytest
 
 import httpcore
 from httpcore._types import URL
-from tests.conftest import HTTPS_SERVER_URL, UvicornServer
+from tests.conftest import HTTPS_SERVER_URL
 from tests.utils import Server, lookup_sync_backend
 
 
@@ -347,17 +347,17 @@ def test_connection_pool_get_connection_info(
 )
 
 def test_http_request_unix_domain_socket(
-    uds_server: UvicornServer, backend: str
+    uds_server: Server, backend: str
 ) -> None:
-    uds = uds_server.config.uds
-    assert uds is not None
+    uds = uds_server.uds
     with httpcore.SyncConnectionPool(uds=uds, backend=backend) as http:
         method = b"GET"
         url = (b"http", b"localhost", None, b"/")
         headers = [(b"host", b"localhost")]
         status_code, headers, stream, ext = http.request(method, url, headers)
         assert status_code == 200
-        assert ext == {"http_version": "HTTP/1.1", "reason": "OK"}
+        reason = "OK" if uds_server.sends_reason else ""
+        assert ext == {"http_version": "HTTP/1.1", "reason": reason}
         body = read_body(stream)
         assert body == b"Hello, world!"
 


### PR DESCRIPTION
Follow-up to #205

Use `hypercorn` for UDS tests. Had to refactor `HypercornServer` a bit to remove the `host/port` options, and use `bind` in all cases.

We can't ditch `uvicorn` entirely because `hypercorn` is 3.7+ only, so we only install and use `uvicorn` on 3.6.

The great part here is that we now use the `Server` interface across all tests.