### PR TITLE
Add an unclosed warning when connection is being destroyed

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -245,8 +245,8 @@ class AsyncConnectionPool(AsyncHTTPTransport):
             except BaseException:  # noqa: PIE786
                 # See https://github.com/encode/httpcore/pull/305 for motivation
                 # behind catching 'BaseException' rather than 'Exception' here.
-                logger.trace("remove from pool connection=%r", connection)
                 await self._remove_from_pool(connection)
+                await connection.aclose()
                 raise
 
         status_code, headers, stream, extensions = response

--- a/httpcore/_async/http.py
+++ b/httpcore/_async/http.py
@@ -46,4 +46,4 @@ class AsyncBaseHTTPConnection(AsyncHTTPTransport):
 
     def __del__(self) -> None:
         if not self.is_closed():
-            warnings.warn(f"Unclosed {self!r} {id(self)}")
+            warnings.warn(f"Unclosed {self!r}")

--- a/httpcore/_async/http.py
+++ b/httpcore/_async/http.py
@@ -1,3 +1,4 @@
+import warnings
 from ssl import SSLContext
 
 from .._backends.auto import AsyncSocketStream
@@ -6,6 +7,8 @@ from .base import AsyncHTTPTransport
 
 
 class AsyncBaseHTTPConnection(AsyncHTTPTransport):
+    socket: AsyncSocketStream
+
     def info(self) -> str:
         raise NotImplementedError()  # pragma: nocover
 

--- a/httpcore/_async/http.py
+++ b/httpcore/_async/http.py
@@ -40,3 +40,7 @@ class AsyncBaseHTTPConnection(AsyncHTTPTransport):
         Upgrade the underlying socket to TLS.
         """
         raise NotImplementedError()  # pragma: nocover
+
+    def __del__(self) -> None:
+        if not self.is_closed():
+            warnings.warn(f"Unclosed {self!r} {id(self)}")

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -266,4 +266,5 @@ class AsyncHTTP11Connection(AsyncBaseHTTPConnection):
                 event = h11.ConnectionClosed()
                 self._h11_state.send(event)
 
-            await self.socket.aclose()
+            if self.socket is not None:
+                await self.socket.aclose()

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -210,7 +210,8 @@ class AsyncHTTP2Connection(AsyncBaseHTTPConnection):
         if self._state != ConnectionState.CLOSED:
             self._state = ConnectionState.CLOSED
 
-            await self.socket.aclose()
+            if self.socket is not None:
+                await self.socket.aclose()
 
     async def wait_for_outgoing_flow(self, stream_id: int, timeout: TimeoutDict) -> int:
         """

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -292,7 +292,6 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 extensions=extensions,
             )
         except BaseException:  # noqa: PIE786
-            # TODO add test case
             await self._remove_from_pool(connection)
             await connection.aclose()
             raise

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -268,6 +268,9 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             )
             await self._add_to_pool(connection, timeout)
 
+            proxy_connection.connection.socket = None  # type: ignore
+            await proxy_connection.aclose()
+
         # Once the connection has been established we can send requests on
         # it as normal.
         (

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -245,8 +245,8 @@ class SyncConnectionPool(SyncHTTPTransport):
             except BaseException:  # noqa: PIE786
                 # See https://github.com/encode/httpcore/pull/305 for motivation
                 # behind catching 'BaseException' rather than 'Exception' here.
-                logger.trace("remove from pool connection=%r", connection)
                 self._remove_from_pool(connection)
+                connection.close()
                 raise
 
         status_code, headers, stream, extensions = response

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -1,3 +1,4 @@
+import warnings
 from ssl import SSLContext
 
 from .._backends.sync import SyncSocketStream
@@ -6,6 +7,8 @@ from .base import SyncHTTPTransport
 
 
 class SyncBaseHTTPConnection(SyncHTTPTransport):
+    socket: SyncSocketStream
+
     def info(self) -> str:
         raise NotImplementedError()  # pragma: nocover
 

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -46,4 +46,4 @@ class SyncBaseHTTPConnection(SyncHTTPTransport):
 
     def __del__(self) -> None:
         if not self.is_closed():
-            warnings.warn(f"Unclosed {self!r} {id(self)}")
+            warnings.warn(f"Unclosed {self!r}")

--- a/httpcore/_sync/http.py
+++ b/httpcore/_sync/http.py
@@ -40,3 +40,7 @@ class SyncBaseHTTPConnection(SyncHTTPTransport):
         Upgrade the underlying socket to TLS.
         """
         raise NotImplementedError()  # pragma: nocover
+
+    def __del__(self) -> None:
+        if not self.is_closed():
+            warnings.warn(f"Unclosed {self!r} {id(self)}")

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -266,4 +266,5 @@ class SyncHTTP11Connection(SyncBaseHTTPConnection):
                 event = h11.ConnectionClosed()
                 self._h11_state.send(event)
 
-            self.socket.close()
+            if self.socket is not None:
+                self.socket.close()

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -210,7 +210,8 @@ class SyncHTTP2Connection(SyncBaseHTTPConnection):
         if self._state != ConnectionState.CLOSED:
             self._state = ConnectionState.CLOSED
 
-            self.socket.close()
+            if self.socket is not None:
+                self.socket.close()
 
     def wait_for_outgoing_flow(self, stream_id: int, timeout: TimeoutDict) -> int:
         """

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -292,7 +292,6 @@ class SyncHTTPProxy(SyncConnectionPool):
                 extensions=extensions,
             )
         except BaseException:  # noqa: PIE786
