### PR TITLE
Improve 'RemoteProtocolError' message on early server disconnects.

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -172,6 +172,19 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
                 data = await self._network_stream.read(
                     self.READ_NUM_BYTES, timeout=timeout
                 )
+
+                # If we feed this case through h11 we'll raise an exception like:
+                #
+                #     httpcore.RemoteProtocolError: can't handle event type
+                #     ConnectionClosed when role=SERVER and state=SEND_RESPONSE
+                #
+                # Which is accurate, but not very informative from an end-user
+                # perspective. Instead we handle this case distinctly and treat
+                # it as a ConnectError.
+                if data == b"" and self._h11_state.their_state == h11.SEND_RESPONSE:
+                    msg = "Server disconnected without sending a response."
+                    raise RemoteProtocolError(msg)
+
                 self._h11_state.receive_data(data)
             else:
                 return event


### PR DESCRIPTION
Revisit #313 - looks like this behaviour got lost in the 0.14 redesign.

Currently if the server is in a listening state, then disconnects without sending a response, then users will see the following error...

```python
httpcore.RemoteProtocolError: can't handle event type ConnectionClosed when role=SERVER and state=SEND_RESPONSE
```

Which really isn't informative as an end-user. We probably would prefer to special case this particular transition as a `ConnectError`. It's not quite the same as a *network* `ConnectError`, since it occurs in cases where the connection was already established and hanging around, but is closed once it an incoming request is sent.