### PR TITLE
Only create SSLContext when required

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -35,10 +35,6 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         uds: str = None,
         network_backend: AsyncNetworkBackend = None,
     ) -> None:
-        ssl_context = default_ssl_context() if ssl_context is None else ssl_context
-        alpn_protocols = ["http/1.1", "h2"] if http2 else ["http/1.1"]
-        ssl_context.set_alpn_protocols(alpn_protocols)
-
         self._origin = origin
         self._ssl_context = ssl_context
         self._keepalive_expiry = keepalive_expiry
@@ -137,8 +133,16 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                 break
 
         if self._origin.scheme == b"https":
+            ssl_context = (
+                default_ssl_context()
+                if self._ssl_context is None
+                else self._ssl_context
+            )
+            alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+            ssl_context.set_alpn_protocols(alpn_protocols)
+
             kwargs = {
-                "ssl_context": self._ssl_context,
+                "ssl_context": ssl_context,
                 "server_hostname": self._origin.host.decode("ascii"),
                 "timeout": timeout,
             }

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -5,7 +5,6 @@ from typing import AsyncIterable, AsyncIterator, List, Optional, Type
 
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Request, Response
-from .._ssl import default_ssl_context
 from .._synchronization import AsyncEvent, AsyncLock
 from ..backends.auto import AutoBackend
 from ..backends.base import AsyncNetworkBackend
@@ -82,9 +81,6 @@ class AsyncConnectionPool(AsyncRequestInterface):
             uds: Path to a Unix Domain Socket to use instead of TCP sockets.
             network_backend: A backend instance to use for handling network I/O.
         """
-        if ssl_context is None:
-            ssl_context = default_ssl_context()
-
         self._ssl_context = ssl_context
 
         self._max_connections = (

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -3,7 +3,6 @@ from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 from .._exceptions import ProxyError
 from .._models import URL, Origin, Request, Response, enforce_headers, enforce_url
-from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
 from ..backends.base import AsyncNetworkBackend
 from .connection import AsyncHTTPConnection
@@ -80,9 +79,6 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             uds: Path to a Unix Domain Socket to use instead of TCP sockets.
             network_backend: A backend instance to use for handling network I/O.
         """
-        if ssl_context is None:
-            ssl_context = default_ssl_context()
-
         super().__init__(
             ssl_context=ssl_context,
             max_connections=max_connections,
@@ -178,7 +174,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
         self,
         proxy_origin: Origin,
         remote_origin: Origin,
-        ssl_context: ssl.SSLContext,
+        ssl_context: ssl.SSLContext = None,
         proxy_headers: Sequence[Tuple[bytes, bytes]] = None,
         keepalive_expiry: float = None,
         network_backend: AsyncNetworkBackend = None,

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -5,7 +5,6 @@ from typing import Iterable, Iterator, List, Optional, Type
 
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Request, Response
-from .._ssl import default_ssl_context
 from .._synchronization import Event, Lock
 from ..backends.sync import SyncBackend
 from ..backends.base import NetworkBackend
@@ -82,9 +81,6 @@ class ConnectionPool(RequestInterface):
             uds: Path to a Unix Domain Socket to use instead of TCP sockets.
             network_backend: A backend instance to use for handling network I/O.
         """
-        if ssl_context is None:
-            ssl_context = default_ssl_context()
-
         self._ssl_context = ssl_context
 
         self._max_connections = (

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -3,7 +3,6 @@ from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 from .._exceptions import ProxyError
 from .._models import URL, Origin, Request, Response, enforce_headers, enforce_url
-from .._ssl import default_ssl_context
 from .._synchronization import Lock
 from ..backends.base import NetworkBackend
 from .connection import HTTPConnection
@@ -80,9 +79,6 @@ class HTTPProxy(ConnectionPool):
             uds: Path to a Unix Domain Socket to use instead of TCP sockets.
             network_backend: A backend instance to use for handling network I/O.
         """
-        if ssl_context is None:
-            ssl_context = default_ssl_context()
-
         super().__init__(
             ssl_context=ssl_context,
             max_connections=max_connections,
@@ -178,7 +174,7 @@ class TunnelHTTPConnection(ConnectionInterface):
         self,
         proxy_origin: Origin,
         remote_origin: Origin,
-        ssl_context: ssl.SSLContext,
+        ssl_context: ssl.SSLContext = None,
         proxy_headers: Sequence[Tuple[bytes, bytes]] = None,
         keepalive_expiry: float = None,
         network_backend: NetworkBackend = None,


### PR DESCRIPTION
Only create `SSLContext` instances when they're actually required.

Closes #455