### PR TITLE
Version 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.14.4 (January 5th, 2021)
+
+- Support HTTP/2 on HTTPS tunnelling proxies. (#468)
+- Fix proxy headers missing on HTTP forwarding. (#456)
+- Only instantiate SSL context if required. (#457)
+- More robust HTTP/2 handling. (#253, #439, #440, #441)
+
 ## 0.14.3 (November 17th, 2021)
 
 - Fix race condition when removing closed connections from the pool (#437)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -78,7 +78,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 
 
 __locals = locals()


### PR DESCRIPTION
## 0.14.4 (January 5th, 2021)

- Support HTTP/2 on HTTPS tunnelling proxies. (#468)
- Fix proxy headers missing on HTTP forwarding. (#456)
- Only instantiate SSL context if required. (#457)
- More robust HTTP/2 handling. (#253, #439, #440, #441)