### PR TITLE
Fix SOCKS support for 'http://' URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Master branch
 
-- Fix SOCKS support for `http://` URLs.
+- Fix SOCKS support for `http://` URLs. (#492)
 
 ## 0.14.5 (January 18th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Master branch
+
+- Fix SOCKS support for `http://` URLs.
+
 ## 0.14.5 (January 18th, 2022)
 
 - SOCKS proxy support. (#478)

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -239,22 +239,23 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         trace.return_value = stream
 
                     # Upgrade the stream to SSL
-                    ssl_context = (
-                        default_ssl_context()
-                        if self._ssl_context is None
-                        else self._ssl_context
-                    )
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                    ssl_context.set_alpn_protocols(alpn_protocols)
+                    if self._remote_origin.scheme == b"https":
+                        ssl_context = (
+                            default_ssl_context()
+                            if self._ssl_context is None
+                            else self._ssl_context
+                        )
+                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        ssl_context.set_alpn_protocols(alpn_protocols)
 
-                    kwargs = {
-                        "ssl_context": ssl_context,
-                        "server_hostname": self._remote_origin.host.decode("ascii"),
-                        "timeout": timeout,
-                    }
-                    async with Trace("connection.start_tls", request, kwargs) as trace:
-                        stream = await stream.start_tls(**kwargs)
-                        trace.return_value = stream
+                        kwargs = {
+                            "ssl_context": ssl_context,
+                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "timeout": timeout,
+                        }
+                        async with Trace("connection.start_tls", request, kwargs) as trace:
+                            stream = await stream.start_tls(**kwargs)
+                            trace.return_value = stream
 
                     # Determine if we should be using HTTP/1.1 or HTTP/2
                     ssl_object = stream.get_extra_info("ssl_object")

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -245,7 +245,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                             if self._ssl_context is None
                             else self._ssl_context
                         )
-                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        alpn_protocols = (
+                            ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
                         kwargs = {
@@ -253,7 +255,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                             "server_hostname": self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
-                        async with Trace("connection.start_tls", request, kwargs) as trace:
+                        async with Trace(
+                            "connection.start_tls", request, kwargs
+                        ) as trace:
                             stream = await stream.start_tls(**kwargs)
                             trace.return_value = stream
 

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -239,22 +239,23 @@ class Socks5Connection(ConnectionInterface):
                         trace.return_value = stream
 
                     # Upgrade the stream to SSL
-                    ssl_context = (
-                        default_ssl_context()
-                        if self._ssl_context is None
-                        else self._ssl_context
-                    )
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                    ssl_context.set_alpn_protocols(alpn_protocols)
+                    if self._remote_origin.scheme == b"https":
+                        ssl_context = (
+                            default_ssl_context()
+                            if self._ssl_context is None
+                            else self._ssl_context
+                        )
+                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        ssl_context.set_alpn_protocols(alpn_protocols)
 
-                    kwargs = {
-                        "ssl_context": ssl_context,
-                        "server_hostname": self._remote_origin.host.decode("ascii"),
-                        "timeout": timeout,
-                    }
-                    with Trace("connection.start_tls", request, kwargs) as trace:
-                        stream = stream.start_tls(**kwargs)
-                        trace.return_value = stream
+                        kwargs = {
+                            "ssl_context": ssl_context,
+                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "timeout": timeout,
+                        }
+                        with Trace("connection.start_tls", request, kwargs) as trace:
+                            stream = stream.start_tls(**kwargs)
+                            trace.return_value = stream
 
                     # Determine if we should be using HTTP/1.1 or HTTP/2
                     ssl_object = stream.get_extra_info("ssl_object")

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -245,7 +245,9 @@ class Socks5Connection(ConnectionInterface):
                             if self._ssl_context is None
                             else self._ssl_context
                         )
-                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        alpn_protocols = (
+                            ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                        )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
                         kwargs = {
@@ -253,7 +255,9 @@ class Socks5Connection(ConnectionInterface):
                             "server_hostname": self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
-                        with Trace("connection.start_tls", request, kwargs) as trace:
+                        with Trace(
+                            "connection.start_tls", request, kwargs
+                        ) as trace:
                             stream = stream.start_tls(**kwargs)
                             trace.return_value = stream
 


### PR DESCRIPTION
Closes https://github.com/encode/httpcore/pull/491

The SOCKS proxy code was missing the check for "is this an `https` URL or not" at the point of setting up SSL with the remote endpoint.

Compare this...

https://github.com/encode/httpcore/blob/25a5ad3422b3cd3f0ee8ff02eee755de07393645/httpcore/_async/socks_proxy.py#L241-L257

To the equivalent within a regular connection...

https://github.com/encode/httpcore/blob/25a5ad3422b3cd3f0ee8ff02eee755de07393645/httpcore/_async/connection.py#L135-L151

Bit silly really. Fix is easy-peasy. 