### PR TITLE
Pass SSL Context to HTTP Connection

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -186,6 +186,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
             network_backend=network_backend,
+            ssl_context=ssl_context
         )
         self._proxy_origin = proxy_origin
         self._remote_origin = remote_origin

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -186,7 +186,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
             network_backend=network_backend,
-            ssl_context=ssl_context
+            ssl_context=ssl_context,
         )
         self._proxy_origin = proxy_origin
         self._remote_origin = remote_origin

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -186,7 +186,7 @@ class TunnelHTTPConnection(ConnectionInterface):
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
             network_backend=network_backend,
-            ssl_context=ssl_context
+            ssl_context=ssl_context,
         )
         self._proxy_origin = proxy_origin
         self._remote_origin = remote_origin

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -186,6 +186,7 @@ class TunnelHTTPConnection(ConnectionInterface):
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
             network_backend=network_backend,
+            ssl_context=ssl_context
         )
         self._proxy_origin = proxy_origin
         self._remote_origin = remote_origin


### PR DESCRIPTION
It seems with [this version](https://github.com/encode/httpcore/commit/f9b93918a54a49a4e917824ad38cf5bd8da21450#diff-86d6569fbcb083111143bf4da9580b782eb64f8f9f17c4b0873867ea7e3d9bd1), the SSL context stopped being passed to the HTTP connection. Raising `OSError: [Errno 24] Too many open files` when sending over 500 async requests simultaneously.