### PR TITLE
Use 'standard_compatible=False' for all TLS streams.

### DIFF
--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -43,6 +43,7 @@ class SocketStream(AsyncSocketStream):
                     self.stream,
                     ssl_context=ssl_context,
                     hostname=hostname.decode("ascii"),
+                    standard_compatible=False,
                 )
         except TimeoutError:
             raise ConnectTimeout from None


### PR DESCRIPTION
May close #361