### PR TITLE
Fix import of HTTP/1.1 connection causing thread-safety bug on 3.9

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -12,6 +12,7 @@ from .base import (
     NewConnectionRequired,
 )
 from .http import AsyncBaseHTTPConnection
+from .http11 import AsyncHTTP11Connection
 
 logger = get_logger(__name__)
 
@@ -150,8 +151,6 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
                 socket=socket, backend=self.backend, ssl_context=self.ssl_context
             )
         else:
-            from .http11 import AsyncHTTP11Connection
-
             self.is_http11 = True
             self.connection = AsyncHTTP11Connection(
                 socket=socket, ssl_context=self.ssl_context

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -12,6 +12,7 @@ from .base import (
     NewConnectionRequired,
 )
 from .http import SyncBaseHTTPConnection
+from .http11 import SyncHTTP11Connection
 
 logger = get_logger(__name__)
 
@@ -150,8 +151,6 @@ class SyncHTTPConnection(SyncHTTPTransport):
                 socket=socket, backend=self.backend, ssl_context=self.ssl_context
             )
         else:
-            from .http11 import SyncHTTP11Connection
-
             self.is_http11 = True
             self.connection = SyncHTTP11Connection(
                 socket=socket, ssl_context=self.ssl_context

--- a/tests/test_threadsafety.py
+++ b/tests/test_threadsafety.py
@@ -1,0 +1,46 @@
+import concurrent.futures
+
+import pytest
+
+import httpcore
+
+from .utils import Server
+
+
+def read_body(stream: httpcore.SyncByteStream) -> bytes:
+    try:
+        return b"".join(chunk for chunk in stream)
+    finally:
+        stream.close()
+
+
+@pytest.mark.parametrize(
+    "http2", [pytest.param(False, id="h11"), pytest.param(True, id="h2")]
+)
+def test_threadsafe_basic(server: Server, http2: bool) -> None:
+    """
+    The sync connection pool can be made to perform requests concurrently using
+    threads.
+
+    Also a regression test for: https://github.com/encode/httpx/issues/1393
+    """
+    with httpcore.SyncConnectionPool(http2=http2) as http:
+
+        def request(http: httpcore.SyncHTTPTransport) -> int:
+            method = b"GET"
+            url = (b"http", *server.netloc, b"/")
+            headers = [server.host_header]
+            status_code, headers, stream, ext = http.request(method, url, headers)
+            read_body(stream)
+            return status_code
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(request, http) for _ in range(10)]
+            num_results = 0
+
+            for future in concurrent.futures.as_completed(futures):
+                status_code = future.result()
+                assert status_code == 200
+                num_results += 1
+
+            assert num_results == 10

--- a/tests/test_threadsafety.py
+++ b/tests/test_threadsafety.py
@@ -19,7 +19,7 @@ def read_body(stream: httpcore.SyncByteStream) -> bytes:
 )
 def test_threadsafe_basic(server: Server, http2: bool) -> None:
     """
-    The sync connection pool can be made to perform requests concurrently using
+    The sync connection pool can be used to perform requests concurrently using
     threads.
 
     Also a regression test for: https://github.com/encode/httpx/issues/1393


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/issues/1393

Moves the local import of the HTTP/1.1 connection class to a global one. It wasn't necessary (`h11` is always installed), and it's a non-threadsafe trick which started causing `ImportError` on Python 3.9 (that it worked in 3.8 and before was actually considered as a bug: https://bugs.python.org/issue35943).

Also adds a basic test case to verify that `httpcore.SyncConnectionPool` can indeed be used in thread-concurrent environments.

Local testing showed that this is not a problem for `h2`, so keeping that local import as-is for now.

cc @Senpos