### PR TITLE
Raise ConnectError when server disconnects without sending a response

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -5,7 +5,7 @@ import h11
 
 from .._backends.auto import AsyncSocketStream
 from .._bytestreams import AsyncIteratorByteStream
-from .._exceptions import ConnectError, LocalProtocolError, RemoteProtocolError, map_exceptions
+from .._exceptions import LocalProtocolError, RemoteProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import AsyncByteStream, ConnectionState
@@ -177,7 +177,8 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
                 # perspective. Instead we handle this case distinctly and treat
                 # it as a ConnectError.
                 if data == b"" and self.h11_state.their_state == h11.SEND_RESPONSE:
-                    raise ConnectError("Server disconnected without sending response.")
+                    msg = "Server disconnected without sending a response."
+                    raise RemoteProtocolError(msg)
 
                 self.h11_state.receive_data(data)
             else:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -5,7 +5,7 @@ import h11
 
 from .._backends.sync import SyncSocketStream
 from .._bytestreams import IteratorByteStream
-from .._exceptions import LocalProtocolError, RemoteProtocolError, map_exceptions
+from .._exceptions import ConnectError, LocalProtocolError, RemoteProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import SyncByteStream, ConnectionState
@@ -167,6 +167,18 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
 
             if event is h11.NEED_DATA:
                 data = self.socket.read(self.READ_NUM_BYTES, timeout)
+
+                # If we feed this case through h11 we'll raise an exception like:
+                #
+                #     httpcore.RemoteProtocolError: can't handle event type
+                #     ConnectionClosed when role=SERVER and state=SEND_RESPONSE
+                #
+                # Which is accurate, but not very informative from an end-user
+                # perspective. Instead we handle this case distinctly and treat
+                # it as a ConnectError.
+                if data == b"" and self.h11_state.their_state == h11.SEND_RESPONSE:
+                    raise ConnectError("Server disconnected without sending response")
+
                 self.h11_state.receive_data(data)
             else:
                 assert event is not h11.NEED_DATA

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -5,7 +5,7 @@ import h11
 
 from .._backends.sync import SyncSocketStream
 from .._bytestreams import IteratorByteStream
-from .._exceptions import ConnectError, LocalProtocolError, RemoteProtocolError, map_exceptions
+from .._exceptions import LocalProtocolError, RemoteProtocolError, map_exceptions
 from .._types import URL, Headers, TimeoutDict
 from .._utils import get_logger
 from .base import SyncByteStream, ConnectionState
@@ -177,7 +177,8 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
                 # perspective. Instead we handle this case distinctly and treat
                 # it as a ConnectError.
                 if data == b"" and self.h11_state.their_state == h11.SEND_RESPONSE:
-                    raise ConnectError("Server disconnected without sending response")
+                    msg = "Server disconnected without sending a response."
+                    raise RemoteProtocolError(msg)
 
                 self.h11_state.receive_data(data)
             else:


### PR DESCRIPTION
Refs: https://github.com/encode/httpx/issues/1478

Currently if the server is in a listening state, then disconnects without sending a response, then users will see the following error...

```python
httpcore.RemoteProtocolError: can't handle event type ConnectionClosed when role=SERVER and state=SEND_RESPONSE
```

Which really isn't informative as an end-user. We probably would prefer to special case this particular transition as a `ConnectError`. It's not quite the same as a *network* `ConnectError`, since it occurs in cases where the connection was already established and hanging around, but is closed once it an incoming request is sent.

It's not super obvious if we want to treat this case as a `ConnectError` or something else. Here's our existing hierarchy in this area...

* NetworkError
  * ConnectError
  * ReadError
  * WriteError
  * CloseError
* ProtocolError
  * LocalProtocolError
  * RemoteProtocolError
