### PR TITLE
Fix invalid scheme errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.6 (June 15th, 2021)
+
+### Fixed
+
+- Close sockets when read or write timeouts occur. (Pull #365)
+
 ## 0.13.5 (June 14th, 2021)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Master
+
+- Fix broken error messaging when URL scheme is missing, or a non HTTP(S) scheme is used.
+
 ## 0.13.6 (June 15th, 2021)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Master
 
-- Fix broken error messaging when URL scheme is missing, or a non HTTP(S) scheme is used.
+- Fix broken error messaging when URL scheme is missing, or a non HTTP(S) scheme is used. (Pull #403)
 
 ## 0.13.6 (June 15th, 2021)
 

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
     "WriteError",
     "WriteTimeout",
 ]
-__version__ = "0.13.5"
+__version__ = "0.13.6"
 
 __locals = locals()
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -195,19 +195,16 @@ class AsyncConnectionPool(AsyncHTTPTransport):
         stream: AsyncByteStream,
         extensions: dict,
     ) -> Tuple[int, Headers, AsyncByteStream, dict]:
+        if not url[0]:
+            raise UnsupportedProtocol(
+                "Request URL missing either an 'http://' or 'https://' protocol."
+            )
+
         if url[0] not in (b"http", b"https"):
-            scheme = url[0].decode("latin-1")
-            host = url[1].decode("latin-1")
-            if scheme == "":
-                raise UnsupportedProtocol(
-                    f"The request to '://{host}/' is missing either an 'http://' \
-                        or 'https://' protocol."
-                )
-            else:
-                raise UnsupportedProtocol(
-                    f"The request to '{scheme}://{host}' has \
-                        an unsupported protocol {scheme!r}"
-                )
+            protocol = url[0].decode("ascii")
+            raise UnsupportedProtocol(
+                f"Request URL has an unsupported protocol '{protocol}://'."
+            )
 
         if not url[1]:
             raise LocalProtocolError("Missing hostname in URL.")

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -195,19 +195,16 @@ class SyncConnectionPool(SyncHTTPTransport):
         stream: SyncByteStream,
         extensions: dict,
     ) -> Tuple[int, Headers, SyncByteStream, dict]:
+        if not url[0]:
+            raise UnsupportedProtocol(
+                "Request URL missing either an 'http://' or 'https://' protocol."
+            )
+
         if url[0] not in (b"http", b"https"):
-            scheme = url[0].decode("latin-1")
-            host = url[1].decode("latin-1")
-            if scheme == "":
-                raise UnsupportedProtocol(
-                    f"The request to '://{host}/' is missing either an 'http://' \
-                        or 'https://' protocol."
-                )
-            else:
-                raise UnsupportedProtocol(
-                    f"The request to '{scheme}://{host}' has \
-                        an unsupported protocol {scheme!r}"
-                )
+            protocol = url[0].decode("ascii")
+            raise UnsupportedProtocol(
+                f"Request URL has an unsupported protocol '{protocol}://'."
+            )
 
         if not url[1]:
             raise LocalProtocolError("Missing hostname in URL.")


### PR DESCRIPTION
The formatting in #354 of the error messages was all wrong. This pull request still retains the neater error messaging, but doesn't mirror back the URL string that was passed. (Since it's actually a little bit awkward to get right.)