### PR TITLE
Skip CONNECT when making HTTPS requests through an HTTPS proxy

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -188,8 +188,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         timeout = cast(TimeoutDict, ext.get("timeout", {}))
         origin = url_to_origin(url)
         connection = await self._get_connection_from_pool(origin)
+        proxy_scheme, _, _ = self.proxy_origin
 
-        if connection is None:
+        if connection is None and proxy_scheme == b"http":
             scheme, host, port = origin
 
             # First, create a connection to the proxy server
@@ -250,6 +251,16 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 http2=self._http2,
                 ssl_context=self._ssl_context,
                 socket=proxy_connection.socket,
+            )
+            await self._add_to_pool(connection, timeout)
+        elif connection is None:
+            # HTTPS requests issued through an HTTPS proxy don't need proxying
+            # at all. Send them through directly.
+            assert proxy_scheme == b"https"
+            connection = AsyncHTTPConnection(
+                origin=origin,
+                http2=self._http2,
+                ssl_context=self._ssl_context,
             )
             await self._add_to_pool(connection, timeout)
 


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/1424

_Not sure_ about this, so happy to take any reviews / proof-thinking.

When an HTTP proxy is used, if a request to an HTTPS server is made then we issue a CONNECT to the proxy to establish a tunnel, then upgrade to TLS. This is standard, and fine.

However if using an HTTPS proxy, then the TCP connection returned by CONNECT will be a TLS connection between the client and the proxy. Right now we still attempt to do `.start_tls()` on top of it, which fails, obviously.

From investigation, it seems that instead of "re-upgrading" to TLS, `curl` drops the proxy connection at this point and proceeds to requesting the HTTPS server directly, while Requests doesn't even bother and does the HTTPS request directly, without a CONNECT request. (Both assumptions need confirming through source code, but that's the behavior I'm guessing from investigation and observations in https://github.com/encode/httpx/issues/1424.)

This PR switches HTTPCore to doing to same thing as Requests. The net result is that everything is as before, except any HTTPS proxy is ignored when making HTTPS requests. (If using an HTTP proxy then we still do `.start_tls()`.)

TODO: tests:

* [ ] Update `pproxy` test setup so it listens on an HTTPS port as well.
* [ ] Add `test_https_proxy_http_request()` and `test_https_proxy_https_request()`.