### PR TITLE
Additional HTTP/1.1 tests.

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -331,7 +331,6 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             return
 
         self._next_keepalive_check = now + min(1.0, self._keepalive_expiry)
-
         connections_to_close = set()
 
         for connection in self._get_all_connections():

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -254,7 +254,8 @@ class AsyncConnectionPool(AsyncHTTPTransport):
                 if connection.is_socket_readable():
                     # If the socket is readable while the connection is idle (meaning
                     # we don't expect the server to send any data), then the only valid
-                    # reason_phrase is that the other end has disconnected, which
+                    # reason is that the other end has disconnected, and is readable
+                    # because it is ready to return the b"" disconnect indicator, which
                     # means we should drop the connection too.
                     # (For a detailed run-through of what a "readable" socket is, and
                     # why this is the best thing for us to do here, see:
@@ -330,6 +331,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             return
 
         self._next_keepalive_check = now + min(1.0, self._keepalive_expiry)
+
         connections_to_close = set()
 
         for connection in self._get_all_connections():

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -133,12 +133,9 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
 
         http_version = b"HTTP/" + event.http_version
 
-        if hasattr(event.headers, "raw_items"):
-            # h11 version 0.11+ supports a `raw_items` interface to get the
-            # raw header casing, rather than the enforced lowercase headers.
-            headers = event.headers.raw_items()
-        else:
-            headers = event.headers
+        # h11 version 0.11+ supports a `raw_items` interface to get the
+        # raw header casing, rather than the enforced lowercase headers.
+        headers = event.headers.raw_items()
 
         return http_version, event.status_code, event.reason, headers
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -254,7 +254,8 @@ class SyncConnectionPool(SyncHTTPTransport):
                 if connection.is_socket_readable():
                     # If the socket is readable while the connection is idle (meaning
                     # we don't expect the server to send any data), then the only valid
-                    # reason_phrase is that the other end has disconnected, which
+                    # reason is that the other end has disconnected, and is readable
+                    # because it is ready to return the b"" disconnect indicator, which
                     # means we should drop the connection too.
                     # (For a detailed run-through of what a "readable" socket is, and
                     # why this is the best thing for us to do here, see:
@@ -337,6 +338,9 @@ class SyncConnectionPool(SyncHTTPTransport):
                 connection.state == ConnectionState.IDLE
                 and connection.expires_at is not None
                 and now >= connection.expires_at
+            ) or (
+                connection.state == ConnectionState.IDLE
+                and connection.is_socket_readable
             ):
                 connections_to_close.add(connection)
                 self._remove_from_pool(connection)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -338,9 +338,6 @@ class SyncConnectionPool(SyncHTTPTransport):
                 connection.state == ConnectionState.IDLE
                 and connection.expires_at is not None
                 and now >= connection.expires_at
-            ) or (
-                connection.state == ConnectionState.IDLE
-                and connection.is_socket_readable
             ):
                 connections_to_close.add(connection)
                 self._remove_from_pool(connection)

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -133,12 +133,9 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
 
         http_version = b"HTTP/" + event.http_version
 
