### PR TITLE
Fix SocketStream.is_readable()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,6 @@ mypy==0.790
 pproxy==2.3.7
 pytest==6.1.2
 pytest-trio==0.7.0
+pytest-asyncio==0.14.0
 trustme==0.6.0
 uvicorn==0.12.1; python_version < '3.7'

--- a/tests/backend_tests/test_asyncio.py
+++ b/tests/backend_tests/test_asyncio.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from httpcore._backends.asyncio import SocketStream
+
+
+class TestSocketStream:
+    class TestIsReadable:
+        @pytest.mark.asyncio
+        async def test_returns_true_when_transport_has_no_socket(self):
+            stream_reader = MagicMock()
+            stream_reader._transport.get_extra_info.return_value = None
+            sock_stream = SocketStream(stream_reader, MagicMock())
+
+            assert sock_stream.is_readable()
+
+        @pytest.mark.asyncio
+        async def test_returns_true_when_socket_is_readable(self):
+            stream_reader = MagicMock()
+            stream_reader._transport.get_extra_info.return_value = MagicMock()
+            sock_stream = SocketStream(stream_reader, MagicMock())
+
+            with patch(
+                "httpcore._utils.is_socket_readable", MagicMock(return_value=True)
+            ):
+                assert sock_stream.is_readable()


### PR DESCRIPTION
transport.get_extra_info('socket') may return None when connection is dropped.
This commit makes sure we expect such case.
Also, that means socket is readable so that the stream user would be notified/awaken and act accordingly.

Fixes https://github.com/encode/httpcore/issues/239