### PR TITLE
Fix connect timeouts for anyio backend

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -137,8 +137,8 @@ class AnyIOBackend(AsyncBackend):
         connect_timeout = timeout.get("connect")
         unicode_host = hostname.decode("utf-8")
         exc_map = {
-            OSError: ConnectError,
             TimeoutError: ConnectTimeout,
+            OSError: ConnectError,
             BrokenResourceError: ConnectError,
         }
 
@@ -168,8 +168,8 @@ class AnyIOBackend(AsyncBackend):
         connect_timeout = timeout.get("connect")
         unicode_host = hostname.decode("utf-8")
         exc_map = {
-            OSError: ConnectError,
             TimeoutError: ConnectTimeout,
+            OSError: ConnectError,
             BrokenResourceError: ConnectError,
         }
 

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 import pytest
 
@@ -466,3 +467,41 @@ async def test_cannot_connect_uds(backend: str) -> None:
     async with httpcore.AsyncConnectionPool(backend=backend, uds=uds) as http:
         with pytest.raises(httpcore.ConnectError):
             await http.arequest(method, url)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
+)
+@pytest.mark.anyio
+async def test_connection_timeout_tcp(backend: str, server: Server) -> None:
+    # we try to access http server using https. It caused some SSL timeouts
+    # in TLSStream.wrap inside inside AnyIOBackend.open_tcp_stream
+    method = b"GET"
+    url = (b"https", *server.netloc, b"/")
+    headers = [server.host_header]
+    ext = {"timeout": {"connect": 0.1}}
+
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+        with pytest.raises(httpcore.ConnectTimeout):
+            await http.arequest(method, url, headers, ext=ext)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
+)
+@pytest.mark.anyio
+async def test_connection_timeout_uds(
+    backend: str, uds_server: Server, uds: str
+) -> None:
+    # we try to access http server using https. It caused some SSL timeouts
+    # in TLSStream.wrap inside AnyIOBackend.open_uds_stream
+    method = b"GET"
+    url = (b"https", b"localhost", None, b"/")
+    headers = [(b"host", b"localhost")]
+    ext = {"timeout": {"connect": 0.1}}
+
+    async with httpcore.AsyncConnectionPool(uds=uds, backend=backend) as http:
+        with pytest.raises(httpcore.ConnectTimeout):
+            await http.arequest(method, url, headers, ext=ext)

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 import pytest
 
@@ -466,3 +467,41 @@ def test_cannot_connect_uds(backend: str) -> None:
     with httpcore.SyncConnectionPool(backend=backend, uds=uds) as http:
         with pytest.raises(httpcore.ConnectError):
             http.request(method, url)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
+)
+
+def test_connection_timeout_tcp(backend: str, server: Server) -> None:
+    # we try to access http server using https. It caused some SSL timeouts
+    # in TLSStream.wrap inside inside AnyIOBackend.open_tcp_stream
+    method = b"GET"
+    url = (b"https", *server.netloc, b"/")
+    headers = [server.host_header]
+    ext = {"timeout": {"connect": 0.1}}
+
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        with pytest.raises(httpcore.ConnectTimeout):
+            http.request(method, url, headers, ext=ext)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
+)
+
+def test_connection_timeout_uds(
+    backend: str, uds_server: Server, uds: str
+) -> None:
+    # we try to access http server using https. It caused some SSL timeouts
+    # in TLSStream.wrap inside AnyIOBackend.open_uds_stream
+    method = b"GET"
+    url = (b"https", b"localhost", None, b"/")
+    headers = [(b"host", b"localhost")]
+    ext = {"timeout": {"connect": 0.1}}
+
+    with httpcore.SyncConnectionPool(uds=uds, backend=backend) as http:
+        with pytest.raises(httpcore.ConnectTimeout):
+            http.request(method, url, headers, ext=ext)


### PR DESCRIPTION
### Why to add changes
In https://github.com/encode/httpx/issues/1387#issuecomment-726775441 I found that `anyio` backend has problem with connection timeouts [here](https://github.com/encode/httpcore/blob/db81ed09592bac8ce740b3be74cf99c86a68c104/httpcore/_backends/anyio.py#L170-L186):

```python
        exc_map = {
            OSError: ConnectError,
            TimeoutError: ConnectTimeout,
            BrokenResourceError: ConnectError,
        }

        with map_exceptions(exc_map):
            async with anyio.fail_after(connect_timeout):
                stream: anyio.abc.ByteStream
                stream = await anyio.connect_tcp(
                    unicode_host, port, local_host=local_address
                )
                if ssl_context:
                    stream = await TLSStream.wrap(
                        stream,
                        hostname=unicode_host,
                        ssl_context=ssl_context,
                        standard_compatible=False,
                    )

```

As `assert isinstance(TimeoutError(), OSError)`, the above `map_exceptions` throws `ConnectError` in case of any timeout (at least in `await TLSStream.wrap`)

### What has been done
I added 2 tests (`test_connection_timeout_tcp` and `test_connection_timeout_uds`) and fixed the error

#### Note

`test_connection_timeout_uds` has been marked as `python >= 3.7` to reduce changeset footprint in the `slow_uds_server` fixture (otherwise there should be a fallback Uvicorn server)