### PR TITLE
Drop trio-typing package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 
 # Optionals
 trio==0.19.0
-trio-typing==0.5.1
 curio==1.4; python_version < '3.7'
 curio==1.5; python_version >= '3.7'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ exclude = httpcore/_sync,tests/_sync
 [mypy]
 disallow_untyped_defs = True
 ignore_missing_imports = True
-plugins = trio_typing.plugin
 
 [mypy-tests.*]
 disallow_untyped_defs = False


### PR DESCRIPTION
Prompted by #461, #463.

Packaging changes that cause unnecessary busy work without adding value.

Simplify, simplify, simplify.
