### PR TITLE
Use RuntimeError for HTTP/2 request made to incorrect origin on connection.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -56,7 +56,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     async def handle_async_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
-            raise ConnectionNotAvailable(
+            # This cannot occur in normal operation, since the connection pool
+            # will only send requests on connections that handle them.
+            # It's in place simply for resilience as a guard against incorrect
+            # usage, for anyone working directly with httpcore connections.
+            raise RuntimeError(
                 f"Attempted to send request to {request.url.origin} on connection "
                 f"to {self._origin}"
             )

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -56,7 +56,11 @@ class HTTP2Connection(ConnectionInterface):
 
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
-            raise ConnectionNotAvailable(
+            # This cannot occur in normal operation, since the connection pool
+            # will only send requests on connections that handle them.
+            # It's in place simply for resilience as a guard against incorrect
+            # usage, for anyone working directly with httpcore connections.
+            raise RuntimeError(
                 f"Attempted to send request to {request.url.origin} on connection "
                 f"to {self._origin}"
             )

--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -229,5 +229,5 @@ async def test_http2_request_to_incorrect_origin():
     origin = Origin(b"https", b"example.com", 443)
     stream = AsyncMockStream([])
     async with AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
-        with pytest.raises(ConnectionNotAvailable):
+        with pytest.raises(RuntimeError):
             await conn.request("GET", "https://other.com/")

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -229,5 +229,5 @@ def test_http2_request_to_incorrect_origin():
     origin = Origin(b"https", b"example.com", 443)
     stream = MockStream([])
     with HTTP2Connection(origin=origin, stream=stream) as conn:
-        with pytest.raises(ConnectionNotAvailable):
+        with pytest.raises(RuntimeError):
             conn.request("GET", "https://other.com/")


### PR DESCRIPTION
This is just a bit of internal refactoring, that isn't actually ever hit in normal operation.

This difference in exception would only be visible is a developer was working with `HTTP2Connection` directly, and attempted to send a request to an incorrect origin. Given that this is just an internal guard-rail bit of defensive programming, it really ought to be a `RuntimeError`. The `ConnectionNotAvailable` special case is used for when we need the connection pool to re-attempt a request.

This changes now matches the exception used in the equivalent HTTP/1.1 case.