### PR TITLE
Version 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.14.2 (November 16th, 2021)
+
+- Failed connections no longer remain in the pool. (Pull #433)
+
 ## 0.14.1 (November 12th, 2021)
 
 - `max_connections` becomes optional. (Pull #429)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -78,7 +78,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"
 
 
 __locals = locals()


### PR DESCRIPTION
## 0.14.2 (November 16th, 2021)

- Failed connections no longer remain in the pool. (Pull #433)