### PR TITLE
Rework connection timeout tests

### DIFF
--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 
 import pytest
 
@@ -469,39 +468,13 @@ async def test_cannot_connect_uds(backend: str) -> None:
             await http.arequest(method, url)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
-)
 @pytest.mark.anyio
-async def test_connection_timeout_tcp(backend: str, server: Server) -> None:
-    # we try to access http server using https. It caused some SSL timeouts
-    # in TLSStream.wrap inside inside AnyIOBackend.open_tcp_stream
+async def test_connection_timeout_tcp(backend: str, busy_server: Server) -> None:
     method = b"GET"
-    url = (b"https", *server.netloc, b"/")
-    headers = [server.host_header]
-    ext = {"timeout": {"connect": 0.1}}
-
-    async with httpcore.AsyncConnectionPool(backend=backend) as http:
-        with pytest.raises(httpcore.ConnectTimeout):
-            await http.arequest(method, url, headers, ext=ext)
-
-
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
-)
-@pytest.mark.anyio
-async def test_connection_timeout_uds(
-    backend: str, uds_server: Server, uds: str
-) -> None:
-    # we try to access http server using https. It caused some SSL timeouts
-    # in TLSStream.wrap inside AnyIOBackend.open_uds_stream
-    method = b"GET"
-    url = (b"https", b"localhost", None, b"/")
+    url = (b"http", *busy_server.netloc, b"/")
     headers = [(b"host", b"localhost")]
     ext = {"timeout": {"connect": 0.1}}
 
-    async with httpcore.AsyncConnectionPool(uds=uds, backend=backend) as http:
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
             await http.arequest(method, url, headers, ext=ext)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,13 @@ import trustme
 
 from httpcore._types import URL
 
-from .utils import HypercornServer, LiveServer, Server, http_proxy_server
+from .utils import (
+    HypercornServer,
+    LiveServer,
+    NotListeningServer,
+    Server,
+    http_proxy_server,
+)
 
 try:
     import hypercorn
@@ -24,6 +30,8 @@ else:
     SERVER_HTTP_PORT = 8002
     SERVER_HTTPS_PORT = 8003
     HTTPS_SERVER_URL = f"https://localhost:{SERVER_HTTPS_PORT}"
+
+SERVER_BUSY_PORT = 8004
 
 
 @pytest.fixture(scope="session")
@@ -158,6 +166,13 @@ def https_server(
         keyfile=localhost_cert_private_key_file,
     )
     with server.serve_in_thread():
+        yield server
+
+
+@pytest.fixture
+def busy_server() -> typing.Iterator[Server]:
+    server = NotListeningServer(("localhost", SERVER_BUSY_PORT))
+    with server.serve():
         yield server
 
 

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 
 import pytest
 
@@ -469,39 +468,13 @@ def test_cannot_connect_uds(backend: str) -> None:
             http.request(method, url)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
-)
 
-def test_connection_timeout_tcp(backend: str, server: Server) -> None:
-    # we try to access http server using https. It caused some SSL timeouts
-    # in TLSStream.wrap inside inside AnyIOBackend.open_tcp_stream
+def test_connection_timeout_tcp(backend: str, busy_server: Server) -> None:
     method = b"GET"
-    url = (b"https", *server.netloc, b"/")
-    headers = [server.host_header]
-    ext = {"timeout": {"connect": 0.1}}
-
-    with httpcore.SyncConnectionPool(backend=backend) as http:
-        with pytest.raises(httpcore.ConnectTimeout):
-            http.request(method, url, headers, ext=ext)
-
-
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="Hypercorn doesn't support python < 3.7 (this test is local-only)",
-)
-
-def test_connection_timeout_uds(
-    backend: str, uds_server: Server, uds: str
-) -> None:
-    # we try to access http server using https. It caused some SSL timeouts
-    # in TLSStream.wrap inside AnyIOBackend.open_uds_stream
-    method = b"GET"
-    url = (b"https", b"localhost", None, b"/")
+    url = (b"http", *busy_server.netloc, b"/")
     headers = [(b"host", b"localhost")]
     ext = {"timeout": {"connect": 0.1}}
 
-    with httpcore.SyncConnectionPool(uds=uds, backend=backend) as http:
+    with httpcore.SyncConnectionPool(backend=backend) as http:
         with pytest.raises(httpcore.ConnectTimeout):
             http.request(method, url, headers, ext=ext)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,6 +148,27 @@ class HypercornServer(Server):  # pragma: no cover  # Python 3.7+ only
             thread.join()
 
 
+class NotListeningServer(Server):
+    """
+    A test server that binds to a TCP port but never listens for or accepts incoming
+    connections. For testing connection timeouts.
+    """
+
+    def __init__(self, address: Tuple[str, int]) -> None:
+        self._address = address
+
+    @property
+    def netloc(self) -> Tuple[bytes, int]:
+        host, port = self._address
+        return (host.encode("ascii"), port)
+
+    @contextlib.contextmanager
+    def serve(self) -> Iterator[None]:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(self._address)
+            yield
+
+
 @contextlib.contextmanager
 def http_proxy_server(proxy_host: str, proxy_port: int):
     """


### PR DESCRIPTION
These tests are currently broken on master. They also don't really seem to be tests for connection timeouts, rather for the behaviour when trying to connect using SSL to a server that wasn't using SSL. This behaviour used to be a connection timeout, but now (at least on Python 3.7+) is an SSL error. I'm not sure what changed to cause this to happen (possibly different OpenSSL version?) but it would be good to know.

Change the `test_connection_timeout_tcp` test to attempt to connect to a server port that is bound but not listening/accepting connections.

Remove the `test_connection_timeout_uds` test because as far as I can tell there isn't really a way to cause a timeout here (connect returns immediately with either success or failure on any bound Unix socket).

Not super sure about the naming of things here...