### PR TITLE
Resolve race condition around exceptions during streaming a response.

### DIFF
--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -58,7 +58,7 @@ and does not currently support SSL proxy connections, which require HTTPS-in-HTT
 
 ## SOCKS proxy support
 
-The `httpcore` package also supports proxies using the SOCKS protocol.
+The `httpcore` package also supports proxies using the SOCKS5 protocol.
 
 Make sure to install the optional dependancy using `pip install httpcore[socks]`.
 
@@ -68,7 +68,7 @@ The `SOCKSProxy` class should be using instead of a standard connection pool:
 import httpcore
 
 # Note that the SOCKS port is 1080.
-proxy = httpcore.SOCKSProxy(proxy_url="socks://127.0.0.1:1080/")
+proxy = httpcore.SOCKSProxy(proxy_url="socks5://127.0.0.1:1080/")
 r = proxy.request("GET", "https://www.example.com/")
 ```
 
@@ -78,7 +78,7 @@ Authentication via SOCKS is also supported:
 import httpcore
 
 proxy = httpcore.SOCKSProxy(
-    proxy_url="socks://127.0.0.1:8080/",
+    proxy_url="socks5://127.0.0.1:8080/",
     proxy_auth=("<username>", "<password>")
 )
 r = proxy.request("GET", "https://www.example.com/")

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -267,7 +267,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
         async with self._pool_lock:
             # Update the state of the connection pool.
-            self._requests.remove(status)
+            if status in self._requests:
+                self._requests.remove(status)
 
             if connection.is_closed() and connection in self._pool:
                 self._pool.remove(connection)

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -239,7 +239,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     # status so that the request becomes queued again.
                     status.unset_connection()
                     await self._attempt_to_acquire_connection(status)
-            except Exception as exc:
+            except BaseException as exc:
                 await self.response_closed(status)
                 raise exc
             else:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -292,7 +292,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         Close any connections in the pool.
         """
         async with self._pool_lock:
-            requests_still_in_flight = bool(self._requests)
+            requests_still_in_flight = len(self._requests)
 
             for connection in self._pool:
                 await connection.aclose()
@@ -301,8 +301,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
             if requests_still_in_flight:
                 raise RuntimeError(
-                    "The connection pool was closed while some HTTP "
-                    "requests/responses were still in-flight."
+                    f"The connection pool was closed while {requests_still_in_flight} "
+                    f"HTTP requests/responses were still in-flight."
                 )
 
     async def __aenter__(self) -> "AsyncConnectionPool":

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -305,7 +305,6 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def aclose(self) -> None:
         # Note that this method unilaterally closes the connection, and does
         # not have any kind of locking in place around it.
-        # For task-safe/thread-safe operations call into 'attempt_close' instead.
         self._h2_state.close_connection()
         self._state = HTTPConnectionState.CLOSED
         await self._network_stream.aclose()
@@ -446,16 +445,26 @@ class HTTP2ConnectionByteStream:
         self._connection = connection
         self._request = request
         self._stream_id = stream_id
+        self._closed = False
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         kwargs = {"request": self._request, "stream_id": self._stream_id}
-        async with Trace("http2.receive_response_body", self._request, kwargs):
-            async for chunk in self._connection._receive_response_body(
-                request=self._request, stream_id=self._stream_id
-            ):
-                yield chunk
+        try:
+            async with Trace("http2.receive_response_body", self._request, kwargs):
+                async for chunk in self._connection._receive_response_body(
+                    request=self._request, stream_id=self._stream_id
+                ):
+                    yield chunk
+        except BaseException as exc:
+            # If we get an exception while streaming the response,
+            # we want to close the response (and possibly the connection)
+            # before raising that exception.
+            await self.aclose()
+            raise exc
 
     async def aclose(self) -> None:
-        kwargs = {"stream_id": self._stream_id}
-        async with Trace("http2.response_closed", self._request, kwargs):
-            await self._connection._response_closed(stream_id=self._stream_id)
+        if not self._closed:
+            self._closed = True
+            kwargs = {"stream_id": self._stream_id}
+            async with Trace("http2.response_closed", self._request, kwargs):
+                await self._connection._response_closed(stream_id=self._stream_id)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -292,7 +292,7 @@ class ConnectionPool(RequestInterface):
         Close any connections in the pool.
         """
         with self._pool_lock:
-            requests_still_in_flight = bool(self._requests)
+            requests_still_in_flight = len(self._requests)
 
             for connection in self._pool:
                 connection.close()
@@ -301,8 +301,8 @@ class ConnectionPool(RequestInterface):
 
             if requests_still_in_flight:
                 raise RuntimeError(
-                    "The connection pool was closed while some HTTP "
-                    "requests/responses were still in-flight."
+                    f"The connection pool was closed while {requests_still_in_flight} "
+                    f"HTTP requests/responses were still in-flight."
                 )
 
     def __enter__(self) -> "ConnectionPool":

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -239,7 +239,7 @@ class ConnectionPool(RequestInterface):
                     # status so that the request becomes queued again.
                     status.unset_connection()
                     self._attempt_to_acquire_connection(status)
-            except Exception as exc:
+            except BaseException as exc:
                 self.response_closed(status)
                 raise exc
             else:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -292,10 +292,18 @@ class ConnectionPool(RequestInterface):
         Close any connections in the pool.
         """
         with self._pool_lock:
+            requests_still_in_flight = bool(self._requests)
+
             for connection in self._pool:
                 connection.close()
             self._pool = []
             self._requests = []
+
+            if requests_still_in_flight:
+                raise RuntimeError(
+                    "The connection pool was closed while some HTTP "
+                    "requests/responses were still in-flight."
+                )
 
     def __enter__(self) -> "ConnectionPool":
         return self

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -267,7 +267,8 @@ class ConnectionPool(RequestInterface):
 
         with self._pool_lock:
             # Update the state of the connection pool.
-            self._requests.remove(status)
+            if status in self._requests:
+                self._requests.remove(status)
 
             if connection.is_closed() and connection in self._pool:
                 self._pool.remove(connection)

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -435,3 +435,29 @@ async def test_unsupported_protocol():
 
         with pytest.raises(UnsupportedProtocol):
             await pool.request("GET", "://www.example.com/")
+
+
+@pytest.mark.anyio
+async def test_connection_pool_closed_while_request_in_flight():
+    """
+    Closing a connection pool while a request/response is still in-flight
+    should raise an error.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        network_backend=network_backend,
+    ) as pool:
+        # Send a request, and then close the connection pool while the
+        # response has not yet been streamed.
+        async with pool.stream("GET", "https://example.com/"):
+            with pytest.raises(RuntimeError):
+                await pool.aclose()

--- a/tests/_sync/test_http11.py
+++ b/tests/_sync/test_http11.py
@@ -92,6 +92,35 @@ def test_http11_connection_with_remote_protocol_error():
 
 
 
+def test_http11_connection_with_incomplete_response():
+    """
+    We should be gracefully handling the case where the connection ends prematurely.
+    """
+    origin = Origin(b"https", b"example.com", 443)
+    stream = MockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, wor",
+        ]
+    )
+    with HTTP11Connection(origin=origin, stream=stream) as conn:
+        with pytest.raises(RemoteProtocolError):
+            conn.request("GET", "https://example.com/")
+
+        assert not conn.is_idle()
+        assert conn.is_closed()
+        assert not conn.is_available()
+        assert not conn.has_expired()
+        assert (
+            repr(conn)
+            == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
+        )
+
+
+
 def test_http11_connection_with_local_protocol_error():
     """
     If a local protocol error occurs, then no response will be returned,


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/2047 by resolving a race condition that can occur when an exception is raised while streaming the response.

Prior to this PR it's possible that the exception is handled first, closing the connection, and *then* the request close callback occurs.

The changes are:

* If an exception occurs while streaming a response, then close the response (and possibly the connection) 
**before allowing the exception to bubble up**.
* If a connection pool is closed while there are still open requests, then close it but then raise a `RuntimeError`.
* Defensive programming around removing the request status from the connection pool, when closing the request.