### PR TITLE
Use select.select when select.poll is not available (#327)

### DIFF
--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -97,7 +97,7 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
 
     # Use select.select on Windows, and when poll is unavailable (e.g. eventlet is in use)
     # and select.poll everywhere else
-    if sys.platform == "win32" or getattr(socket, 'poll', None) is None:
+    if sys.platform == "win32" or getattr(socket, "poll", None) is None:
         rready, _, _ = select.select([sock_fd], [], [], 0)
         return bool(rready)
     p = select.poll()

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -97,7 +97,7 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
 
     # Use select.select on Windows, and when poll is unavailable and select.poll
     # everywhere else. (E.g. When eventlet is in use. See #327)
-    if sys.platform == "win32" or getattr(socket, "poll", None) is None:
+    if sys.platform == "win32" or getattr(select, "poll", None) is None:
         rready, _, _ = select.select([sock_fd], [], [], 0)
         return bool(rready)
     p = select.poll()

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -95,8 +95,8 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     # https://github.com/python-trio/trio/blob/20ee2b1b7376db637435d80e266212a35837ddcc/trio/_socket.py#L471-L478
     # See also: https://github.com/encode/httpcore/pull/193#issuecomment-703129316
 
-    # Use select.select on Windows, and when poll is unavailable (e.g. eventlet is in use)
-    # and select.poll everywhere else
+    # Use select.select on Windows, and when poll is unavailable and select.poll
+    # everywhere else. (E.g. When eventlet is in use. See #327)
     if sys.platform == "win32" or getattr(socket, "poll", None) is None:
         rready, _, _ = select.select([sock_fd], [], [], 0)
         return bool(rready)

--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -95,8 +95,9 @@ def is_socket_readable(sock: typing.Optional[socket.socket]) -> bool:
     # https://github.com/python-trio/trio/blob/20ee2b1b7376db637435d80e266212a35837ddcc/trio/_socket.py#L471-L478
     # See also: https://github.com/encode/httpcore/pull/193#issuecomment-703129316
 
-    # Use select.select on Windows, and select.poll everywhere else
-    if sys.platform == "win32":
+    # Use select.select on Windows, and when poll is unavailable (e.g. eventlet is in use)
+    # and select.poll everywhere else
+    if sys.platform == "win32" or getattr(socket, 'poll', None) is None:
         rready, _, _ = select.select([sock_fd], [], [], 0)
         return bool(rready)
     p = select.poll()


### PR DESCRIPTION
Fixes the case where socket has been monkey-patched by something like eventlet, which removes support for the poll() method.

Resolved #327