### PR TITLE
Version 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.14.0
+## 0.14.0 (November 11th, 2021)
 
 The 0.14 release is a complete reworking of `httpcore`, comprehensively addressing some underlying issues in the connection pooling, as well as substantially redesigning the API to be more user friendly.
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Some things HTTP Core does do:
 For HTTP/1.1 only support, install with...
 
 ```shell
-$ pip install git+https://github.com/encode/httpcore
+$ pip install httpcore
 ```
 
 For HTTP/1.1 and HTTP/2 support, install with...
 
 ```shell
-$ pip install git+https://github.com/encode/httpcore[http2]
+$ pip install httpcore[http2]
 ```
 
 # Sending requests

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,13 +28,13 @@ Some things HTTP Core does do:
 For HTTP/1.1 only support, install with...
 
 ```shell
-$ pip install git+https://github.com/encode/httpcore
+$ pip install httpcore
 ```
 
 For HTTP/1.1 and HTTP/2 support, install with...
 
 ```shell
-$ pip install git+https://github.com/encode/httpcore[http2]
+$ pip install httpcore[http2]
 ```
 
 ## Example


### PR DESCRIPTION
Release draft: https://github.com/encode/httpcore/releases/tag/untagged-1e559d0bc081ba647499

---

## 0.14.0 (November 11th, 2021)

The 0.14 release is a complete reworking of `httpcore`, comprehensively addressing some underlying issues in the connection pooling, as well as substantially redesigning the API to be more user friendly.

Some of the lower-level API design also makes the components more easily testable in isolation, and the package now has 100% test coverage.

See [discussion #419](https://github.com/encode/httpcore/discussions/419) for a little more background.

There's some other neat bits in there too, such as the "trace" extension, which gives a hook into inspecting the internal events that occur during the request/response cycle. This extension is needed for the HTTPX cli, in order to...

* Log the point at which the connection is established, and the IP/port on which it is made.
* Determine if the outgoing request should log as HTTP/1.1 or HTTP/2, rather than having to assume it's HTTP/2 if the --http2 flag was passed. (Which may not actually be true.)
* Log SSL version info / certificate info.

Note that `curio` support is not currently available in 0.14.0. If you're using `httpcore` with `curio` please get in touch, so we can assess if we ought to prioritize it as a feature or not.