### PR TITLE
Drop extra flake8 checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,6 @@ autoflake==1.4
 black==21.12b0
 coverage==6.2
 flake8==4.0.1
-flake8-bugbear==21.11.29
-flake8-pie==0.6.1
 isort==5.10.1
 mypy==0.910
 pytest==6.2.5


### PR DESCRIPTION
Continuing with the slimming down in #469, #470, #472, #473.

Let's also drop `flake8-bugbear` and `flake8-pie`.

Simplify, simplify, simplify.

