### PR TITLE
Don't raise exceptions on graceless close cases

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -7,7 +7,6 @@ from anyio.abc import ByteStream, SocketAttribute
 from anyio.streams.tls import TLSAttribute, TLSStream
 
 from .._exceptions import (
-    CloseError,
     ConnectError,
     ConnectTimeout,
     ReadError,
@@ -101,8 +100,8 @@ class SocketStream(AsyncSocketStream):
         async with self.write_lock:
             try:
                 await self.stream.aclose()
-            except BrokenResourceError as exc:
-                raise CloseError from exc
+            except BrokenResourceError:
+                pass
 
     def is_readable(self) -> bool:
         sock = self.stream.extra(SocketAttribute.raw_socket)

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from .. import _utils
 from .._exceptions import (
-    CloseError,
     ConnectError,
     ConnectTimeout,
     ReadError,
@@ -186,7 +185,7 @@ class SocketStream(AsyncSocketStream):
         is_ssl = self.stream_writer.get_extra_info("ssl_object") is not None
 
         async with self.write_lock:
-            with map_exceptions({OSError: CloseError}):
+            try:
                 self.stream_writer.close()
                 if is_ssl:
                     # Give the connection a chance to write any data in the buffer,
@@ -196,6 +195,8 @@ class SocketStream(AsyncSocketStream):
                 if hasattr(self.stream_writer, "wait_closed"):
                     # Python 3.7+ only.
                     await self.stream_writer.wait_closed()  # type: ignore
+            except OSError:
+                pass
 
     def is_readable(self) -> bool:
         transport = self.stream_reader._transport  # type: ignore

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -6,7 +6,6 @@ from types import TracebackType
 from typing import Optional, Type
 
 from .._exceptions import (
-    CloseError,
     ConnectError,
     ConnectTimeout,
     ReadError,
@@ -74,8 +73,10 @@ class SyncSocketStream:
 
     def close(self) -> None:
         with self.write_lock:
-            with map_exceptions({socket.error: CloseError}):
+            try:
                 self.sock.close()
+            except socket.error:
+                pass
 
     def is_readable(self) -> bool:
         return is_socket_readable(self.sock.fileno())

--- a/httpcore/_backends/trio.py
+++ b/httpcore/_backends/trio.py
@@ -4,7 +4,6 @@ from typing import Optional
 import trio
 
 from .._exceptions import (
-    CloseError,
     ConnectError,
     ConnectTimeout,
     ReadError,
@@ -79,8 +78,10 @@ class SocketStream(AsyncSocketStream):
 
     async def aclose(self) -> None:
         async with self.write_lock:
-            with map_exceptions({trio.BrokenResourceError: CloseError}):
+            try:
                 await self.stream.aclose()
+            except trio.BrokenResourceError:
+                pass
 
     def is_readable(self) -> bool:
         # Adapted from: https://github.com/encode/httpx/pull/143#issuecomment-515202982


### PR DESCRIPTION
When a connection fails to close gracefully we're currently raising exceptions.
Actually I really don't think we want to be doing that.

An exception raised during connection close means that the connection wasn't terminated gracefully, but it will still be terminated. Raising exceptions here just means that:

* We can have cases where a request/response cycle runs to completion, but the client library will raise an exception because an unclean close occurred.
* We can have cases where an exception occurs on issuing a request against the connection pool, where we tear down an expired keep alive connection before issuing a fresh request, but an exception ends up being raised.
* We're closing a client and an exception is raised, that we really don't want to occur.
