### PR TITLE
Added open method to open just the connection

### DIFF
--- a/httpcore/_async/base.py
+++ b/httpcore/_async/base.py
@@ -100,7 +100,13 @@ class AsyncHTTPTransport:
         and any keep alive connections.
         """
 
+    async def aopen(self) -> None:
+        """
+        Opens the implementation connection to the target.
+        """
+
     async def __aenter__(self: T) -> T:
+        await self.aopen()
         return self
 
     async def __aexit__(

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -170,8 +170,8 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
                 await self.connection.aclose()
 
     async def aopen(
-            self,
-            ext: dict = None,
+        self,
+        ext: dict = None,
     ) -> None:
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))

--- a/httpcore/_sync/base.py
+++ b/httpcore/_sync/base.py
@@ -100,7 +100,13 @@ class SyncHTTPTransport:
         and any keep alive connections.
         """
 
+    def open(self) -> None:
+        """
+        Opens the implementation connection to the target.
+        """
+
     def __enter__(self: T) -> T:
+        self.open()
         return self
 
     def __exit__(

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -82,23 +82,8 @@ class SyncHTTPConnection(SyncHTTPTransport):
     ) -> Tuple[int, Headers, SyncByteStream, dict]:
         assert url_to_origin(url) == self.origin
         ext = {} if ext is None else ext
-        timeout = cast(TimeoutDict, ext.get("timeout", {}))
 
-        with self.request_lock:
-            if self.state == ConnectionState.PENDING:
-                if not self.socket:
-                    logger.trace(
-                        "open_socket origin=%r timeout=%r", self.origin, timeout
-                    )
-                    self.socket = self._open_socket(timeout)
-                self._create_connection(self.socket)
-            elif self.state in (ConnectionState.READY, ConnectionState.IDLE):
-                pass
-            elif self.state == ConnectionState.ACTIVE and self.is_http2:
-                pass
-            else:
-                raise NewConnectionRequired()
-
+        self.open(ext=ext)
         assert self.connection is not None
         logger.trace(
             "connection.request method=%r url=%r headers=%r", method, url, headers
@@ -156,6 +141,8 @@ class SyncHTTPConnection(SyncHTTPTransport):
                 socket=socket, ssl_context=self.ssl_context
             )
 
+        self.connection.state = ConnectionState.READY
+
     @property
     def state(self) -> ConnectionState:
         if self.connect_failed:
@@ -181,3 +168,25 @@ class SyncHTTPConnection(SyncHTTPTransport):
         with self.request_lock:
             if self.connection is not None:
                 self.connection.close()
+
+    def open(
+            self,
+            ext: dict = None,
+    ) -> None:
+        ext = {} if ext is None else ext
+        timeout = cast(TimeoutDict, ext.get("timeout", {}))
+
+        with self.request_lock:
+            if self.state == ConnectionState.PENDING:
+                if not self.socket:
+                    logger.trace(
+                        "open_socket origin=%r timeout=%r", self.origin, timeout
+                    )
+                    self.socket = self._open_socket(timeout)
+                self._create_connection(self.socket)
+            elif self.state in (ConnectionState.READY, ConnectionState.IDLE):
+                pass
+            elif self.state == ConnectionState.ACTIVE and self.is_http2:
+                pass
+            else:
+                raise NewConnectionRequired()

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -170,8 +170,8 @@ class SyncHTTPConnection(SyncHTTPTransport):
                 self.connection.close()
 
     def open(
-            self,
-            ext: dict = None,
+        self,
+        ext: dict = None,
     ) -> None:
         ext = {} if ext is None else ext
         timeout = cast(TimeoutDict, ext.get("timeout", {}))


### PR DESCRIPTION
This adds a `(a)open()` method to the transport base class that defaults to a no-op operation. It is used by the HTTP Connection classes to solely open the socket connection and create the underlying HTTP connection object without sending an actual HTTP request.

Just wanted to get your thoughts on this before I start spending some time on adding some tests to see if this approach is ok. Right now the default open method is a no-op and the classes that do have an actual implementation aren't publicly exposed so it shouldn't affect users of this library. Hopefully it's a first step to enable some of my use cases without re implementing the entire class myself.

Fixes https://github.com/encode/httpcore/issues/273