### PR TITLE
Wildcard versions to ranges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11>=0,<1", "sniffio>=1,<1"],
+    install_requires=["h11>=0,<1", "sniffio>=1,<2"],
     extras_require={
         "http2": ["h2>=3,<5"],
     },

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11==0.*", "sniffio==1.*"],
+    install_requires=["h11>=0,<1", "sniffio>=1,<1"],
     extras_require={
         "http2": ["h2>=3,<5"],
     },


### PR DESCRIPTION
Related to https://github.com/encode/httpx/pull/1494

Using wildcards causes `pip` to retrieve all versions that match that pattern, then compare all dependencies against each of those versions.

When there are multiple dependencies doing that, it becomes a multiplicative comparison.

Pip actually came up with this warning when installing `httpx`:
```log
INFO: pip is looking at multiple versions of httpcore to determine which version is compatible with other requirements. This could take a while.
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking
```

This patch changes from wildcard to range, which `pip` will treat as `use the latest that works, try older if it doesn't`