-            # TODO add test case
             self._remove_from_pool(connection)
             connection.close()
             raise

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -268,6 +268,9 @@ class SyncHTTPProxy(SyncConnectionPool):
             )
             self._add_to_pool(connection, timeout)
 
+            proxy_connection.connection.socket = None  # type: ignore
+            proxy_connection.close()
+
         # Once the connection has been established we can send requests on
         # it as normal.
         (

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -167,14 +167,19 @@ class SyncHTTPProxy(SyncConnectionPool):
         url = self.proxy_origin + (target,)
         headers = merge_headers(self.proxy_headers, headers)
 
-        (
-            status_code,
-            headers,
-            stream,
-            extensions,
-        ) = connection.handle_request(
-            method, url, headers=headers, stream=stream, extensions=extensions
-        )
+        try:
+            (
+                status_code,
+                headers,
+                stream,
+                extensions,
+            ) = connection.handle_request(
+                method, url, headers=headers, stream=stream, extensions=extensions
+            )
+        except BaseException:  # noqa: PIE786
+            self._remove_from_pool(connection)
+            connection.close()
+            raise
 
         wrapped_stream = ResponseByteStream(
             stream, connection=connection, callback=self._response_closed
@@ -273,18 +278,24 @@ class SyncHTTPProxy(SyncConnectionPool):
 
         # Once the connection has been established we can send requests on
         # it as normal.
-        (
-            status_code,
-            headers,
-            stream,
-            extensions,
-        ) = connection.handle_request(
-            method,
-            url,
-            headers=headers,
-            stream=stream,
-            extensions=extensions,
-        )
+        try:
+            (
+                status_code,
+                headers,
+                stream,
+                extensions,
+            ) = connection.handle_request(
+                method,
+                url,
+                headers=headers,
+                stream=stream,
+                extensions=extensions,
+            )
+        except BaseException:  # noqa: PIE786
+            # TODO add test case
+            self._remove_from_pool(connection)
+            connection.close()
+            raise
 
         wrapped_stream = ResponseByteStream(
             stream, connection=connection, callback=self._response_closed

--- a/tests/async_tests/test_interfaces.py
+++ b/tests/async_tests/test_interfaces.py
@@ -302,16 +302,15 @@ async def test_http_proxy(
 @pytest.mark.parametrize("proxy_mode", ["DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"])
 @pytest.mark.parametrize("protocol,port", [(b"http", 80), (b"https", 443)])
 @pytest.mark.trio
-async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_to_pool(
+async def test_proxy_connection_does_not_leak(
     proxy_server: URL,
-    server: Server,
     proxy_mode: str,
     protocol: bytes,
     port: int,
 ):
     async with httpcore.AsyncHTTPProxy(proxy_server, proxy_mode=proxy_mode) as http:
         for _ in range(100):
-            try:
+            with pytest.raises((httpcore.ProxyError, httpcore.RemoteProtocolError)):
                 _ = await http.handle_async_request(
                     method=b"GET",
                     url=(protocol, b"blockedhost.example.com", port, b"/"),
@@ -319,8 +318,7 @@ async def test_proxy_socket_does_not_leak_when_the_connection_hasnt_been_added_t
                     stream=httpcore.ByteStream(b""),
                     extensions={},
                 )
-            except (httpcore.ProxyError, httpcore.RemoteProtocolError):
-                pass
+            assert len(await http.get_connection_info()) == 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Based on #378 
- Add a warning to `BaseHTTPConnection.__del__`
- Ensure connections are closed in some cases