### PR TITLE
Drop pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,0 @@
-[tool.black]
-exclude = '''
-/(
-    httpcore/_sync
-  | tests/sync_tests
-)/
-'''
-target-version = ['py36']

--- a/scripts/check
+++ b/scripts/check
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}isort --check --diff --project=httpcore $SOURCE_FILES
-${PREFIX}black --check --diff --target-version=py36 --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py36 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/check
+++ b/scripts/check
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}isort --check --diff --project=httpcore $SOURCE_FILES
-${PREFIX}black --check --diff $SOURCE_FILES
+${PREFIX}black --check --diff --target-version=py36 --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,7 +10,7 @@ set -x
 
 ${PREFIX}autoflake --in-place --recursive --remove-all-unused-imports $SOURCE_FILES
 ${PREFIX}isort --project=httpcore $SOURCE_FILES
-${PREFIX}black $SOURCE_FILES
+${PREFIX}black --target-version=py36 --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,7 +10,7 @@ set -x
 
 ${PREFIX}autoflake --in-place --recursive --remove-all-unused-imports $SOURCE_FILES
 ${PREFIX}isort --project=httpcore $SOURCE_FILES
-${PREFIX}black --target-version=py36 --exclude 'httpcore/_sync/.*' --exclude 'tests/sync_tests/.*' $SOURCE_FILES
+${PREFIX}black --target-version=py36 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)


### PR DESCRIPTION
Personally I'm not keen on us having a `pyproject.toml` exclusively for some bits of black configuration. We don't have this on our other projects, and I don't particularly appreciate IDE design choices forcing us into particular tooling conventions.

I'm okay with us having a conversation around this, but also am very strongly in favour of us being able to stick with similar conventions on our projects across `encode`, and striving towards low-config, low-tooling approaches wherever possible. To me this also include narrowing down the number of magical configuration files we have at the top-level.

Also, I needed a PR excuse to have a look at [the latest build failure nonsense](https://github.com/encode/httpcore/runs/1785395873).