### PR TITLE
Version 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.6 (June 15th, 2021)
+
+### Fixed
+
+- Close sockets when read or write timeouts occur. (Pull #365)
+
 ## 0.13.5 (June 14th, 2021)
 
 ### Fixed

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
     "WriteError",
     "WriteTimeout",
 ]
-__version__ = "0.13.5"
+__version__ = "0.13.6"
 
 __locals = locals()
 


### PR DESCRIPTION
## 0.13.6 (June 15th, 2021)

### Fixed

- Close sockets when read or write timeouts occur. (Pull #365)