### PR TITLE
Drop unused testing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ pytest==6.2.5
 pytest-httpbin==1.0.1
 pytest-trio==0.7.0
 pytest-asyncio==0.16.0
-trustme==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,10 @@ coverage==6.2
 flake8==4.0.1
 flake8-bugbear==21.11.29
 flake8-pie==0.6.1
-hypercorn==0.12.0; python_version >= '3.7'
 isort==5.10.1
 mypy==0.910
-pproxy==2.7.8
 pytest==6.2.5
 pytest-httpbin==1.0.1
 pytest-trio==0.7.0
 pytest-asyncio==0.16.0
 trustme==0.9.0
-uvicorn==0.12.1; python_version < '3.7'


### PR DESCRIPTION
We have several test requirements that are actually no longer being used.

For context, this is a result of the drastic 0.14 re-working, which has made the package much more testable throughout.
We're generally testing against mocked streams, rather than against uvicorn/hypercorn. We have *far* better coverage now than we had before (100%, with only *explicit* exemptions.)

The integration testing we do have is currently using `pytest-httpbin`. Personally I'd like to drop this too in favour of something more explicit, but that's a story for another day.