### PR TITLE
More resiliant `is_readable` testing

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -106,7 +106,7 @@ class SocketStream(AsyncSocketStream):
 
     def is_readable(self) -> bool:
         sock = self.stream.extra(SocketAttribute.raw_socket)
-        return is_socket_readable(sock.fileno())
+        return is_socket_readable(sock)
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/asyncio.py
+++ b/httpcore/_backends/asyncio.py
@@ -3,7 +3,6 @@ import socket
 from ssl import SSLContext
 from typing import Optional
 
-from .. import _utils
 from .._exceptions import (
     CloseError,
     ConnectError,
@@ -15,6 +14,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._types import TimeoutDict
+from .._utils import is_socket_readable
 from .base import AsyncBackend, AsyncLock, AsyncSemaphore, AsyncSocketStream
 
 SSL_MONKEY_PATCH_APPLIED = False
@@ -200,10 +200,7 @@ class SocketStream(AsyncSocketStream):
     def is_readable(self) -> bool:
         transport = self.stream_reader._transport  # type: ignore
         sock: Optional[socket.socket] = transport.get_extra_info("socket")
-        # If socket was detached from the transport, most likely connection was reset.
-        # Hence make it readable to notify users to poll the socket.
-        # We'd expect the read operation to return `b""` indicating the socket closure.
-        return sock is None or _utils.is_socket_readable(sock.fileno())
+        return is_socket_readable(sock)
 
 
 class Lock(AsyncLock):

--- a/httpcore/_backends/curio.py
+++ b/httpcore/_backends/curio.py
@@ -132,7 +132,7 @@ class SocketStream(AsyncSocketStream):
         await self.socket.close()
 
     def is_readable(self) -> bool:
-        return is_socket_readable(self.socket.fileno())
+        return is_socket_readable(self.socket)
 
 
 class CurioBackend(AsyncBackend):

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -78,7 +78,7 @@ class SyncSocketStream:
                 self.sock.close()
 
     def is_readable(self) -> bool:
-        return is_socket_readable(self.sock.fileno())
+        return is_socket_readable(self.sock)
 
 
 class SyncLock:

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import os
 import select
+import socket
 import sys
 import typing
 
@@ -73,7 +74,7 @@ def exponential_backoff(factor: float) -> typing.Iterator[float]:
         yield factor * (2 ** (n - 2))
 
 
-def is_socket_readable(sock: Optional[socket.socket]) -> bool:
+def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     """
     Return whether a socket, as identifed by its file descriptor, is readable.
 

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -88,7 +88,7 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     # descriptor, we treat it as being readable, as if it the next read operation
     # on it is ready to return the terminating `b""`.
     sock_fd = None if sock is None else sock.fileno()
-    if sock_fd is None or sock_fd < -1:
+    if sock_fd is None or sock_fd < 0:
         return True
 
     # The implementation below was stolen from:

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -88,7 +88,7 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     # descriptor, we treat it as being readable, as if it the next read operation
     # on it is ready to return the terminating `b""`.
     sock_fd = None if sock is None else sock.fileno()
-    if sock_fd is None or sock_fd == -1:
+    if sock_fd is None or sock_fd < -1:
         return True
 
     # The implementation below was stolen from:

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -73,7 +73,7 @@ def exponential_backoff(factor: float) -> typing.Iterator[float]:
         yield factor * (2 ** (n - 2))
 
 
-def is_socket_readable(sock_fd: int) -> bool:
+def is_socket_readable(sock: Optional[socket.socket]) -> bool:
     """
     Return whether a socket, as identifed by its file descriptor, is readable.
 
@@ -82,6 +82,13 @@ def is_socket_readable(sock_fd: int) -> bool:
     """
     # NOTE: we want check for readability without actually attempting to read, because
     # we don't want to block forever if it's not readable.
+
+    # In the case that the socket no longer exists, or cannot return a file
+    # descriptor, we treat it as being readable, as if it the next read operation
+    # on it is ready to return the terminating `b""`.
+    sock_fd = None if sock is None else sock.fileno()
+    if sock_fd in (None, -1):
+        return True
 
     # The implementation below was stolen from:
     # https://github.com/python-trio/trio/blob/20ee2b1b7376db637435d80e266212a35837ddcc/trio/_socket.py#L471-L478

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -88,7 +88,7 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     # descriptor, we treat it as being readable, as if it the next read operation
     # on it is ready to return the terminating `b""`.
     sock_fd = None if sock is None else sock.fileno()
-    if sock_fd in (None, -1):
+    if sock_fd is None or sock_fd == -1:
         return True
 
     # The implementation below was stolen from:

--- a/tests/backend_tests/test_asyncio.py
+++ b/tests/backend_tests/test_asyncio.py
@@ -5,6 +5,11 @@ import pytest
 from httpcore._backends.asyncio import SocketStream
 
 
+class MockSocket:
+    def fileno(self):
+        return 1
+
+
 class TestSocketStream:
     class TestIsReadable:
         @pytest.mark.asyncio
@@ -18,7 +23,7 @@ class TestSocketStream:
         @pytest.mark.asyncio
         async def test_returns_true_when_socket_is_readable(self):
             stream_reader = MagicMock()
-            stream_reader._transport.get_extra_info.return_value = MagicMock()
+            stream_reader._transport.get_extra_info.return_value = MockSocket()
             sock_stream = SocketStream(stream_reader, MagicMock())
 
             with patch(


### PR DESCRIPTION
Refactoring for better resilience.

* More consistent use of `is_socket_readable` from the `_utils.py` module.
* Handles the case where `socket.fileno()` returns `-1`.