### PR TITLE
Tidy up warning in test suite

### DIFF
--- a/httpcore/backends/mock.py
+++ b/httpcore/backends/mock.py
@@ -59,14 +59,13 @@ class MockBackend(NetworkBackend):
 
 class AsyncMockStream(AsyncNetworkStream):
     def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
-        self._original_buffer = buffer
-        self._current_buffer = list(self._original_buffer)
+        self._buffer = buffer
         self._http2 = http2
 
     async def read(self, max_bytes: int, timeout: float = None) -> bytes:
-        if not self._current_buffer:
-            self._current_buffer = list(self._original_buffer)
-        return self._current_buffer.pop(0)
+        if not self._buffer:
+            return b""
+        return self._buffer.pop(0)
 
     async def write(self, buffer: bytes, timeout: float = None) -> None:
         pass

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -325,10 +325,12 @@ async def test_connection_pool_concurrency():
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
+            # Each connection was to a different host, and only sent a single
+            # request on that connection.
             assert item[0] in [
                 "<AsyncHTTPConnection ['http://a.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
                 "<AsyncHTTPConnection ['http://b.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
@@ -369,17 +371,15 @@ async def test_connection_pool_concurrency_same_domain_closing():
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
-            assert item[0] in [
-                "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>",
-                "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>",
-                "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 3]>",
-                "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 4]>",
-                "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 5]>",
-            ]
+            # Only a single request was sent on each connection.
+            assert (
+                item[0]
+                == "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            )
 
 
 @pytest.mark.trio
@@ -413,10 +413,11 @@ async def test_connection_pool_concurrency_same_domain_keepalive():
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
+            # The connection sent multiple requests.
             assert item[0] in [
                 "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>",
                 "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>",

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -349,6 +349,7 @@ async def test_connection_pool_concurrency_same_domain_closing():
             b"HTTP/1.1 200 OK\r\n",
             b"Content-Type: plain/text\r\n",
             b"Content-Length: 13\r\n",
+            b"Connection: close\r\n",
             b"\r\n",
             b"Hello, world!",
         ]

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -325,10 +325,12 @@ def test_connection_pool_concurrency():
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
+            # Each connection was to a different host, and only sent a single
+            # request on that connection.
             assert item[0] in [
                 "<HTTPConnection ['http://a.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
                 "<HTTPConnection ['http://b.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
@@ -369,17 +371,15 @@ def test_connection_pool_concurrency_same_domain_closing():
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
-            assert item[0] in [
-                "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>",
-                "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>",
-                "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 3]>",
-                "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 4]>",
-                "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 5]>",
-            ]
+            # Only a single request was sent on each connection.
+            assert (
+                item[0]
+                == "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            )
 
 
 
@@ -413,10 +413,11 @@ def test_connection_pool_concurrency_same_domain_keepalive():
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
 
-        # Check that each time we inspect the connection pool, only a
-        # single connection was established.
         for item in info_list:
+            # Check that each time we inspected the connection pool, only a
+            # single connection was established at any one time.
             assert len(item) == 1
+            # The connection sent multiple requests.
             assert item[0] in [
                 "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>",
                 "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>",

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -349,6 +349,7 @@ def test_connection_pool_concurrency_same_domain_closing():
             b"HTTP/1.1 200 OK\r\n",
             b"Content-Type: plain/text\r\n",
             b"Content-Length: 13\r\n",
+            b"Connection: close\r\n",
             b"\r\n",
             b"Hello, world!",
         ]


### PR DESCRIPTION
This particular test wasn't quite doing what I'd expected. As a result it was raising errors in the sync case, because of unhandled exceptions that's raised.

The test sends 5 requests to the same domain, against a connection pool that only allows 1 request concurrently.
Each request has to occur strictly in order.

Every 2nd request alternately was failing because the server side was leaving the connection open (No `Connection: close` header), and was only terminating once the request was sent (by responding with a `b""` sentinel marker.)

We fix this by adding a `Connection: close` to the response, so that we've got the expected behaviour. (We could *also* fix this by ensuring that the mock backend returns `is_readable` == True at the point that it is inspected by the connection pool for aliveness.)