-        if hasattr(event.headers, "raw_items"):
-            # h11 version 0.11+ supports a `raw_items` interface to get the
-            # raw header casing, rather than the enforced lowercase headers.
-            headers = event.headers.raw_items()
-        else:
-            headers = event.headers
+        # h11 version 0.11+ supports a `raw_items` interface to get the
+        # raw header casing, rather than the enforced lowercase headers.
+        headers = event.headers.raw_items()
 
         return http_version, event.status_code, event.reason, headers
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -24,4 +24,4 @@ fi
 set -x
 
 ${PREFIX}twine upload dist/*
-scripts/docs gh-deploy --push
+scripts/docs gh-deploy --push --force

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11==0.*", "sniffio==1.*"],
+    install_requires=["h11>=0.11,<0.13", "sniffio==1.*"],
     extras_require={
         "http2": ["h2>=3,<5"],
     },

--- a/tests/async_tests/test_http11.py
+++ b/tests/async_tests/test_http11.py
@@ -246,4 +246,4 @@ async def test_get_request_with_unclean_close_after_first_request() -> None:
                 stream=httpcore.ByteStream(b""),
                 extensions={},
             )
-        assert excinfo.value == "Server disconnected without sending a response."
+        assert str(excinfo.value) == "Server disconnected without sending a response."

--- a/tests/async_tests/test_http11.py
+++ b/tests/async_tests/test_http11.py
@@ -1,0 +1,249 @@
+import collections
+
+import pytest
+
+import httpcore
+from httpcore._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream
+
+
+class MockStream(AsyncSocketStream):
+    def __init__(self, http_buffer, disconnect):
+        self.read_buffer = collections.deque(http_buffer)
+        self.disconnect = disconnect
+
+    def get_http_version(self) -> str:
+        return "HTTP/1.1"
+
+    async def write(self, data, timeout):
+        pass
+
+    async def read(self, n, timeout):
+        return self.read_buffer.popleft()
+
+    async def aclose(self):
+        pass
+
+    def is_readable(self):
+        return self.disconnect
+
+
+class MockLock(AsyncLock):
+    async def release(self) -> None:
+        pass
+
+    async def acquire(self) -> None:
+        pass
+
+
+class MockBackend(AsyncBackend):
+    def __init__(self, http_buffer, disconnect=False):
+        self.http_buffer = http_buffer
+        self.disconnect = disconnect
+
+    async def open_tcp_stream(
+        self, hostname, port, ssl_context, timeout, *, local_address
+    ):
+        return MockStream(self.http_buffer, self.disconnect)
+
+    def create_lock(self):
+        return MockLock()
+
+
+@pytest.mark.trio
+async def test_get_request_with_connection_keepalive() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+        ]
+    )
+
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+        # We're sending a request with a standard keep-alive connection, so
+        # it will remain in the pool once we've sent the request.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+        # This second request will go out over the same connection.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+
+@pytest.mark.trio
+async def test_get_request_with_connection_close_header() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"",  # Terminate the connection.
+        ]
+    )
+
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+        # We're sending a request with 'Connection: close', so the connection
+        # does not remain in the pool once we've sent the request.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {}
+
+        # The second request will go out over a new connection.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {}
+
+
+@pytest.mark.trio
+async def test_get_request_with_socket_disconnect_between_requests() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+        ],
+        disconnect=True,
+    )
+
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+        # Send an initial request. We're using a standard keep-alive
+        # connection, so the connection remains in the pool after completion.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+        # On sending this second request, at the point of pool re-acquiry the
+        # socket indicates that it has disconnected, and we'll send the request
+        # over a new connection.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+
+@pytest.mark.trio
+async def test_get_request_with_unclean_close_after_first_request() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"",  # Terminate the connection.
+        ],
+    )
+
+    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+        # Send an initial request. We're using a standard keep-alive
+        # connection, so the connection remains in the pool after completion.
+        response = await http.handle_async_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = await stream.aread()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert await http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+        # At this point we successfully write another request, but the socket
+        # read returns `b""`, indicating a premature close.
+        with pytest.raises(httpcore.RemoteProtocolError) as excinfo:
+            await http.handle_async_request(
+                method=b"GET",
+                url=(b"http", b"example.org", None, b"/"),
+                headers=[(b"Host", b"example.org")],
+                stream=httpcore.ByteStream(b""),
+                extensions={},
+            )
+        assert excinfo.value == "Server disconnected without sending a response."

--- a/tests/sync_tests/test_http11.py
+++ b/tests/sync_tests/test_http11.py
@@ -246,4 +246,4 @@ def test_get_request_with_unclean_close_after_first_request() -> None:
                 stream=httpcore.ByteStream(b""),
                 extensions={},
             )
-        assert excinfo.value == "Server disconnected without sending a response."
+        assert str(excinfo.value) == "Server disconnected without sending a response."

--- a/tests/sync_tests/test_http11.py
+++ b/tests/sync_tests/test_http11.py
@@ -71,6 +71,8 @@ def test_get_request_with_connection_keepalive() -> None:
     )
 
     with httpcore.SyncConnectionPool(backend=backend) as http:
+        # We're sending a request with a standard keep-alive connection, so
+        # it will remain in the pool once we've sent the request.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
@@ -86,6 +88,7 @@ def test_get_request_with_connection_keepalive() -> None:
             "http://example.org": ["HTTP/1.1, IDLE"]
         }
 
+        # This second request will go out over the same connection.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
@@ -113,11 +116,13 @@ def test_get_request_with_connection_close_header() -> None:
             b"Content-Type: text/plain\r\n",
             b"\r\n",
             b"Hello, world.",
-            b"",
+            b"",  # Terminate the connection.
         ]
     )
 
     with httpcore.SyncConnectionPool(backend=backend) as http:
+        # We're sending a request with 'Connection: close', so the connection
+        # does not remain in the pool once we've sent the request.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
@@ -131,6 +136,7 @@ def test_get_request_with_connection_close_header() -> None:
         assert body == b"Hello, world."
         assert http.get_connection_info() == {}
 
+        # The second request will go out over a new connection.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
@@ -161,6 +167,8 @@ def test_get_request_with_socket_disconnect_between_requests() -> None:
     )
 
     with httpcore.SyncConnectionPool(backend=backend) as http:
+        # Send an initial request. We're using a standard keep-alive
+        # connection, so the connection remains in the pool after completion.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
@@ -172,12 +180,17 @@ def test_get_request_with_socket_disconnect_between_requests() -> None:
         body = stream.read()
         assert status_code == 200
         assert body == b"Hello, world."
-        assert http.get_connection_info() == {}
+        assert http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
 
+        # On sending this second request, at the point of pool re-acquiry the
+        # socket indicates that it has disconnected, and we'll send the request
+        # over a new connection.
         response = http.handle_request(
             method=b"GET",
             url=(b"http", b"example.org", None, b"/"),
-            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            headers=[(b"Host", b"example.org")],
             stream=httpcore.ByteStream(b""),
             extensions={},
         )
@@ -185,4 +198,52 @@ def test_get_request_with_socket_disconnect_between_requests() -> None:
         body = stream.read()
         assert status_code == 200
         assert body == b"Hello, world."
-        assert http.get_connection_info() == {}
+        assert http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+
+
+def test_get_request_with_unclean_close_after_first_request() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"",  # Terminate the connection.
+        ],
+    )
+
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        # Send an initial request. We're using a standard keep-alive
+        # connection, so the connection remains in the pool after completion.
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+        # At this point we successfully write another request, but the socket
+        # read returns `b""`, indicating a premature close.
+        with pytest.raises(httpcore.RemoteProtocolError) as excinfo:
+            http.handle_request(
+                method=b"GET",
+                url=(b"http", b"example.org", None, b"/"),
+                headers=[(b"Host", b"example.org")],
+                stream=httpcore.ByteStream(b""),
+                extensions={},
+            )
+        assert excinfo.value == "Server disconnected without sending a response."

--- a/tests/sync_tests/test_http11.py
+++ b/tests/sync_tests/test_http11.py
@@ -1,0 +1,188 @@
+import collections
+
+import pytest
+
+import httpcore
+from httpcore._backends.sync import SyncBackend, SyncLock, SyncSocketStream
+
+
+class MockStream(SyncSocketStream):
+    def __init__(self, http_buffer, disconnect):
+        self.read_buffer = collections.deque(http_buffer)
+        self.disconnect = disconnect
+
+    def get_http_version(self) -> str:
+        return "HTTP/1.1"
+
+    def write(self, data, timeout):
+        pass
+
+    def read(self, n, timeout):
+        return self.read_buffer.popleft()
+
+    def close(self):
+        pass
+
+    def is_readable(self):
+        return self.disconnect
+
+
+class MockLock(SyncLock):
+    def release(self) -> None:
+        pass
+
+    def acquire(self) -> None:
+        pass
+
+
+class MockBackend(SyncBackend):
+    def __init__(self, http_buffer, disconnect=False):
+        self.http_buffer = http_buffer
+        self.disconnect = disconnect
+
+    def open_tcp_stream(
+        self, hostname, port, ssl_context, timeout, *, local_address
+    ):
+        return MockStream(self.http_buffer, self.disconnect)
+
+    def create_lock(self):
+        return MockLock()
+
+
+
+def test_get_request_with_connection_keepalive() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+        ]
+    )
+
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {
+            "http://example.org": ["HTTP/1.1, IDLE"]
+        }
+
+
+
+def test_get_request_with_connection_close_header() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+            b"",
+        ]
+    )
+
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {}
+
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {}
+
+
+
+def test_get_request_with_socket_disconnect_between_requests() -> None:
+    backend = MockBackend(
+        http_buffer=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Date: Sat, 06 Oct 2049 12:34:56 GMT\r\n",
+            b"Server: Apache\r\n",
+            b"Content-Length: 13\r\n",
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"Hello, world.",
+        ],
+        disconnect=True,
+    )
+
+    with httpcore.SyncConnectionPool(backend=backend) as http:
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {}
+
+        response = http.handle_request(
+            method=b"GET",
+            url=(b"http", b"example.org", None, b"/"),
+            headers=[(b"Host", b"example.org"), (b"Connection", b"close")],
+            stream=httpcore.ByteStream(b""),
+            extensions={},
+        )
+        status_code, headers, stream, extensions = response
+        body = stream.read()
+        assert status_code == 200
+        assert body == b"Hello, world."
+        assert http.get_connection_info() == {}


### PR DESCRIPTION
I want to start broadening out our testing. The reliable way for us to really start to dig into all the corners is to use mock backends for the majority of our tests, so that we can exactly specify which bytes are returned, and when sockets should disconnect etc.

Taking a first pass at this with some simple HTTP/1.1 test cases.