### PR TITLE
Enable SSL verification by default

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
@@ -25,7 +25,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         origin: Origin,
         http2: bool = False,
         uds: str = None,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
         socket: AsyncSocketStream = None,
         local_address: str = None,
         retries: int = 0,
@@ -34,12 +34,14 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self.origin = origin
         self.http2 = http2
         self.uds = uds
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self.local_address = local_address
         self.retries = retries
 
-        if self.http2:
+        if self.http2 and self.ssl_context is not None:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
         self.connection: Optional[AsyncBaseHTTPConnection] = None

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,5 +1,5 @@
+import ssl
 import warnings
-from ssl import SSLContext
 from typing import (
     AsyncIterator,
     Callable,
@@ -101,7 +101,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
 
     def __init__(
         self,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
         max_connections: int = None,
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
@@ -122,7 +122,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_async_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import AsyncIterator, List, Tuple, Union, cast
 
 import h11
@@ -26,9 +26,11 @@ logger = get_logger(__name__)
 class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
     READ_NUM_BYTES = 64 * 1024
 
-    def __init__(self, socket: AsyncSocketStream, ssl_context: SSLContext = None):
+    def __init__(self, socket: AsyncSocketStream, ssl_context: ssl.SSLContext = None):
         self.socket = socket
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
 
         self.h11_state = h11.Connection(our_role=h11.CLIENT)
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import AsyncIterator, Dict, List, Tuple, cast
 
 import h2.connection
@@ -26,10 +26,12 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         self,
         socket: AsyncSocketStream,
         backend: AsyncBackend,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
     ):
         self.socket = socket
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
 
         self.backend = backend
         self.h2_state = h2.connection.H2Connection(config=self.CONFIG)

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
@@ -25,7 +25,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         origin: Origin,
         http2: bool = False,
         uds: str = None,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
         socket: SyncSocketStream = None,
         local_address: str = None,
         retries: int = 0,
@@ -34,12 +34,14 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self.origin = origin
         self.http2 = http2
         self.uds = uds
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self.local_address = local_address
         self.retries = retries
 
-        if self.http2:
+        if self.http2 and self.ssl_context is not None:
             self.ssl_context.set_alpn_protocols(["http/1.1", "h2"])
 
         self.connection: Optional[SyncBaseHTTPConnection] = None

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,5 +1,5 @@
+import ssl
 import warnings
-from ssl import SSLContext
 from typing import (
     Iterator,
     Callable,
@@ -101,7 +101,7 @@ class SyncConnectionPool(SyncHTTPTransport):
 
     def __init__(
         self,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
         max_connections: int = None,
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
@@ -122,7 +122,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_sync_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import Iterator, List, Tuple, Union, cast
 
 import h11
@@ -26,9 +26,11 @@ logger = get_logger(__name__)
 class SyncHTTP11Connection(SyncBaseHTTPConnection):
     READ_NUM_BYTES = 64 * 1024
 
-    def __init__(self, socket: SyncSocketStream, ssl_context: SSLContext = None):
+    def __init__(self, socket: SyncSocketStream, ssl_context: ssl.SSLContext = None):
         self.socket = socket
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
 
         self.h11_state = h11.Connection(our_role=h11.CLIENT)
 

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+import ssl
 from typing import Iterator, Dict, List, Tuple, cast
 
 import h2.connection
@@ -26,10 +26,12 @@ class SyncHTTP2Connection(SyncBaseHTTPConnection):
         self,
         socket: SyncSocketStream,
         backend: SyncBackend,
-        ssl_context: SSLContext = None,
+        ssl_context: ssl.SSLContext = None,
     ):
         self.socket = socket
-        self.ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self.ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
 
         self.backend = backend
         self.h2_state = h2.connection.H2Connection(config=self.CONFIG)

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -41,7 +41,9 @@ async def test_http_request(backend: str, server: Server) -> None:
 
 @pytest.mark.anyio
 async def test_https_request(backend: str, https_server: Server) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend, ssl_context=https_server.client_ssl_context
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -66,7 +68,9 @@ async def test_request_unsupported_protocol(backend: str) -> None:
 
 @pytest.mark.anyio
 async def test_http2_request(backend: str, https_server: Server) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend, http2=True) as http:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend, http2=True, ssl_context=https_server.client_ssl_context
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -123,7 +127,10 @@ async def test_http_request_reuse_connection(backend: str, server: Server) -> No
 async def test_https_request_reuse_connection(
     backend: str, https_server: Server
 ) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend,
+        ssl_context=https_server.client_ssl_context,
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -271,6 +278,7 @@ async def test_proxy_https_requests(
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         http2=http2,
+        ssl_context=https_server.client_ssl_context,
     ) as http:
         status_code, headers, stream, ext = await http.arequest(method, url, headers)
         _ = await read_body(stream)
@@ -319,7 +327,10 @@ async def test_connection_pool_get_connection_info(
     https_server: Server,
 ) -> None:
     async with httpcore.AsyncConnectionPool(
-        http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
+        http2=http2,
+        ssl_context=https_server.client_ssl_context,
+        keepalive_expiry=keepalive_expiry,
+        backend=backend,
     ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -41,7 +41,9 @@ def test_http_request(backend: str, server: Server) -> None:
 
 
 def test_https_request(backend: str, https_server: Server) -> None:
-    with httpcore.SyncConnectionPool(backend=backend) as http:
+    with httpcore.SyncConnectionPool(
+        backend=backend, ssl_context=https_server.client_ssl_context
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -66,7 +68,9 @@ def test_request_unsupported_protocol(backend: str) -> None:
 
 
 def test_http2_request(backend: str, https_server: Server) -> None:
-    with httpcore.SyncConnectionPool(backend=backend, http2=True) as http:
+    with httpcore.SyncConnectionPool(
+        backend=backend, http2=True, ssl_context=https_server.client_ssl_context
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -123,7 +127,10 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
 def test_https_request_reuse_connection(
     backend: str, https_server: Server
 ) -> None:
-    with httpcore.SyncConnectionPool(backend=backend) as http:
+    with httpcore.SyncConnectionPool(
+        backend=backend,
+        ssl_context=https_server.client_ssl_context,
+    ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")
         headers = [https_server.host_header]
@@ -271,6 +278,7 @@ def test_proxy_https_requests(
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         http2=http2,
+        ssl_context=https_server.client_ssl_context,
     ) as http:
         status_code, headers, stream, ext = http.request(method, url, headers)
         _ = read_body(stream)
@@ -319,7 +327,10 @@ def test_connection_pool_get_connection_info(
     https_server: Server,
 ) -> None:
     with httpcore.SyncConnectionPool(
-        http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
+        http2=http2,
+        ssl_context=https_server.client_ssl_context,
+        keepalive_expiry=keepalive_expiry,
+        backend=backend,
     ) as http:
         method = b"GET"
         url = (b"https", *https_server.netloc, b"/")


### PR DESCRIPTION
Closes #255 

This PR switches our SSL verification behavior from "no verify by default" to "verify by default".

As a result, it also updates the test suite so that we pass a proper `ssl_context` corresponding to the test servers whenever we make HTTPS or HTTP/2 requests.

## Backwards compatibility

### HTTPX

For HTTPX this will have no impact, because HTTPX is already always passing a properly-configured `SSLContext` (eg created via `httpx.create_ssl_context()`).

### Direct users

Anyone that's using `httpcore` directly would now have to expect SSL verification errors if they're requesting a host that has certs that are not in the default cert chain. For example, that would be the case if they're requesting a local HTTPS server that uses custom certs, or a remote server that uses custom certs.