### PR TITLE
Fix race condition when removing closed connections from the pool

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -273,7 +273,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
             # Update the state of the connection pool.
             self._requests.remove(status)
 
-            if connection.is_closed():
+            if connection.is_closed() and connection in self._pool:
                 self._pool.remove(connection)
 
             # Since we've had a response closed, it's possible we'll now be able

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -273,7 +273,7 @@ class ConnectionPool(RequestInterface):
             # Update the state of the connection pool.
             self._requests.remove(status)
 
-            if connection.is_closed():
+            if connection.is_closed() and connection in self._pool:
                 self._pool.remove(connection)
 
             # Since we've had a response closed, it's possible we'll now be able


### PR DESCRIPTION
When there's more than one request made (or queued) on a connection, and the connection is closed, we should guard against trying to pop it from the pool twice. There's no good reason to assume that  of the multiple calls to `response_closed()` that only the final call will happen to satisfy `connection.is_closed()`.