### PR TITLE
Version 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Master branch
+## 0.14.6 (February 1st, 2022)
 
 - Fix SOCKS support for `http://` URLs. (#492)
 - Resolve race condition around exceptions during streaming a response. (#491)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.5"
+__version__ = "0.14.6"
 
 
 __locals = locals()


### PR DESCRIPTION
## 0.14.6 (February 1st, 2022)

- Fix SOCKS support for `http://` URLs. (#492)
- Resolve race condition around exceptions during streaming a response. (#491)