### PR TITLE
Fix asyncio SSL warning when using proxy tunneling

### DIFF
--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -120,7 +120,7 @@ class SocketStream(AsyncSocketStream):
                 timeout=timeout.get("connect"),
             )
 
-        # Initialize the protocol, so the reader is made aware of being tied to
+        # Initialize the protocol, so it is made aware of being tied to
         # a TLS connection.
         # See: https://github.com/encode/httpx/issues/859
         protocol.connection_made(transport)

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -120,7 +120,11 @@ class SocketStream(AsyncSocketStream):
                 timeout=timeout.get("connect"),
             )
 
-        stream_reader.set_transport(transport)
+        # Initialize the protocol, so the reader is made aware of being tied to
+        # a TLS connection.
+        # See: https://github.com/encode/httpx/issues/859
+        protocol.connection_made(transport)
+
         stream_writer = asyncio.StreamWriter(
             transport=transport, protocol=protocol, reader=stream_reader, loop=loop
         )


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/859

Turns out we need to call `protocol.connection_made()`. It calls `stream_reader.set_transport(...)`, as well as a bunch of other stuff, _including_ marking the reader as being "over SSL", which fixes the warning saw in the issue.

See https://github.com/encode/httpx/issues/859#issuecomment-740004212 for the detailed analysis.