### PR TITLE
Treat warnings as errors

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT
 from typing import List, Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
@@ -33,7 +33,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
@@ -33,7 +33,9 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        self._ssl_context = (
+            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,3 +1,4 @@
+import ssl
 from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
@@ -33,7 +34,9 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,9 +1,9 @@
-import ssl
 from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
 from .._exceptions import ConnectError, ConnectTimeout
+from .._ssl import default_ssl_context
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import exponential_backoff, get_logger, url_to_origin
 from .base import AsyncByteStream, AsyncHTTPTransport, NewConnectionRequired
@@ -35,7 +35,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
         self._ssl_context = (
-            ssl.create_default_context() if ssl_context is None else ssl_context
+            default_ssl_context() if ssl_context is None else ssl_context
         )
         self.socket = socket
         self._local_address = local_address

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,4 +1,4 @@
-from ssl import PROTOCOL_TLS_CLIENT, SSLContext
+from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSocketStream, AutoBackend
@@ -33,9 +33,7 @@ class AsyncHTTPConnection(AsyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = (
-            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
-        )
+        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,3 +1,4 @@
+import ssl
 import warnings
 from ssl import SSLContext
 from typing import (
@@ -125,7 +126,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_async_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import PROTOCOL_TLS_CLIENT, SSLContext
+from ssl import SSLContext
 from typing import (
     AsyncIterator,
     Callable,
@@ -125,9 +125,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_async_backend(backend)
 
-        self._ssl_context = (
-            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
-        )
+        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from typing import (
     AsyncIterator,
     Callable,
@@ -125,7 +125,9 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_async_backend(backend)
 
-        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        self._ssl_context = (
+            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import SSLContext
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT
 from typing import (
     AsyncIterator,
     Callable,
@@ -125,7 +125,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_async_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -1,4 +1,3 @@
-import ssl
 import warnings
 from ssl import SSLContext
 from typing import (
@@ -16,6 +15,7 @@ from typing import (
 from .._backends.auto import AsyncBackend, AsyncLock, AsyncSemaphore
 from .._backends.base import lookup_async_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
+from .._ssl import default_ssl_context
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -127,7 +127,7 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             backend = lookup_async_backend(backend)
 
         self._ssl_context = (
-            ssl.create_default_context() if ssl_context is None else ssl_context
+            default_ssl_context() if ssl_context is None else ssl_context
         )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -51,7 +51,7 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         self._exhausted_available_stream_ids = False
 
     def __repr__(self) -> str:
-        return f"<AsyncHTTP2Connection [{self._state}]>"
+        return f"<AsyncHTTP2Connection [{self._state.name}]>"
 
     def info(self) -> str:
         return f"HTTP/2, {self._state.name}, {len(self._streams)} streams"

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -163,7 +163,7 @@ class SyncBackend:
                     sock = ssl_context.wrap_socket(
                         sock, server_hostname=hostname.decode("ascii")
                     )
-            except OSError:
+            except BaseException:
                 sock.close()
                 raise
 

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -155,13 +155,17 @@ class SyncBackend:
 
         with map_exceptions(exc_map):
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.settimeout(connect_timeout)
-            sock.connect(path)
+            try:
+                sock.settimeout(connect_timeout)
+                sock.connect(path)
 
-            if ssl_context is not None:
-                sock = ssl_context.wrap_socket(
-                    sock, server_hostname=hostname.decode("ascii")
-                )
+                if ssl_context is not None:
+                    sock = ssl_context.wrap_socket(
+                        sock, server_hostname=hostname.decode("ascii")
+                    )
+            except OSError:
+                sock.close()
+                raise
 
             return SyncSocketStream(sock=sock)
 

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -155,8 +155,8 @@ class SyncBackend:
 
         with map_exceptions(exc_map):
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(connect_timeout)
             try:
-                sock.settimeout(connect_timeout)
                 sock.connect(path)
 
                 if ssl_context is not None:

--- a/httpcore/_ssl.py
+++ b/httpcore/_ssl.py
@@ -1,0 +1,9 @@
+import ssl
+
+import certifi
+
+
+def default_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    context.load_verify_locations(certifi.where())
+    return context

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
@@ -33,7 +33,9 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        self._ssl_context = (
+            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,9 +1,9 @@
-import ssl
 from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
 from .._exceptions import ConnectError, ConnectTimeout
+from .._ssl import default_ssl_context
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import exponential_backoff, get_logger, url_to_origin
 from .base import SyncByteStream, SyncHTTPTransport, NewConnectionRequired
@@ -35,7 +35,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
         self._ssl_context = (
-            ssl.create_default_context() if ssl_context is None else ssl_context
+            default_ssl_context() if ssl_context is None else ssl_context
         )
         self.socket = socket
         self._local_address = local_address

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,3 +1,4 @@
+import ssl
 from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
@@ -33,7 +34,9 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,4 +1,4 @@
-from ssl import PROTOCOL_TLS_CLIENT, SSLContext
+from ssl import SSLContext
 from typing import List, Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
@@ -33,9 +33,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = (
-            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
-        )
+        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,4 +1,4 @@
-from ssl import SSLContext
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT
 from typing import List, Optional, Tuple, cast
 
 from .._backends.sync import SyncBackend, SyncLock, SyncSocketStream, SyncBackend
@@ -33,7 +33,7 @@ class SyncHTTPConnection(SyncHTTPTransport):
         self._http2_enabled = http2
         self._keepalive_expiry = keepalive_expiry
         self._uds = uds
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
         self.socket = socket
         self._local_address = local_address
         self._retries = retries

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import SSLContext
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT
 from typing import (
     Iterator,
     Callable,
@@ -125,7 +125,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_sync_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,3 +1,4 @@
+import ssl
 import warnings
 from ssl import SSLContext
 from typing import (
@@ -125,7 +126,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_sync_backend(backend)
 
-        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
+        self._ssl_context = (
+            ssl.create_default_context() if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,4 +1,3 @@
-import ssl
 import warnings
 from ssl import SSLContext
 from typing import (
@@ -16,6 +15,7 @@ from typing import (
 from .._backends.sync import SyncBackend, SyncLock, SyncSemaphore
 from .._backends.base import lookup_sync_backend
 from .._exceptions import LocalProtocolError, PoolTimeout, UnsupportedProtocol
+from .._ssl import default_ssl_context
 from .._threadlock import ThreadLock
 from .._types import URL, Headers, Origin, TimeoutDict
 from .._utils import get_logger, origin_to_url_string, url_to_origin
@@ -127,7 +127,7 @@ class SyncConnectionPool(SyncHTTPTransport):
             backend = lookup_sync_backend(backend)
 
         self._ssl_context = (
-            ssl.create_default_context() if ssl_context is None else ssl_context
+            default_ssl_context() if ssl_context is None else ssl_context
         )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import PROTOCOL_TLS_CLIENT, SSLContext
+from ssl import SSLContext
 from typing import (
     Iterator,
     Callable,
@@ -125,9 +125,7 @@ class SyncConnectionPool(SyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_sync_backend(backend)
 
-        self._ssl_context = (
-            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
-        )
+        self._ssl_context = SSLContext() if ssl_context is None else ssl_context
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,5 +1,5 @@
 import warnings
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from typing import (
     Iterator,
     Callable,
@@ -125,7 +125,9 @@ class SyncConnectionPool(SyncHTTPTransport):
         if isinstance(backend, str):
             backend = lookup_sync_backend(backend)
 
-        self._ssl_context = SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        self._ssl_context = (
+            SSLContext(PROTOCOL_TLS_CLIENT) if ssl_context is None else ssl_context
+        )
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
         self._keepalive_expiry = keepalive_expiry

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -51,7 +51,7 @@ class SyncHTTP2Connection(SyncBaseHTTPConnection):
         self._exhausted_available_stream_ids = False
 
     def __repr__(self) -> str:
-        return f"<SyncHTTP2Connection [{self._state}]>"
+        return f"<SyncHTTP2Connection [{self._state.name}]>"
 
     def info(self) -> str:
         return f"HTTP/2, {self._state.name}, {len(self._streams)} streams"

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ pytest-asyncio==0.15.1
 trustme==0.8.0
 uvicorn==0.12.1; python_version < '3.7'
 certifi==2021.5.30
+types-certifi==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ pytest-trio==0.7.0
 pytest-asyncio==0.15.1
 trustme==0.8.0
 uvicorn==0.12.1; python_version < '3.7'
+certifi==2021.5.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,4 @@ pytest-trio==0.7.0
 pytest-asyncio==0.15.1
 trustme==0.8.0
 uvicorn==0.12.1; python_version < '3.7'
-certifi==2021.5.30
 types-certifi==0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,9 @@ skip = httpcore/_sync/,tests/sync_tests/
 
 [tool:pytest]
 addopts = -rxXs
+filterwarnings =
+  error
+  ignore:::hypercorn
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ skip = httpcore/_sync/,tests/sync_tests/
 addopts = -rxXs
 filterwarnings =
   error
-  ignore:::hypercorn
+  default:::hypercorn
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=get_packages("httpcore"),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["h11>=0.11,<0.13", "sniffio==1.*", "anyio==3.*"],
+    install_requires=["h11>=0.11,<0.13", "sniffio==1.*", "anyio==3.*", "certifi"],
     extras_require={
         "http2": ["h2>=3,<5"],
     },

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -54,10 +54,10 @@ async def test_http_request(backend: str, server: Server) -> None:
 
 @pytest.mark.anyio
 async def test_https_request(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     async with httpcore.AsyncConnectionPool(
-        backend=backend, ssl_context=localhost_ssl_context
+        backend=backend, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
@@ -98,10 +98,10 @@ async def test_request_unsupported_protocol(
 
 @pytest.mark.anyio
 async def test_http2_request(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     async with httpcore.AsyncConnectionPool(
-        backend=backend, http2=True, ssl_context=localhost_ssl_context
+        backend=backend, http2=True, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
@@ -182,10 +182,10 @@ async def test_http_request_reuse_connection(backend: str, server: Server) -> No
 
 @pytest.mark.anyio
 async def test_https_request_reuse_connection(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     async with httpcore.AsyncConnectionPool(
-        backend=backend, ssl_context=localhost_ssl_context
+        backend=backend, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
@@ -364,7 +364,7 @@ async def test_proxy_https_requests(
     proxy_mode: str,
     http2: bool,
     https_server: Server,
-    localhost_ssl_context: ssl.SSLContext,
+    ssl_context: ssl.SSLContext,
 ) -> None:
     max_connections = 1
     async with httpcore.AsyncHTTPProxy(
@@ -372,7 +372,7 @@ async def test_proxy_https_requests(
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         http2=http2,
-        ssl_context=localhost_ssl_context,
+        ssl_context=ssl_context,
     ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
@@ -425,13 +425,13 @@ async def test_connection_pool_get_connection_info(
     expected_during_idle: dict,
     backend: str,
     https_server: Server,
-    localhost_ssl_context: ssl.SSLContext,
+    ssl_context: ssl.SSLContext,
 ) -> None:
     async with httpcore.AsyncConnectionPool(
         http2=http2,
         keepalive_expiry=keepalive_expiry,
         backend=backend,
-        ssl_context=localhost_ssl_context,
+        ssl_context=ssl_context,
     ) as http:
         _, _, stream_1, _ = await http.handle_async_request(
             method=b"GET",

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -1,4 +1,5 @@
 import platform
+import ssl
 from typing import Tuple
 
 import pytest
@@ -52,8 +53,12 @@ async def test_http_request(backend: str, server: Server) -> None:
 
 
 @pytest.mark.anyio
-async def test_https_request(backend: str, https_server: Server) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+async def test_https_request(
+    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+) -> None:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend, ssl_context=localhost_ssl_context
+    ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
             url=(b"https", *https_server.netloc, b"/"),
@@ -92,8 +97,12 @@ async def test_request_unsupported_protocol(
 
 
 @pytest.mark.anyio
-async def test_http2_request(backend: str, https_server: Server) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend, http2=True) as http:
+async def test_http2_request(
+    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+) -> None:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend, http2=True, ssl_context=localhost_ssl_context
+    ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
             url=(b"https", *https_server.netloc, b"/"),
@@ -173,9 +182,11 @@ async def test_http_request_reuse_connection(backend: str, server: Server) -> No
 
 @pytest.mark.anyio
 async def test_https_request_reuse_connection(
-    backend: str, https_server: Server
+    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
 ) -> None:
-    async with httpcore.AsyncConnectionPool(backend=backend) as http:
+    async with httpcore.AsyncConnectionPool(
+        backend=backend, ssl_context=localhost_ssl_context
+    ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
             url=(b"https", *https_server.netloc, b"/"),
@@ -353,6 +364,7 @@ async def test_proxy_https_requests(
     proxy_mode: str,
     http2: bool,
     https_server: Server,
+    localhost_ssl_context: ssl.SSLContext,
 ) -> None:
     max_connections = 1
     async with httpcore.AsyncHTTPProxy(
@@ -360,6 +372,7 @@ async def test_proxy_https_requests(
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         http2=http2,
+        ssl_context=localhost_ssl_context,
     ) as http:
         status_code, headers, stream, extensions = await http.handle_async_request(
             method=b"GET",
@@ -412,9 +425,13 @@ async def test_connection_pool_get_connection_info(
     expected_during_idle: dict,
     backend: str,
     https_server: Server,
+    localhost_ssl_context: ssl.SSLContext,
 ) -> None:
     async with httpcore.AsyncConnectionPool(
-        http2=http2, keepalive_expiry=keepalive_expiry, backend=backend
+        http2=http2,
+        keepalive_expiry=keepalive_expiry,
+        backend=backend,
+        ssl_context=localhost_ssl_context,
     ) as http:
         _, _, stream_1, _ = await http.handle_async_request(
             method=b"GET",

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -302,9 +302,6 @@ async def test_http_proxy(
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
 @pytest.mark.trio
-# Filter out asyncio module resource warning, convert other warnings to errors.
-@pytest.mark.filterwarnings("ignore::ResourceWarning:asyncio")
-@pytest.mark.filterwarnings("error")
 async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(
     proxy_server: URL,
     server: Server,

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -302,9 +302,7 @@ async def test_http_proxy(
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
 @pytest.mark.trio
-# Filter out ssl module deprecation warnings and asyncio module resource warning,
-# convert other warnings to errors.
-@pytest.mark.filterwarnings("ignore:.*(SSLContext|PROTOCOL_TLS):DeprecationWarning")
+# Filter out asyncio module resource warning, convert other warnings to errors.
 @pytest.mark.filterwarnings("ignore::ResourceWarning:asyncio")
 @pytest.mark.filterwarnings("error")
 async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,10 @@ import threading
 import time
 import typing
 
-import certifi
 import pytest
 import trustme
 
+from httpcore._ssl import default_ssl_context
 from httpcore._types import URL
 
 from .utils import HypercornServer, LiveServer, Server, http_proxy_server
@@ -146,11 +146,9 @@ def localhost_cert_private_key_file(
 def ssl_context(
     cert_authority: trustme.CA, localhost_cert: trustme.LeafCert
 ) -> ssl.SSLContext:
-    ssl_context = ssl.create_default_context()
+    ssl_context = default_ssl_context()
 
-    if hypercorn is None:
-        ssl_context.load_verify_locations(certifi.where())
-    else:
+    if hypercorn is not None:
         cert_authority.configure_trust(ssl_context)
         localhost_cert.configure_cert(ssl_context)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import ssl
 import threading
 import time
 import typing
@@ -124,6 +125,16 @@ def localhost_cert(cert_authority: trustme.CA) -> trustme.LeafCert:
 def localhost_cert_path(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
     with localhost_cert.private_key_and_cert_chain_pem.tempfile() as tmp:
         yield tmp
+
+
+@pytest.fixture(scope="session")
+def localhost_ssl_context(
+    cert_authority: trustme.CA, localhost_cert: trustme.LeafCert
+) -> ssl.SSLContext:
+    ssl_context = ssl.create_default_context()
+    cert_authority.configure_trust(ssl_context)
+    localhost_cert.configure_cert(ssl_context)
+    return ssl_context
 
 
 @pytest.fixture(scope="session")

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -302,9 +302,7 @@ def test_http_proxy(
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
 
-# Filter out ssl module deprecation warnings and asyncio module resource warning,
-# convert other warnings to errors.
-@pytest.mark.filterwarnings("ignore:.*(SSLContext|PROTOCOL_TLS):DeprecationWarning")
+# Filter out asyncio module resource warning, convert other warnings to errors.
 @pytest.mark.filterwarnings("ignore::ResourceWarning:asyncio")
 @pytest.mark.filterwarnings("error")
 def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -302,9 +302,6 @@ def test_http_proxy(
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
 
-# Filter out asyncio module resource warning, convert other warnings to errors.
-@pytest.mark.filterwarnings("ignore::ResourceWarning:asyncio")
-@pytest.mark.filterwarnings("error")
 def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(
     proxy_server: URL,
     server: Server,

--- a/tests/sync_tests/test_interfaces.py
+++ b/tests/sync_tests/test_interfaces.py
@@ -54,10 +54,10 @@ def test_http_request(backend: str, server: Server) -> None:
 
 
 def test_https_request(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     with httpcore.SyncConnectionPool(
-        backend=backend, ssl_context=localhost_ssl_context
+        backend=backend, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = http.handle_request(
             method=b"GET",
@@ -98,10 +98,10 @@ def test_request_unsupported_protocol(
 
 
 def test_http2_request(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     with httpcore.SyncConnectionPool(
-        backend=backend, http2=True, ssl_context=localhost_ssl_context
+        backend=backend, http2=True, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = http.handle_request(
             method=b"GET",
@@ -182,10 +182,10 @@ def test_http_request_reuse_connection(backend: str, server: Server) -> None:
 
 
 def test_https_request_reuse_connection(
-    backend: str, https_server: Server, localhost_ssl_context: ssl.SSLContext
+    backend: str, https_server: Server, ssl_context: ssl.SSLContext
 ) -> None:
     with httpcore.SyncConnectionPool(
-        backend=backend, ssl_context=localhost_ssl_context
+        backend=backend, ssl_context=ssl_context
     ) as http:
         status_code, headers, stream, extensions = http.handle_request(
             method=b"GET",
@@ -364,7 +364,7 @@ def test_proxy_https_requests(
     proxy_mode: str,
     http2: bool,
     https_server: Server,
-    localhost_ssl_context: ssl.SSLContext,
+    ssl_context: ssl.SSLContext,
 ) -> None:
     max_connections = 1
     with httpcore.SyncHTTPProxy(
@@ -372,7 +372,7 @@ def test_proxy_https_requests(
         proxy_mode=proxy_mode,
         max_connections=max_connections,
         http2=http2,
-        ssl_context=localhost_ssl_context,
+        ssl_context=ssl_context,
     ) as http:
         status_code, headers, stream, extensions = http.handle_request(
             method=b"GET",
@@ -425,13 +425,13 @@ def test_connection_pool_get_connection_info(
     expected_during_idle: dict,
     backend: str,
     https_server: Server,
-    localhost_ssl_context: ssl.SSLContext,
+    ssl_context: ssl.SSLContext,
 ) -> None:
     with httpcore.SyncConnectionPool(
         http2=http2,
         keepalive_expiry=keepalive_expiry,
         backend=backend,
-        ssl_context=localhost_ssl_context,
+        ssl_context=ssl_context,
     ) as http:
         _, _, stream_1, _ = http.handle_request(
             method=b"GET",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,7 +179,7 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
         finally:
             if proc is not None:
                 proc.kill()
-                proc.wait()
+                proc.communicate()
 
 
 @contextlib.contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,6 +179,7 @@ def http_proxy_server(proxy_host: str, proxy_port: int):
         finally:
             if proc is not None:
                 proc.kill()
+                proc.wait()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes https://github.com/encode/httpcore/issues/384

Follow up #368

- Use `ssl.create_default_context()` instead `ssl.SSLContext()` to avoid some ssl deprecation warnings
- Add a `ssl_context` fixture that trusts our self issued certificates for localhost
- Minor fix for the enum repr change in 3.10
- Close the UDS socket if connection error