### PR TITLE
Drop types-certifi package.

### DIFF
--- a/httpcore/_ssl.py
+++ b/httpcore/_ssl.py
@@ -1,6 +1,6 @@
 import ssl
 
-import certifi
+import certifi  # type: ignore
 
 
 def default_ssl_context() -> ssl.SSLContext:

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,4 @@ pytest-httpbin==1.0.1
 pytest-trio==0.7.0
 pytest-asyncio==0.16.0
 trustme==0.9.0
-types-certifi==2021.10.8.0
 uvicorn==0.12.1; python_version < '3.7'


### PR DESCRIPTION
We really don't care about mypy verifying for us that `certifi.where()` returns a `str`.

It's not worth the package download of `types-certifi` on every CI run.

Somewhat minded to use `mypy --ignore-missing-imports`, which would also allow us to drop that type-stub package. We use `mypy` and type checking throughout our package in order to ensure internal consistency. It's a form of test suite, and allows us to much more safely undertake changes and refactoring when needed. I don't care half as much about what type signatures packages we rely on advertise.

Here's what the `types-certifi` package installs for us: https://github.com/python/typeshed/blob/master/stubs/certifi/certifi.pyi
 
Related reading: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports