### PR TITLE
Proxy HTTP/2 support

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -3,7 +3,9 @@ from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 from .._exceptions import ProxyError
 from .._models import URL, Origin, Request, Response, enforce_headers, enforce_url
+from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
+from .._trace import Trace
 from ..backends.base import AsyncNetworkBackend
 from .connection import AsyncHTTPConnection
 from .connection_pool import AsyncConnectionPool
@@ -46,6 +48,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
         max_connections: Optional[int] = 10,
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
+        http1: bool = True,
+        http2: bool = False,
         retries: int = 0,
         local_address: str = None,
         uds: str = None,
@@ -69,6 +73,10 @@ class AsyncHTTPProxy(AsyncConnectionPool):
                 that will be maintained in the pool.
             keepalive_expiry: The duration in seconds that an idle HTTP connection
                 may be maintained for before being expired from the pool.
+            http1: A boolean indicating if HTTP/1.1 requests should be supported
+                by the connection pool. Defaults to True.
+            http2: A boolean indicating if HTTP/2 requests should be supported by
+                the connection pool. Defaults to False.
             retries: The maximum number of retries when trying to establish
                 a connection.
             local_address: Local address to connect from. Can also be used to
@@ -84,6 +92,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             max_connections=max_connections,
             max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
+            http1=http1,
+            http2=http2,
             network_backend=network_backend,
             retries=retries,
             local_address=local_address,
@@ -107,6 +117,8 @@ class AsyncHTTPProxy(AsyncConnectionPool):
             remote_origin=origin,
             ssl_context=self._ssl_context,
             keepalive_expiry=self._keepalive_expiry,
+            http1=self._http1,
+            http2=self._http2,
             network_backend=self._network_backend,
         )
 
@@ -177,6 +189,8 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
         ssl_context: ssl.SSLContext = None,
         proxy_headers: Sequence[Tuple[bytes, bytes]] = None,
         keepalive_expiry: float = None,
+        http1: bool = True,
+        http2: bool = False,
         network_backend: AsyncNetworkBackend = None,
     ) -> None:
         self._connection: AsyncConnectionInterface = AsyncHTTPConnection(
@@ -189,6 +203,8 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
         self._ssl_context = ssl_context
         self._proxy_headers = enforce_headers(proxy_headers, name="proxy_headers")
         self._keepalive_expiry = keepalive_expiry
+        self._http1 = http1
+        self._http2 = http2
         self._connect_lock = AsyncLock()
         self._connected = False
 
@@ -224,16 +240,48 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     raise ProxyError(msg)
 
                 stream = connect_response.extensions["network_stream"]
-                stream = await stream.start_tls(
-                    ssl_context=self._ssl_context,
-                    server_hostname=self._remote_origin.host.decode("ascii"),
-                    timeout=timeout,
+
+                # Upgrade the stream to SSL
+                ssl_context = (
+                    default_ssl_context()
+                    if self._ssl_context is None
+                    else self._ssl_context
                 )
-                self._connection = AsyncHTTP11Connection(
-                    origin=self._remote_origin,
-                    stream=stream,
-                    keepalive_expiry=self._keepalive_expiry,
+                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                ssl_context.set_alpn_protocols(alpn_protocols)
+
+                kwargs = {
+                    "ssl_context": ssl_context,
+                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "timeout": timeout,
+                }
+                async with Trace("connection.start_tls", request, kwargs) as trace:
+                    stream = await stream.start_tls(**kwargs)
+                    trace.return_value = stream
+
+                # Determine if we should be using HTTP/1.1 or HTTP/2
+                ssl_object = stream.get_extra_info("ssl_object")
+                http2_negotiated = (
+                    ssl_object is not None
+                    and ssl_object.selected_alpn_protocol() == "h2"
                 )
+
+                # Create the HTTP/1.1 or HTTP/2 connection
+                if http2_negotiated or (self._http2 and not self._http1):
+                    from .http2 import AsyncHTTP2Connection
+
+                    self._connection = AsyncHTTP2Connection(
+                        origin=self._remote_origin,
+                        stream=stream,
+                        keepalive_expiry=self._keepalive_expiry,
+                    )
+                else:
+                    self._connection = AsyncHTTP11Connection(
+                        origin=self._remote_origin,
+                        stream=stream,
+                        keepalive_expiry=self._keepalive_expiry,
+                    )
+
                 self._connected = True
         return await self._connection.handle_async_request(request)
 

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -3,7 +3,9 @@ from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 from .._exceptions import ProxyError
 from .._models import URL, Origin, Request, Response, enforce_headers, enforce_url
+from .._ssl import default_ssl_context
 from .._synchronization import Lock
+from .._trace import Trace
 from ..backends.base import NetworkBackend
 from .connection import HTTPConnection
 from .connection_pool import ConnectionPool
@@ -46,6 +48,8 @@ class HTTPProxy(ConnectionPool):
         max_connections: Optional[int] = 10,
         max_keepalive_connections: int = None,
         keepalive_expiry: float = None,
+        http1: bool = True,
+        http2: bool = False,
         retries: int = 0,
         local_address: str = None,
         uds: str = None,
@@ -69,6 +73,10 @@ class HTTPProxy(ConnectionPool):
                 that will be maintained in the pool.
             keepalive_expiry: The duration in seconds that an idle HTTP connection
                 may be maintained for before being expired from the pool.
+            http1: A boolean indicating if HTTP/1.1 requests should be supported
+                by the connection pool. Defaults to True.
+            http2: A boolean indicating if HTTP/2 requests should be supported by
+                the connection pool. Defaults to False.
             retries: The maximum number of retries when trying to establish
                 a connection.
             local_address: Local address to connect from. Can also be used to
@@ -84,6 +92,8 @@ class HTTPProxy(ConnectionPool):
             max_connections=max_connections,
             max_keepalive_connections=max_keepalive_connections,
             keepalive_expiry=keepalive_expiry,
+            http1=http1,
+            http2=http2,
             network_backend=network_backend,
             retries=retries,
             local_address=local_address,
@@ -107,6 +117,8 @@ class HTTPProxy(ConnectionPool):
             remote_origin=origin,
             ssl_context=self._ssl_context,
             keepalive_expiry=self._keepalive_expiry,
+            http1=self._http1,
+            http2=self._http2,
             network_backend=self._network_backend,
         )
 
@@ -177,6 +189,8 @@ class TunnelHTTPConnection(ConnectionInterface):
         ssl_context: ssl.SSLContext = None,
         proxy_headers: Sequence[Tuple[bytes, bytes]] = None,
         keepalive_expiry: float = None,
+        http1: bool = True,
+        http2: bool = False,
         network_backend: NetworkBackend = None,
     ) -> None:
         self._connection: ConnectionInterface = HTTPConnection(
@@ -189,6 +203,8 @@ class TunnelHTTPConnection(ConnectionInterface):
         self._ssl_context = ssl_context
         self._proxy_headers = enforce_headers(proxy_headers, name="proxy_headers")
         self._keepalive_expiry = keepalive_expiry
+        self._http1 = http1
+        self._http2 = http2
         self._connect_lock = Lock()
         self._connected = False
 
@@ -224,16 +240,48 @@ class TunnelHTTPConnection(ConnectionInterface):
                     raise ProxyError(msg)
 
                 stream = connect_response.extensions["network_stream"]
-                stream = stream.start_tls(
-                    ssl_context=self._ssl_context,
-                    server_hostname=self._remote_origin.host.decode("ascii"),
-                    timeout=timeout,
+
+                # Upgrade the stream to SSL
+                ssl_context = (
+                    default_ssl_context()
+                    if self._ssl_context is None
+                    else self._ssl_context
                 )
-                self._connection = HTTP11Connection(
-                    origin=self._remote_origin,
-                    stream=stream,
-                    keepalive_expiry=self._keepalive_expiry,
+                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                ssl_context.set_alpn_protocols(alpn_protocols)
+
+                kwargs = {
+                    "ssl_context": ssl_context,
+                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "timeout": timeout,
+                }
+                with Trace("connection.start_tls", request, kwargs) as trace:
+                    stream = stream.start_tls(**kwargs)
+                    trace.return_value = stream
+
+                # Determine if we should be using HTTP/1.1 or HTTP/2
+                ssl_object = stream.get_extra_info("ssl_object")
+                http2_negotiated = (
+                    ssl_object is not None
+                    and ssl_object.selected_alpn_protocol() == "h2"
                 )
+
+                # Create the HTTP/1.1 or HTTP/2 connection
+                if http2_negotiated or (self._http2 and not self._http1):
+                    from .http2 import HTTP2Connection
+
+                    self._connection = HTTP2Connection(
+                        origin=self._remote_origin,
+                        stream=stream,
+                        keepalive_expiry=self._keepalive_expiry,
+                    )
+                else:
+                    self._connection = HTTP11Connection(
+                        origin=self._remote_origin,
+                        stream=stream,
+                        keepalive_expiry=self._keepalive_expiry,
+                    )
+
                 self._connected = True
         return self._connection.handle_request(request)
 

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=93
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=100

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -5,6 +5,7 @@ import hyperframe.frame
 import pytest
 
 from httpcore import AsyncHTTPProxy, Origin, ProxyError
+from httpcore.backends.base import AsyncNetworkStream
 from httpcore.backends.mock import AsyncMockBackend, AsyncMockStream
 
 
@@ -127,7 +128,7 @@ class HTTP1ThenHTTP2Stream(AsyncMockStream):
         ssl_context: ssl.SSLContext,
         server_hostname: str = None,
         timeout: float = None,
-    ) -> NetworkStream:
+    ) -> AsyncNetworkStream:
         self._http2 = True
         return self
 
@@ -135,7 +136,7 @@ class HTTP1ThenHTTP2Stream(AsyncMockStream):
 class HTTP1ThenHTTP2Backend(AsyncMockBackend):
     async def connect_tcp(
         self, host: str, port: int, timeout: float = None, local_address: str = None
-    ) -> NetworkStream:
+    ) -> AsyncNetworkStream:
         return HTTP1ThenHTTP2Stream(list(self._buffer))
 
 

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -139,7 +139,8 @@ async def test_proxy_tunneling_http2():
             hyperframe.frame.DataFrame(
                 stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
             ).serialize(),
-        ]
+        ],
+        http2=True,
     )
 
     async with AsyncHTTPProxy(

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -1,3 +1,5 @@
+import hpack
+import hyperframe.frame
 import pytest
 
 from httpcore import AsyncHTTPProxy, Origin, ProxyError
@@ -64,7 +66,9 @@ async def test_proxy_tunneling():
     """
     network_backend = AsyncMockBackend(
         [
+            # The initial response to the proxy CONNECT
             b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            # The actual response from the remote server
             b"HTTP/1.1 200 OK\r\n",
             b"Content-Type: plain/text\r\n",
             b"Content-Length: 13\r\n",
@@ -77,6 +81,72 @@ async def test_proxy_tunneling():
         proxy_url="http://localhost:8080/",
         max_connections=10,
         network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        async with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<AsyncTunnelHTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            await response.aread()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<AsyncTunnelHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+        # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"example.com", 80)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"other.com", 80)
+        )
+        assert proxy.connections[0].can_handle_request(
+            Origin(b"https", b"example.com", 443)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"https", b"other.com", 443)
+        )
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_http2():
+    """
+    Send an HTTP/2 request via a proxy.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            # The actual response from the remote server
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.DataFrame(
+                stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
+            ).serialize(),
+        ]
+    )
+
+    async with AsyncHTTPProxy(
+        proxy_url="http://localhost:8080/",
+        max_connections=10,
+        network_backend=network_backend,
+        http2=True,
     ) as proxy:
         # Sending an intial request, which once complete will return to the pool, IDLE.
         async with proxy.stream("GET", "https://example.com/") as response:

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -5,6 +5,7 @@ import hyperframe.frame
 import pytest
 
 from httpcore import HTTPProxy, Origin, ProxyError
+from httpcore.backends.base import NetworkStream
 from httpcore.backends.mock import MockBackend, MockStream
 
 

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -1,3 +1,5 @@
+import hpack
+import hyperframe.frame
 import pytest
 
 from httpcore import HTTPProxy, Origin, ProxyError
@@ -64,7 +66,9 @@ def test_proxy_tunneling():
     """
     network_backend = MockBackend(
         [
+            # The initial response to the proxy CONNECT
             b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            # The actual response from the remote server
             b"HTTP/1.1 200 OK\r\n",
             b"Content-Type: plain/text\r\n",
             b"Content-Length: 13\r\n",
@@ -77,6 +81,72 @@ def test_proxy_tunneling():
         proxy_url="http://localhost:8080/",
         max_connections=10,
         network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<TunnelHTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            response.read()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<TunnelHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+        # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"example.com", 80)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"other.com", 80)
+        )
+        assert proxy.connections[0].can_handle_request(
+            Origin(b"https", b"example.com", 443)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"https", b"other.com", 443)
+        )
+
+
+
+def test_proxy_tunneling_http2():
+    """
+    Send an HTTP/2 request via a proxy.
+    """
+    network_backend = MockBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            # The actual response from the remote server
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.DataFrame(
+                stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
+            ).serialize(),
+        ]
+    )
+
+    with HTTPProxy(
+        proxy_url="http://localhost:8080/",
+        max_connections=10,
+        network_backend=network_backend,
+        http2=True,
     ) as proxy:
         # Sending an intial request, which once complete will return to the pool, IDLE.
         with proxy.stream("GET", "https://example.com/") as response:

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -139,7 +139,8 @@ def test_proxy_tunneling_http2():
             hyperframe.frame.DataFrame(
                 stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
             ).serialize(),
-        ]
+        ],
+        http2=True,
     )
 
     with HTTPProxy(

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -1,9 +1,11 @@
+import ssl
+
 import hpack
 import hyperframe.frame
 import pytest
 
 from httpcore import HTTPProxy, Origin, ProxyError
-from httpcore.backends.mock import MockBackend
+from httpcore.backends.mock import MockBackend, MockStream
 
 
 
@@ -67,7 +69,7 @@ def test_proxy_tunneling():
     network_backend = MockBackend(
         [
             # The initial response to the proxy CONNECT
-            b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            b"HTTP/1.1 200 OK\r\n\r\n",
             # The actual response from the remote server
             b"HTTP/1.1 200 OK\r\n",
             b"Content-Type: plain/text\r\n",
@@ -115,15 +117,37 @@ def test_proxy_tunneling():
         )
 
 
+# We need to adapt the mock backend here slightly in order to deal
+# with the proxy case. We do not want the initial connection to the proxy
+# to indicate an HTTP/2 connection, but we do want it to indicate HTTP/2
+# once the SSL upgrade has taken place.
+class HTTP1ThenHTTP2Stream(MockStream):
+    def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: str = None,
+        timeout: float = None,
+    ) -> NetworkStream:
+        self._http2 = True
+        return self
+
+
+class HTTP1ThenHTTP2Backend(MockBackend):
+    def connect_tcp(
+        self, host: str, port: int, timeout: float = None, local_address: str = None
+    ) -> NetworkStream:
+        return HTTP1ThenHTTP2Stream(list(self._buffer))
+
+
 
 def test_proxy_tunneling_http2():
     """
     Send an HTTP/2 request via a proxy.
     """
-    network_backend = MockBackend(
+    network_backend = HTTP1ThenHTTP2Backend(
         [
             # The initial response to the proxy CONNECT
-            b"HTTP/1.1 200 OK\r\n" b"\r\n",
+            b"HTTP/1.1 200 OK\r\n\r\n",
             # The actual response from the remote server
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -140,7 +164,6 @@ def test_proxy_tunneling_http2():
                 stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
             ).serialize(),
         ],
-        http2=True,
     )
 
     with HTTPProxy(
@@ -153,7 +176,7 @@ def test_proxy_tunneling_http2():
         with proxy.stream("GET", "https://example.com/") as response:
             info = [repr(c) for c in proxy.connections]
             assert info == [
-                "<TunnelHTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+                "<TunnelHTTPConnection ['https://example.com:443', HTTP/2, ACTIVE, Request Count: 1]>"
             ]
             response.read()
 
@@ -161,7 +184,7 @@ def test_proxy_tunneling_http2():
         assert response.content == b"Hello, world!"
         info = [repr(c) for c in proxy.connections]
         assert info == [
-            "<TunnelHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+            "<TunnelHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"
         ]
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()


### PR DESCRIPTION
Proxy tunnelling should also support HTTP/2

Refs https://github.com/encode/httpx/issues/1992

The `httpx` package will also need an update here... https://github.com/encode/httpx/blob/7b95ddf3999c6a42fd9311e021c7ecf45fc26f82/httpx/_transports/default.py#L141 and ought to pin against a new minor version of httpcore, once we've got this fix out.