### PR TITLE
Add docs i18n infrastructure, with partial FR translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv*/
 .python-version
 build/
 dist/
+*.mo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,12 @@ autodoc_typehints = "description"
 
 html_theme = "furo"
 
+# -- Internationalization --
+# https://www.sphinx-doc.org/en/master/usage/advanced/intl.html
+
+locale_dirs = ['locale/']
+gettext_compact = False
+
 # -- App setup --
 
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -130,6 +130,28 @@ To run the documentation site locally (useful for previewing changes), use:
 $ scripts/docs
 ```
 
+### Working with translations
+
+The documentation has multi-language (internationalization, aka i18n) support. The workflow is built on top of [Sphinx internationalization](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html), which relies on the `gettext` standard.
+
+After editing documentation, sync translation files (i.e. `.po` files under `docs/locale`) using:
+
+```shell
+$ scripts/docs maketranslations
+```
+
+Documentation for a specific language can then be built using:
+
+```shell
+$ SPHINX_LANGUAGE=fr scripts/docs build
+```
+
+Run the documentation site locally for a specific language built using:
+
+```shell
+$ SPHINX_LANGUAGE=fr scripts/docs
+```
+
 ## Resolving Build / CI Failures
 
 Once you've submitted your pull request, the test suite will automatically run, and the results will show up in GitHub.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ api
 :hidden:
 :caption: Development
 
-contributing
+Contributing <contributing>
 Changelog <https://github.com/encode/httpcore/blob/master/CHANGELOG.md>
 License <https://github.com/encode/httpcore/blob/master/LICENSE.md>
 Source Code <https://github.com/encode/httpcore>

--- a/docs/locale/fr/LC_MESSAGES/api.po
+++ b/docs/locale/fr/LC_MESSAGES/api.po
@@ -1,0 +1,346 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021, Encode
+# This file is distributed under the same license as the HTTPCore package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: HTTPCore \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-10 21:37+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: ../../../docs/api.md:1
+msgid "Developer Interface"
+msgstr ""
+
+#: ../../../docs/api.md:3
+msgid "Async API Overview"
+msgstr ""
+
+#: ../../../docs/api.md:5
+msgid "Base async interfaces"
+msgstr ""
+
+#: ../../../docs/api.md:7 ../../../docs/api.md:47
+msgid ""
+"These classes provide the base interface which transport classes need to "
+"implement."
+msgstr ""
+
+#: httpcore.AsyncHTTPTransport:1 httpcore.SyncHTTPTransport:1 of
+msgid "The base interface for sending HTTP requests."
+msgstr ""
+
+#: httpcore.AsyncHTTPTransport:3 of
+msgid ""
+"Concrete implementations should subclass this class, and implement the "
+":meth:`arequest` method, and optionally the :meth:`aclose` method."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:1
+#: httpcore._sync.base.SyncHTTPTransport.request:1 of
+msgid "The interface for sending a single HTTP request, and returning a response."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool httpcore.AsyncHTTPProxy
+#: httpcore.AsyncIteratorByteStream httpcore.IteratorByteStream
+#: httpcore.PlainByteStream httpcore.SyncConnectionPool httpcore.SyncHTTPProxy
+#: httpcore._async.base.AsyncHTTPTransport.arequest
+#: httpcore._sync.base.SyncHTTPTransport.request of
+msgid "Parameters"
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:3
+#: httpcore._sync.base.SyncHTTPTransport.request:3 of
+msgid "The HTTP method, such as ``b'GET'``."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:4
+#: httpcore._sync.base.SyncHTTPTransport.request:4 of
+msgid "The URL as a 4-tuple of (scheme, host, port, path)."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:5
+#: httpcore._sync.base.SyncHTTPTransport.request:5 of
+msgid "Any HTTP headers to send with the request."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:6
+#: httpcore._sync.base.SyncHTTPTransport.request:6 of
+msgid "The body of the HTTP request."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:7
+#: httpcore._sync.base.SyncHTTPTransport.request:7 of
+msgid "A dictionary of optional extensions."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest
+#: httpcore._sync.base.SyncHTTPTransport.request of
+msgid "Returns"
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:9
+#: httpcore._sync.base.SyncHTTPTransport.request:9 of
+msgid ""
+"* *status_code* -- The HTTP status code, such as ``200``. * *headers* -- "
+"Any HTTP headers included on the response. * *stream* -- The body of the "
+"HTTP response. * *ext* -- A dictionary of optional extensions."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:9
+#: httpcore._sync.base.SyncHTTPTransport.request:9 of
+msgid "*status_code* -- The HTTP status code, such as ``200``."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:10
+#: httpcore._sync.base.SyncHTTPTransport.request:10 of
+msgid "*headers* -- Any HTTP headers included on the response."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:11
+#: httpcore._sync.base.SyncHTTPTransport.request:11 of
+msgid "*stream* -- The body of the HTTP response."
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.arequest:12
+#: httpcore._sync.base.SyncHTTPTransport.request:12 of
+msgid "*ext* -- A dictionary of optional extensions."
+msgstr ""
+
+#: httpcore._async.base.AsyncByteStream.__aiter__
+#: httpcore._async.base.AsyncByteStream.aclose
+#: httpcore._async.base.AsyncHTTPTransport.aclose
+#: httpcore._async.base.AsyncHTTPTransport.arequest
+#: httpcore._sync.base.SyncByteStream.__iter__
+#: httpcore._sync.base.SyncByteStream.close
+#: httpcore._sync.base.SyncHTTPTransport.close
+#: httpcore._sync.base.SyncHTTPTransport.request of
+msgid "Return type"
+msgstr ""
+
+#: httpcore._async.base.AsyncHTTPTransport.aclose:1
+#: httpcore._sync.base.SyncHTTPTransport.close:1 of
+msgid ""
+"Close the implementation, which should close any outstanding response "
+"streams, and any keep alive connections."
+msgstr ""
+
+#: httpcore.AsyncByteStream:1 httpcore.SyncByteStream:1 of
+msgid "The base interface for request and response bodies."
+msgstr ""
+
+#: httpcore.AsyncByteStream:3 of
+msgid ""
+"Concrete implementations should subclass this class, and implement the "
+":meth:`__aiter__` method, and optionally the :meth:`aclose` method."
+msgstr ""
+
+#: httpcore._async.base.AsyncByteStream.__aiter__:1
+#: httpcore._sync.base.SyncByteStream.__iter__:1 of
+msgid "Yield bytes representing the request or response body."
+msgstr ""
+
+#: httpcore._async.base.AsyncByteStream.aclose:1
+#: httpcore._sync.base.SyncByteStream.close:1 of
+msgid "Must be called by the client to indicate that the stream has been closed."
+msgstr ""
+
+#: ../../../docs/api.md:17
+msgid "Async connection pool"
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:1 of
+msgid "Bases: :class:`httpcore.AsyncHTTPTransport`"
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:1 httpcore.SyncConnectionPool:1 of
+msgid "A connection pool for making HTTP requests."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:3 httpcore.AsyncHTTPProxy:6
+#: httpcore.SyncConnectionPool:3 httpcore.SyncHTTPProxy:6 of
+msgid "An SSL context to use for verifying connections."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:4 httpcore.AsyncHTTPProxy:7
+#: httpcore.SyncConnectionPool:4 httpcore.SyncHTTPProxy:7 of
+msgid "The maximum number of concurrent connections to allow."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:5 httpcore.AsyncHTTPProxy:8
+#: httpcore.SyncConnectionPool:5 httpcore.SyncHTTPProxy:8 of
+msgid ""
+"The maximum number of connections to allow before closing keep-alive "
+"connections."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:7 httpcore.SyncConnectionPool:7 of
+msgid "The maximum time to allow before closing a keep-alive connection."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:8 httpcore.AsyncHTTPProxy:10
+#: httpcore.SyncConnectionPool:8 httpcore.SyncHTTPProxy:10 of
+msgid "Enable HTTP/2 support."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:9 httpcore.SyncConnectionPool:9 of
+msgid "Path to a Unix Domain Socket to use instead of TCP sockets."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:10 httpcore.SyncConnectionPool:10 of
+msgid ""
+"Local address to connect from. Can also be used to connect using a "
+"particular address family. Using ``local_address=\"0.0.0.0\"`` will "
+"connect using an ``AF_INET`` address (IPv4), while using "
+"``local_address=\"::\"`` will connect using an ``AF_INET6`` address "
+"(IPv6)."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:14 httpcore.SyncConnectionPool:14 of
+msgid "The maximum number of retries when trying to establish a connection."
+msgstr ""
+
+#: httpcore.AsyncConnectionPool:15 httpcore.SyncConnectionPool:15 of
+msgid "A name indicating which concurrency backend to use."
+msgstr ""
+
+#: ../../../docs/api.md:24
+msgid "Async proxy"
+msgstr ""
+
+#: httpcore.AsyncHTTPProxy:1 of
+msgid "Bases: :class:`httpcore.AsyncConnectionPool`"
+msgstr ""
+
+#: httpcore.AsyncHTTPProxy:1 httpcore.SyncHTTPProxy:1 of
+msgid "A connection pool for making HTTP requests via an HTTP proxy."
+msgstr ""
+
+#: httpcore.AsyncHTTPProxy:3 httpcore.SyncHTTPProxy:3 of
+msgid "The URL of the proxy service as a 4-tuple of (scheme, host, port, path)."
+msgstr ""
+
+#: httpcore.AsyncHTTPProxy:4 httpcore.SyncHTTPProxy:4 of
+msgid "A list of proxy headers to include."
+msgstr ""
+
+#: httpcore.AsyncHTTPProxy:5 httpcore.SyncHTTPProxy:5 of
+msgid ""
+"A proxy mode to operate in. May be \"DEFAULT\", \"FORWARD_ONLY\", or "
+"\"TUNNEL_ONLY\"."
+msgstr ""
+
+#: ../../../docs/api.md:31
+msgid "Async byte streams"
+msgstr ""
+
+#: ../../../docs/api.md:33
+msgid ""
+"These classes are concrete implementations of "
+"[`AsyncByteStream`](httpcore.AsyncByteStream)."
+msgstr ""
+
+#: httpcore.PlainByteStream:1 of
+msgid "Bases: :class:`httpcore.AsyncByteStream`, :class:`httpcore.SyncByteStream`"
+msgstr ""
+
+#: httpcore.PlainByteStream:1 of
+msgid "A concrete implementation for either sync or async byte streams."
+msgstr ""
+
+#: httpcore.AsyncIteratorByteStream:3 httpcore.IteratorByteStream:3
+#: httpcore.PlainByteStream:3 of
+msgid "Example::"
+msgstr ""
+
+#: httpcore.PlainByteStream:7 of
+msgid "A plain byte string used as the content of the stream."
+msgstr ""
+
+#: httpcore.AsyncIteratorByteStream:1 of
+msgid "Bases: :class:`httpcore.AsyncByteStream`"
+msgstr ""
+
+#: httpcore.AsyncIteratorByteStream:1 of
+msgid "A concrete implementation for async byte streams."
+msgstr ""
+
+#: httpcore.AsyncIteratorByteStream:11 of
+msgid "An async byte iterator, used as the content of the stream."
+msgstr ""
+
+#: httpcore.AsyncIteratorByteStream:12 of
+msgid "An optional async function called when closing the stream."
+msgstr ""
+
+#: ../../../docs/api.md:43
+msgid "Sync API Overview"
+msgstr ""
+
+#: ../../../docs/api.md:45
+msgid "Base sync interfaces"
+msgstr ""
+
+#: httpcore.SyncHTTPTransport:3 of
+msgid ""
+"Concrete implementations should subclass this class, and implement the "
+":meth:`request` method, and optionally the :meth:`close` method."
+msgstr ""
+
+#: httpcore.SyncByteStream:3 of
+msgid ""
+"Concrete implementations should subclass this class, and implement the "
+":meth:`__iter__` method, and optionally the :meth:`close` method."
+msgstr ""
+
+#: ../../../docs/api.md:57
+msgid "Sync connection pool"
+msgstr ""
+
+#: httpcore.SyncConnectionPool:1 of
+msgid "Bases: :class:`httpcore.SyncHTTPTransport`"
+msgstr ""
+
+#: ../../../docs/api.md:64
+msgid "Sync proxy"
+msgstr ""
+
+#: httpcore.SyncHTTPProxy:1 of
+msgid "Bases: :class:`httpcore.SyncConnectionPool`"
+msgstr ""
+
+#: ../../../docs/api.md:71
+msgid "Sync byte streams"
+msgstr ""
+
+#: ../../../docs/api.md:73
+msgid ""
+"These classes are concrete implementations of "
+"[`SyncByteStream`](httpcore.SyncByteStream)."
+msgstr ""
+
+#: httpcore.IteratorByteStream:1 of
+msgid "Bases: :class:`httpcore.SyncByteStream`"
+msgstr ""
+
+#: httpcore.IteratorByteStream:1 of
+msgid "A concrete implementation for sync byte streams."
+msgstr ""
+
+#: httpcore.IteratorByteStream:11 of
+msgid "A sync byte iterator, used as the content of the stream."
+msgstr ""
+
+#: httpcore.IteratorByteStream:12 of
+msgid "An optional function called when closing the stream."
+msgstr ""
+

--- a/docs/locale/fr/LC_MESSAGES/contributing.po
+++ b/docs/locale/fr/LC_MESSAGES/contributing.po
@@ -1,0 +1,417 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021, Encode
+# This file is distributed under the same license as the HTTPCore package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: HTTPCore \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-10 22:21+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: ../../../docs/contributing.md:1
+msgid "Contributing"
+msgstr ""
+
+#: ../../../docs/contributing.md:3
+msgid "Thanks for considering contributing to HTTP Core!"
+msgstr ""
+
+#: ../../../docs/contributing.md:5
+msgid "We welcome contributors to:"
+msgstr ""
+
+#: ../../../docs/contributing.md:7
+msgid ""
+"Try [HTTPX](https://www.python-httpx.org), as it is HTTP Core's main "
+"entry point, and [report bugs/issues you "
+"find](https://github.com/encode/httpx/issues/new)"
+msgstr ""
+
+#: ../../../docs/contributing.md:9
+msgid ""
+"Help triage [issues](https://github.com/encode/httpcore/issues) and "
+"investigate root causes of bugs"
+msgstr ""
+
+#: ../../../docs/contributing.md:11
+msgid "[Review Pull Requests of others](https://github.com/encode/httpcore/pulls)"
+msgstr ""
+
+#: ../../../docs/contributing.md:12
+msgid "Review, clarify and write documentation"
+msgstr ""
+
+#: ../../../docs/contributing.md:13
+msgid "Participate in discussions"
+msgstr ""
+
+#: ../../../docs/contributing.md:15
+msgid "Reporting Bugs or Other Issues"
+msgstr ""
+
+#: ../../../docs/contributing.md:17
+msgid ""
+"HTTP Core is a fairly specialized library and its main purpose is to "
+"provide a solid base for [HTTPX](https://www.python-httpx.org). HTTPX "
+"should be considered the main entry point to HTTP Core and as such we "
+"encourage users to test and raise issues in [HTTPX's issue "
+"tracker](https://github.com/encode/httpx/issues/new) where maintainers "
+"and contributors can triage and move to HTTP Core if appropriate."
+msgstr ""
+
+#: ../../../docs/contributing.md:23
+msgid ""
+"If you are convinced that the cause of the issue is on HTTP Core you're "
+"more than welcome to [open an "
+"issue](https://github.com/encode/httpcore/issues/new)."
+msgstr ""
+
+#: ../../../docs/contributing.md:26
+msgid ""
+"Please attach as much detail as possible and, in case of a bug report, "
+"provide information like:"
+msgstr ""
+
+#: ../../../docs/contributing.md:29
+msgid "OS platform or Docker image"
+msgstr ""
+
+#: ../../../docs/contributing.md:30
+msgid "Python version"
+msgstr ""
+
+#: ../../../docs/contributing.md:31
+msgid "Installed dependencies and versions (`python -m pip freeze`)"
+msgstr ""
+
+#: ../../../docs/contributing.md:32
+msgid "Code snippet to reproduce the issue"
+msgstr ""
+
+#: ../../../docs/contributing.md:33
+msgid "Error traceback and output"
+msgstr ""
+
+#: ../../../docs/contributing.md:35
+msgid ""
+"It is quite helpful to increase the logging level of HTTP Core and "
+"include the output of your program. To do so set the `HTTPCORE_LOG_LEVEL`"
+" or `HTTPX_LOG_LEVEL` environment variables to `TRACE`, for example:"
+msgstr ""
+
+#: ../../../docs/contributing.md:46
+msgid ""
+"The output will be quite long but it will help dramatically in diagnosing"
+" the problem."
+msgstr ""
+
+#: ../../../docs/contributing.md:48
+msgid ""
+"For more examples please refer to the [environment variables "
+"documentation in HTTPX](https://www.python-"
+"httpx.org/environment_variables/#httpx_log_level)."
+msgstr ""
+
+#: ../../../docs/contributing.md:51
+msgid "Development"
+msgstr ""
+
+#: ../../../docs/contributing.md:53
+msgid ""
+"To start developing HTTP Core create a **fork** of the "
+"[repository](https://github.com/encode/httpcore) on GitHub."
+msgstr ""
+
+#: ../../../docs/contributing.md:56
+msgid ""
+"Then clone your fork with the following command replacing `YOUR-USERNAME`"
+" with your GitHub username:"
+msgstr ""
+
+#: ../../../docs/contributing.md:63
+msgid "You can now install the project and its dependencies using:"
+msgstr ""
+
+#: ../../../docs/contributing.md:70
+msgid "Unasync"
+msgstr ""
+
+#: ../../../docs/contributing.md:72
+msgid ""
+"HTTP Core provides synchronous and asynchronous interfaces. As you can "
+"imagine, keeping two almost identical versions of code in sync can be "
+"quite time consuming. To work around this problem HTTP Core uses a "
+"technique called _unasync_, where the development is focused on the "
+"asynchronous version of the code and a script generates the synchronous "
+"version from it."
+msgstr ""
+
+#: ../../../docs/contributing.md:78
+msgid "As such developers should:"
+msgstr ""
+
+#: ../../../docs/contributing.md:80
+msgid ""
+"Only make modifications in the asynchronous and shared portions of the "
+"code. In practice this roughly means avoiding the `httpcore/_sync` "
+"directory."
+msgstr ""
+
+#: ../../../docs/contributing.md:82
+msgid ""
+"Write tests _only under `async_tests`_, synchronous tests are also "
+"generated as part of the unasync process."
+msgstr ""
+
+#: ../../../docs/contributing.md:84
+msgid ""
+"Run `scripts/unasync` to generate the synchronous versions. Note the "
+"script is ran as part of other scripts as well, so you don't usually need"
+" to run this yourself."
+msgstr ""
+
+#: ../../../docs/contributing.md:87
+msgid "Run the entire test suite as decribed below."
+msgstr ""
+
+#: ../../../docs/contributing.md:89
+msgid "Testing and Linting"
+msgstr ""
+
+#: ../../../docs/contributing.md:91
+msgid ""
+"We use custom shell scripts to automate testing, linting, and "
+"documentation building workflow."
+msgstr ""
+
+#: ../../../docs/contributing.md:94
+msgid "To run the tests, use:"
+msgstr ""
+
+#: ../../../docs/contributing.md:100
+msgid ""
+"The test suite spawns testing servers on ports **8000** and **8001**. "
+"Make sure these are not in use, so the tests can run properly."
+msgstr ""
+
+#: ../../../docs/contributing.md:105
+msgid "You can run a single test script like this:"
+msgstr ""
+
+#: ../../../docs/contributing.md:111
+msgid "To run the code auto-formatting:"
+msgstr ""
+
+#: ../../../docs/contributing.md:117
+msgid ""
+"Lastly, to run code checks separately (they are also run as part of "
+"`scripts/test`), run:"
+msgstr ""
+
+#: ../../../docs/contributing.md:123
+msgid "Documenting"
+msgstr ""
+
+#: ../../../docs/contributing.md:125
+msgid "Documentation pages are located under the `docs/` folder."
+msgstr ""
+
+#: ../../../docs/contributing.md:127
+msgid ""
+"To run the documentation site locally (useful for previewing changes), "
+"use:"
+msgstr ""
+
+#: ../../../docs/contributing.md:133
+msgid "Working with translations"
+msgstr ""
+
+#: ../../../docs/contributing.md:135
+msgid ""
+"The documentation has multi-language (internationalization, aka i18n) "
+"support. The workflow is built on top of [Sphinx "
+"internationalization](https://www.sphinx-"
+"doc.org/en/master/usage/advanced/intl.html), which relies on the "
+"`gettext` standard."
+msgstr ""
+
+#: ../../../docs/contributing.md:137
+msgid ""
+"After editing documentation, sync translation files (i.e. `.po` files "
+"under `docs/locale`) using:"
+msgstr ""
+
+#: ../../../docs/contributing.md:143
+msgid "Documentation for a specific language can then be built using:"
+msgstr ""
+
+#: ../../../docs/contributing.md:149
+msgid "Run the documentation site locally for a specific language built using:"
+msgstr ""
+
+#: ../../../docs/contributing.md:155
+msgid "Resolving Build / CI Failures"
+msgstr ""
+
+#: ../../../docs/contributing.md:157
+msgid ""
+"Once you've submitted your pull request, the test suite will "
+"automatically run, and the results will show up in GitHub. If the test "
+"suite fails, you'll want to click through to the \"Details\" link, and "
+"try to identify why the test suite failed."
+msgstr ""
+
+#: ../../../docs/contributing.md:164
+msgid "Here are some common ways the test suite can fail:"
+msgstr ""
+
+#: ../../../docs/contributing.md:166
+msgid "Check Job Failed"
+msgstr ""
+
+#: ../../../docs/contributing.md:172
+msgid ""
+"This job failing means there is either a code formatting issue or type-"
+"annotation issue. You can look at the job output to figure out why it's "
+"failed or within a shell run:"
+msgstr ""
+
+#: ../../../docs/contributing.md:179
+msgid ""
+"It may be worth it to run `$ scripts/lint` to attempt auto-formatting the"
+" code and if that job succeeds commit the changes."
+msgstr ""
+
+#: ../../../docs/contributing.md:182
+msgid "Docs Job Failed"
+msgstr ""
+
+#: ../../../docs/contributing.md:184
+msgid ""
+"This job failing means the documentation failed to build. This can happen"
+" for a variety of reasons like invalid markdown or missing configuration "
+"within `mkdocs.yml`."
+msgstr ""
+
+#: ../../../docs/contributing.md:187
+msgid "Python 3.X Job Failed"
+msgstr ""
+
+#: ../../../docs/contributing.md:193
+msgid ""
+"This job failing means the unit tests failed or not all code paths are "
+"covered by unit tests."
+msgstr ""
+
+#: ../../../docs/contributing.md:195
+msgid "If tests are failing you will see this message under the coverage report:"
+msgstr ""
+
+#: ../../../docs/contributing.md:197
+msgid "`=== 1 failed, 435 passed, 1 skipped, 1 xfailed in 11.09s ===`"
+msgstr ""
+
+#: ../../../docs/contributing.md:199
+msgid ""
+"If tests succeed but coverage is lower than our current threshold, you "
+"will see this message under the coverage report:"
+msgstr ""
+
+#: ../../../docs/contributing.md:201
+msgid "`FAIL Required test coverage of 100% not reached. Total coverage: 99.00%`"
+msgstr ""
+
+#: ../../../docs/contributing.md:203
+msgid "Releasing"
+msgstr ""
+
+#: ../../../docs/contributing.md:205
+msgid "*This section is targeted at HTTPX maintainers.*"
+msgstr ""
+
+#: ../../../docs/contributing.md:207
+msgid "Before releasing a new version, create a pull request that includes:"
+msgstr ""
+
+#: ../../../docs/contributing.md:209
+msgid "**An update to the changelog**:"
+msgstr ""
+
+#: ../../../docs/contributing.md:210
+msgid ""
+"We follow the format from "
+"[keepachangelog](https://keepachangelog.com/en/1.0.0/)."
+msgstr ""
+
+#: ../../../docs/contributing.md:211
+msgid ""
+"[Compare](https://github.com/encode/httpcore/compare/) `master` with the "
+"tag of the latest release, and list all entries that are of interest to "
+"our users:"
+msgstr ""
+
+#: ../../../docs/contributing.md:212
+msgid ""
+"Things that **must** go in the changelog: added, changed, deprecated or "
+"removed features, and bug fixes."
+msgstr ""
+
+#: ../../../docs/contributing.md:213
+msgid ""
+"Things that **should not** go in the changelog: changes to documentation,"
+" tests or tooling."
+msgstr ""
+
+#: ../../../docs/contributing.md:214
+msgid "Try sorting entries in descending order of impact / importance."
+msgstr ""
+
+#: ../../../docs/contributing.md:215
+msgid "Keep it concise and to-the-point. 🎯"
+msgstr ""
+
+#: ../../../docs/contributing.md:216
+msgid "**A version bump**: see `__version__.py`."
+msgstr ""
+
+#: ../../../docs/contributing.md:218
+msgid "For an example, see [#99](https://github.com/encode/httpcore/pull/99)."
+msgstr ""
+
+#: ../../../docs/contributing.md:220
+msgid ""
+"Once the release PR is merged, create a [new "
+"release](https://github.com/encode/httpcore/releases/new) including:"
+msgstr ""
+
+#: ../../../docs/contributing.md:223
+msgid "Tag version like `0.9.3`."
+msgstr ""
+
+#: ../../../docs/contributing.md:224
+msgid "Release title `Version 0.9.3`"
+msgstr ""
+
+#: ../../../docs/contributing.md:225
+msgid "Description copied from the changelog."
+msgstr ""
+
+#: ../../../docs/contributing.md:227
+msgid "Once created this release will be automatically uploaded to PyPI."
+msgstr ""
+
+#: ../../../docs/contributing.md:229
+msgid ""
+"If something goes wrong with the PyPI job the release can be published "
+"using the `scripts/publish` script."
+msgstr ""
+

--- a/docs/locale/fr/LC_MESSAGES/index.po
+++ b/docs/locale/fr/LC_MESSAGES/index.po
@@ -1,0 +1,174 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021, Encode
+# This file is distributed under the same license as the HTTPCore package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: HTTPCore \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-10 22:21+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: ../../../docs/index.md:6
+msgid "Usage"
+msgstr "Utilisation"
+
+#: ../../../docs/index.md:13
+msgid "Contributing"
+msgstr "Contribuer"
+
+#: ../../../docs/index.md:13
+msgid "Changelog"
+msgstr ""
+
+#: ../../../docs/index.md:13
+msgid "License"
+msgstr "Licence"
+
+#: ../../../docs/index.md:13
+msgid "Source Code"
+msgstr "Code source"
+
+#: ../../../docs/index.md:13
+msgid "Development"
+msgstr "Développement"
+
+#: ../../../README.md:1
+msgid "HTTP Core"
+msgstr ""
+
+#: ../../../README.md:3
+msgid ""
+"[![Test "
+"Suite](https://github.com/encode/httpcore/workflows/Test%20Suite/badge.svg)](https://github.com/encode/httpcore/actions)"
+" [![Package "
+"version](https://badge.fury.io/py/httpcore.svg)](https://pypi.org/project/httpcore/)"
+msgstr ""
+
+#: ../../../README.md:6
+msgid "*Do one thing, and do it well.*"
+msgstr ""
+
+#: ../../../README.md:8
+msgid ""
+"The HTTP Core package provides a minimal low-level HTTP client, which "
+"does one thing only. Sending HTTP requests."
+msgstr ""
+"HTTP Core est un client HTTP bas niveau minimaliste. Il ne fait qu'une "
+"seule chose : envoyer des requêtes HTTP."
+
+#: ../../../README.md:11
+msgid ""
+"It does not provide any high level model abstractions over the API, does "
+"not handle redirects, multipart uploads, building authentication headers,"
+" transparent HTTP caching, URL parsing, session cookie handling, content "
+"or charset decoding, handling JSON, environment based configuration "
+"defaults, or any of that Jazz."
+msgstr ""
+"Pas de modeèles ou d'abstractions haut-niveau, pas de gestion des "
+"redirections, des _multipart uploads_, d'entêtes d'authentification, de "
+"mise en cache, d'analyse d'URL, de déchiffrage de contenu ou de "
+"_charset_, de JSON, de valeurs par défaut via des variables "
+"d'environnement, ou tout autre gadget de ce genre."
+
+#: ../../../README.md:17
+msgid "Some things HTTP Core does do:"
+msgstr "Par contre, voici ce que HTTP Core _peut_ faire :"
+
+#: ../../../README.md:19
+msgid "Sending HTTP requests."
+msgstr "Envoyer des requêtes HTTP."
+
+#: ../../../README.md:20
+msgid "Provides both sync and async interfaces."
+msgstr "Gérer sync et async grâce à des interfaces dédiées."
+
+#: ../../../README.md:21
+msgid "Supports HTTP/1.1 and HTTP/2."
+msgstr "Gérer HTTP/1.1 et HTTP/2."
+
+#: ../../../README.md:22
+msgid "Async backend support for `asyncio`, `trio` and `curio`."
+msgstr "Fonctionner avec `asyncio`, `trio` et `curio`."
+
+#: ../../../README.md:23
+msgid "Automatic connection pooling."
+msgstr "Mutualiser automatiquement les connexions (*connection pooling*)."
+
+#: ../../../README.md:24
+msgid "HTTP(S) proxy support."
+msgstr "Fonctionner avec un proxy HTTP(S)."
+
+#: ../../../README.md:26
+msgid "Installation"
+msgstr "Installation"
+
+#: ../../../README.md:28
+msgid "For HTTP/1.1 only support, install with..."
+msgstr "Si HTTP/1.1 suffit, utilisez cette commande :"
+
+#: ../../../README.md:34
+msgid "For HTTP/1.1 and HTTP/2 support, install with..."
+msgstr "Pour HTTP/1.1 et HTTP/2, utilisez cette commande :"
+
+#: ../../../README.md:40
+msgid "Quickstart"
+msgstr "Démarrage rapide"
+
+#: ../../../README.md:42
+msgid "Here's an example of making an HTTP GET request using `httpcore`..."
+msgstr ""
+"Dans cet exemple, on utilise `httpcore` pour envoyer une requête HTTP GET"
+" :"
+
+#: ../../../README.md:60
+msgid "Or, using async..."
+msgstr "En async, voici à quoi cela ressemble :"
+
+#: ../../../README.md:78
+msgid "Motivation"
+msgstr "Motivation"
+
+#: ../../../README.md:80
+msgid ""
+"You probably don't want to be using HTTP Core directly. It might make "
+"sense if you're writing something like a proxy service in Python, and you"
+" just want something at the lowest possible level, but more typically "
+"you'll want to use a higher level client library, such as `httpx`."
+msgstr ""
+"Dans la pratique, il est probable que presque personne ne doive utiliser "
+"HTTP Core directement. À la limite si vous écrivez quelque chose comme un"
+" service de proxying en Python, et qu'il vous faut une interface aussi "
+"bas-niveau que possible. Mais en général, on vous recommande plutôt "
+"d'utiliser un client HTTP haut-niveau, comme `httpx`."
+
+#: ../../../README.md:85
+msgid "The motivation for `httpcore` is:"
+msgstr "`httpcore` répond à plusieurs objectifs:"
+
+#: ../../../README.md:87
+msgid ""
+"To provide a reusable low-level client library, that other packages can "
+"then build on top of."
+msgstr ""
+"Fournir une librarie client bas-niveau, utilisable comme base par "
+"d'autres libraries."
+
+#: ../../../README.md:88
+msgid ""
+"To provide a *really clear interface split* between the networking code "
+"and client logic, so that each is easier to understand and reason about "
+"in isolation."
+msgstr ""
+"Séparer *très clairement* le code réseau de la logique client, afin qu'il"
+" soit plus facile de comprendre et de travailler avec l'un ou l'autre de "
+"façon isolée."
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ curio==1.5; python_version >= '3.7'
 # Docs
 sphinx==3.5.3
 sphinx-autobuild==2021.3.14
+sphinx-intl==2.0.1
 myst-parser==0.13.5
 furo==2021.3.20b30
 ghp-import==1.1.0

--- a/scripts/docs
+++ b/scripts/docs
@@ -7,6 +7,8 @@ fi
 
 SOURCE_DIR="docs"
 OUT_DIR="build/html"
+SPHINX_CONFIG="docs/conf.py"
+SPHINX_LANGUAGE="${SPHINX_LANGUAGE:-en}"
 
 COMMAND="$1"
 ARGS="${@:2}"
@@ -14,10 +16,13 @@ ARGS="${@:2}"
 set -x
 
 if [ "$COMMAND" = "build" ]; then
-    ${PREFIX}sphinx-build $SOURCE_DIR $OUT_DIR
+    ${PREFIX}sphinx-build $SOURCE_DIR $OUT_DIR -D language=$SPHINX_LANGUAGE
+elif [ "$COMMAND" = "maketranslations" ]; then
+    ${PREFIX}sphinx-build -M gettext $SOURCE_DIR $OUT_DIR
+    ${PREFIX}sphinx-intl -c $SPHINX_CONFIG update -p "$OUT_DIR/gettext" --language fr
 elif [ "$COMMAND" = "gh-deploy" ]; then
     scripts/docs build
     ${PREFIX}ghp-import $OUT_DIR -np -m "Deployed $(git rev-parse --short HEAD)" $ARGS
 else
-    ${PREFIX}sphinx-autobuild $SOURCE_DIR $OUT_DIR --watch httpcore/ $ARGS
+    ${PREFIX}sphinx-autobuild $SOURCE_DIR $OUT_DIR --watch httpcore/ -D language=$SPHINX_LANGUAGE $ARGS
 fi


### PR DESCRIPTION
Follow-up to #285, prompted by https://github.com/encode/httpcore/pull/285#pullrequestreview-631335488

This pull request expands `scripts/docs` so that it supports generating translation files, and building/serving the docs for a given language. Currently only `fr` (French) is supported, since that's the language I'd be happy to contribute translations for. 😄 

Here's how things work:

* `scripts/docs maketranslations` - Sync translation files: this updates `.*po` files under `docs/locale/...` with any changes detected by Sphinx. Should be run to update translations after documentation has been edited.
* `SPHINX_LANGUAGE=<lang> scripts/docs build` - Build the `<lang>` version of the docs.
* `SPHINX_LANGUAGE=<lang> scripts/docs` - Serve (w/ reload, as for the English docs) the `<lang>` version of the docs. Any changes to `.*po` files are autodetected and trigger site reloads.

I wrote up translations for the home page to give an idea of what things look like. I'll do `api.md` and `contributing.md` as a follow-up.

Hosting the translated docs is a different matter and is not included in this PR (hence "Draft"), I'll discuss below.