### PR TITLE
Add missing proxy_header to forward proxy case

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -101,6 +101,7 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         if origin.scheme == b"http":
             return AsyncForwardHTTPConnection(
                 proxy_origin=self._proxy_url.origin,
+                proxy_headers=self._proxy_headers,
                 keepalive_expiry=self._keepalive_expiry,
                 network_backend=self._network_backend,
             )

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -101,6 +101,7 @@ class HTTPProxy(ConnectionPool):
         if origin.scheme == b"http":
             return ForwardHTTPConnection(
                 proxy_origin=self._proxy_url.origin,
+                proxy_headers=self._proxy_headers,
                 keepalive_expiry=self._keepalive_expiry,
                 network_backend=self._network_backend,
             )


### PR DESCRIPTION
Proxy headers are missing when proxying requests to `http` endpoints.

Closes https://github.com/encode/httpx/issues/1970