### PR TITLE
Network errors on HTTP/2 should propagate across all streams.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -52,7 +52,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         self._write_lock = AsyncLock()
         self._sent_connection_init = False
         self._used_all_stream_ids = False
+        self._connection_error = False
         self._events: typing.Dict[int, h2.events.Event] = {}
+        self._read_exception: typing.Optional[Exception] = None
+        self._write_exception: typing.Optional[Exception] = None
 
     async def handle_async_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
@@ -282,9 +285,26 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
-        data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
-        if data == b"":
-            raise RemoteProtocolError("Server disconnected")
+        if self._read_exception is not None:
+            raise self._read_exception  # pragma: nocover
+
+        try:
+            data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
+            if data == b"":
+                raise RemoteProtocolError("Server disconnected")
+        except Exception as exc:
+            # If we get a network error we should:
+            #
+            # 1. Save the exception and just raise it immediately on any future reads.
+            #    (For example, this means that a single read timeout or disconnect will
+            #    immediately close all pending streams. Without requiring multiple
+            #    sequential timeouts.)
+            # 2. Mark the connection as errored, so that we don't accept any other
+            #    incoming requests.
+            self._read_exception = exc
+            self._connection_error = True
+            raise exc
+
         events = self._h2_state.receive_data(data)
 
         return events
@@ -295,7 +315,24 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         async with self._write_lock:
             data_to_send = self._h2_state.data_to_send()
-            await self._network_stream.write(data_to_send, timeout)
+
+            if self._write_exception is not None:
+                raise self._write_exception  # pragma: nocover
+
+            try:
+                await self._network_stream.write(data_to_send, timeout)
+            except Exception as exc:  # pragma: nocover
+                # If we get a network error we should:
+                #
+                # 1. Save the exception and just raise it immediately on any future write.
+                #    (For example, this means that a single write timeout or disconnect will
+                #    immediately close all pending streams. Without requiring multiple
+                #    sequential timeouts.)
+                # 2. Mark the connection as errored, so that we don't accept any other
+                #    incoming requests.
+                self._write_exception = exc
+                self._connection_error = True
+                raise exc
 
     # Flow control...
 
@@ -324,7 +361,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     def is_available(self) -> bool:
         return (
-            self._state != HTTPConnectionState.CLOSED and not self._used_all_stream_ids
+            self._state != HTTPConnectionState.CLOSED
+            and not self._connection_error
+            and not self._used_all_stream_ids
         )
 
     def has_expired(self) -> bool:


### PR DESCRIPTION
Network errors on HTTP/2 need to be handled a bit differently to HTTP/1.1, because there will often be multiple streams being handled on the same connection. Rather than simply raising the exception we should...

* Save the exception.
* Mark the connection as errored, and return `False` for any future `is_available` calls to disallow further requests being queued on the connection.
* Immediately re-raise the exception on any other network calls, so that it applies across all streams.

This closes https://github.com/encode/httpx/issues/1414 - where the observed behaviour was a disconnect, followed by `TooManyStreams` exceptions. Instead of continuing to queue up further requests behind the *one* request that resulted in a disconnect, we instead want to see the disconnect apply to *all* existing requests on that connection, as well as preventing any future requests from being queued up on it.

Testing this out...

```python
import anyio
import httpcore
import time


async def download(http, year):
    url = f"https://en.wikipedia.org/wiki/{year}"
    extensions = {"timeout": {"read": 5.0}}
    try:
        response = await http.request("GET", url, extensions=extensions)
    except Exception as exc:
        print(year, type(exc))
    else:
        print(year, response)


async def main():
    async with httpcore.AsyncConnectionPool(http2=True) as http:
        async with anyio.create_task_group() as task_group:
            for year in range(1900, 2020):
                task_group.start_soon(download, http, year)


anyio.run(main)
```

* Start a number of concurrent HTTP/2 requests, using the above, and allow it to start.
* Quickly disconnect the Wi-Fi / network connection, before all requests have completed.
* We ought to get graceful exception behaviour on the remaining requests. (No `TooManyStreams` exceptions. No gradually one-by-one trickling `ReadTimeout` exceptions.)