### PR TITLE
Fix HTTP/2 race condition waiting on stream events.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -231,19 +231,27 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         self, request: Request, stream_id: int
     ) -> h2.events.Event:
         while not self._events.get(stream_id):
-            await self._receive_events(request)
+            await self._receive_events(request, stream_id)
         return self._events[stream_id].pop(0)
 
-    async def _receive_events(self, request: Request) -> None:
-        events = await self._read_incoming_data(request)
-        for event in events:
-            event_stream_id = getattr(event, "stream_id", 0)
+    async def _receive_events(self, request: Request, stream_id: int = None) -> None:
+        async with self._read_lock:
+            # This conditional is a bit icky. We don't want to block reading if we've
+            # actually got an event to return for a given stream. We need to do that
+            # check *within* the atomic read lock. Though it also need to be optional,
+            # because when we call it from `_wait_for_outgoing_flow` we *do* want to
+            # block until we've available flow control, event when we have events
+            # pending for the stream ID we're attempting to send on.
+            if stream_id is None or not self._events.get(stream_id):
+                events = await self._read_incoming_data(request)
+                for event in events:
+                    event_stream_id = getattr(event, "stream_id", 0)
 
-            if hasattr(event, "error_code"):
-                raise RemoteProtocolError(event)
+                    if hasattr(event, "error_code"):
+                        raise RemoteProtocolError(event)
 
-            if event_stream_id in self._events:
-                self._events[event_stream_id].append(event)
+                    if event_stream_id in self._events:
+                        self._events[event_stream_id].append(event)
 
         await self._write_outgoing_data(request)
 
@@ -274,11 +282,12 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
-        async with self._read_lock:
-            data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
-            if data == b"":
-                raise RemoteProtocolError("Server disconnected")
-            return self._h2_state.receive_data(data)
+        data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
+        if data == b"":
+            raise RemoteProtocolError("Server disconnected")
+        events = self._h2_state.receive_data(data)
+
+        return events
 
     async def _write_outgoing_data(self, request: Request) -> None:
         timeouts = request.extensions.get("timeout", {})


### PR DESCRIPTION
While looking at https://github.com/encode/httpx/issues/1414 I've come across a race condition in the HTTP/2 handling. It's not something I'm able to figure out any sensible test case for, but can describe how to reproduce locally...

First we'll setup `Hypercorn` as a locally HTTP/2-capable server...

**app.py**

```python
async def app(scope, receive, send):
    if scope["type"] != "http":
        raise Exception("Only the HTTP protocol is supported")

    await send({
        'type': 'http.response.start',
        'status': 200,
        'headers': [
            (b'content-type', b'text/plain'),
            (b'content-length', b'5'),
        ],
    })
    await send({
        'type': 'http.response.body',
        'body': b'hello',
    })
```

Let's run that lil kiddo...

```shell
$ hypercorn app:app
```

Okey dokes, now let's bump into it with a coupla concurrent HTTP/2 requests. We've not setup any certificate on the hypercorn server, so we'll just enforce HTTP/2 support, so that we'll still get HTTP/2 without any `https` connection.

```python
import asyncio
import httpcore
import traceback


async def download(http, idx):
    try:
        response = await http.request("GET", f"http://127.0.0.1:8000")
    except Exception as exc:
        traceback.print_exc()
        raise exc
    else:
        print(idx, response)


async def main():
    async with httpcore.AsyncConnectionPool(http1=False, http2=True) as http:
        tasks = [download(http, idx) for idx in range(2)]
        await asyncio.gather(*tasks)


asyncio.run(main())
```

If we run that without this proposed change we get the following...

```shell
$ venv/bin/python ./example.py 
0 <Response [200]>
... [hangs]
```

Here's why:

* Flows `A` and `B` both start.
* Flow `A` hits `while not self._events.get(stream_id)` - there's no events yet so we move on to `_receive_events()`.
* Flow `B` hits `while not self._events.get(stream_id)` - there's no events yet so we move on to `_receive_events()`.
* Flow `A` reads the response events for both streams, and returns ok.
* Flow `B` hangs waiting for network data, despite the fact that there *is* now actually an event for it to return.

The key to resolving this is to move the read lock, so that we check "have we got an event that we can return" *inside* the lock.

I'm not wild about this PR, because it's just *difficult* to be convinced that it's resilient and correct enough, and it's also not obvious how to test case it. *but*. Working code's gotta be better than code that I can demo as hanging. So.