### PR TITLE
Fix misnamed test cases

### DIFF
--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -85,7 +85,7 @@ async def test_http2_connection_post_request():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_with_remote_protocol_error():
+async def test_http2_connection_with_remote_protocol_error():
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -98,7 +98,7 @@ async def test_http11_connection_with_remote_protocol_error():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_with_stream_cancelled():
+async def test_http2_connection_with_stream_cancelled():
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -85,7 +85,7 @@ def test_http2_connection_post_request():
 
 
 
-def test_http11_connection_with_remote_protocol_error():
+def test_http2_connection_with_remote_protocol_error():
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -98,7 +98,7 @@ def test_http11_connection_with_remote_protocol_error():
 
 
 
-def test_http11_connection_with_stream_cancelled():
+def test_http2_connection_with_stream_cancelled():
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.


### PR DESCRIPTION
Fix up some HTTP/2 test cases with `test_http11_*` names. 🤭