### PR TITLE
Fix flaky test

### DIFF
--- a/tests/async_tests/test_retries.py
+++ b/tests/async_tests/test_retries.py
@@ -92,7 +92,7 @@ async def test_retries_enabled(server: Server) -> None:
         backend.push(httpcore.ConnectError(), None)
         response = await http.arequest(method, url, headers)
         assert backend.pop_open_tcp_stream_intervals() == [
-            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0, abs=5e-3),  # Retry immediately.
         ]
         status_code, _, stream, _ = response
         assert status_code == 200
@@ -107,7 +107,7 @@ async def test_retries_enabled(server: Server) -> None:
         )
         response = await http.arequest(method, url, headers)
         assert backend.pop_open_tcp_stream_intervals() == [
-            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0, abs=5e-3),  # Retry immediately.
             pytest.approx(0.5, rel=0.1),  # First backoff.
             pytest.approx(1.0, rel=0.1),  # Second (increased) backoff.
         ]

--- a/tests/sync_tests/test_retries.py
+++ b/tests/sync_tests/test_retries.py
@@ -92,7 +92,7 @@ def test_retries_enabled(server: Server) -> None:
         backend.push(httpcore.ConnectError(), None)
         response = http.request(method, url, headers)
         assert backend.pop_open_tcp_stream_intervals() == [
-            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0, abs=5e-3),  # Retry immediately.
         ]
         status_code, _, stream, _ = response
         assert status_code == 200
@@ -107,7 +107,7 @@ def test_retries_enabled(server: Server) -> None:
         )
         response = http.request(method, url, headers)
         assert backend.pop_open_tcp_stream_intervals() == [
-            pytest.approx(0, abs=1e-3),  # Retry immediately.
+            pytest.approx(0, abs=5e-3),  # Retry immediately.
             pytest.approx(0.5, rel=0.1),  # First backoff.
             pytest.approx(1.0, rel=0.1),  # Second (increased) backoff.
         ]


### PR DESCRIPTION
Prompted by https://github.com/encode/httpcore/pull/233#issuecomment-723445718

It's _probably_ due to Hypercorn (#205), that may be a tiny bit slower, and so this is most likely affecting master too.
