### PR TITLE
Remove `--use-feature` switch from pip install command

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,5 @@ else
     PIP="pip"
 fi
 
-"$PIP" install -U "pip >= 20.2" setuptools wheel
-"$PIP" install --use-feature="2020-resolver" -r "$REQUIREMENTS"
+"$PIP" install -U "pip >= 21.0" setuptools wheel
+"$PIP" install -r "$REQUIREMENTS"


### PR DESCRIPTION
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```