### PR TITLE
Version 0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Master
+## 0.13.7 (September 13th, 2021)
 
 - Fix broken error messaging when URL scheme is missing, or a non HTTP(S) scheme is used. (Pull #403)
 

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
     "WriteError",
     "WriteTimeout",
 ]
-__version__ = "0.13.6"
+__version__ = "0.13.7"
 
 __locals = locals()
 


### PR DESCRIPTION
## 0.13.7 (September 13th, 2021)

- Fix broken error messaging when URL scheme is missing, or a non HTTP(S) scheme is used. (Pull #403)
