### PR TITLE
Prevent orphaned TCP socket

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -143,7 +143,11 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                 "timeout": timeout,
             }
             async with Trace("connection.start_tls", request, kwargs) as trace:
-                stream = await stream.start_tls(**kwargs)
+                try:
+                    stream = await stream.start_tls(**kwargs)
+                except Exception:
+                    await stream.aclose()
+                    raise
                 trace.return_value = stream
         return stream
 

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -143,7 +143,11 @@ class HTTPConnection(ConnectionInterface):
                 "timeout": timeout,
             }
             with Trace("connection.start_tls", request, kwargs) as trace:
-                stream = stream.start_tls(**kwargs)
+                try:
+                    stream = stream.start_tls(**kwargs)
+                except Exception:
+                    stream.close()
+                    raise
                 trace.return_value = stream
         return stream
 


### PR DESCRIPTION
When an exception occurs during the TLS layer creation, the created TCP socket is not connected to any connection and thus never closed leading to a TCP socket leak, see https://github.com/home-assistant/core/issues/60150