### PR TITLE
imprv: explicit the use of http1 headers style in http2 error

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -321,6 +321,9 @@ class AsyncHTTP2Stream:
                 break
 
         if authority is None:
+            for k, v in headers:
+                if k == b":authority":
+                    raise LocalProtocolError("HTTP/2 :authority header is forbidden, please use HTTP/1.1 style headers and replace it with Host: header")
             # Mirror the same error we'd see with `h11`, so that the behaviour
             # is consistent. Although we're dealing with an `:authority`
             # pseudo-header by this point, from an end-user perspective the issue

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -321,6 +321,9 @@ class SyncHTTP2Stream:
                 break
 
         if authority is None:
+            for k, v in headers:
+                if k == b":authority":
+                    raise LocalProtocolError("HTTP/2 :authority header is forbidden, please use HTTP/1.1 style headers and replace it with Host: header")
             # Mirror the same error we'd see with `h11`, so that the behaviour
             # is consistent. Although we're dealing with an `:authority`
             # pseudo-header by this point, from an end-user perspective the issue


### PR DESCRIPTION
Hi, 

This PR aims to improve http2 error message. In my case I'm developing a HTTP/2 only forward proxy agent. Thus the following assertion isn't fully true:
https://github.com/encode/httpcore/blob/958d9924b1b962a7e47991d0dfc670a2a7deb885/httpcore/_async/http2.py#L324-L327

At the first glance I thought it was due to an issue with the project, thus I had decided to include the required `host:` header at the same time of the existing `:authority` one.

Which leaded to a duplicated `:authority` header, hopefully caught by the underlaying `h2` library. 

To explicit the fact that httpcore use HTTP/1.1 styles headers, even for HTTP/2. In the case of a missing authority, an extra check is made to lookup for the expected HTTP/2 header, which will raise a custom HTTP/2 errors message if present.

BR, 