### PR TITLE
Version 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.14.1 (November 12th, 2021)
+
+- `max_connections` becomes optional. (Pull #429)
+- `certifi` is now included in the install dependancies. (Pull #428)
+- `h2` is now strictly optional. (Pull #428)
+
 ## 0.14.0 (November 11th, 2021)
 
 The 0.14 release is a complete reworking of `httpcore`, comprehensively addressing some underlying issues in the connection pooling, as well as substantially redesigning the API to be more user friendly.

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -78,7 +78,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 
 __locals = locals()


### PR DESCRIPTION
## 0.14.1 (November 12th, 2021)

- `max_connections` becomes optional. (Pull #429)
- `certifi` is now included in the install dependancies. (Pull #428)
- `h2` is now strictly optional. (Pull #428)