### PR TITLE
Fix variable declaration in AsyncSocks5Connection __init__ method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.14.7
+
+- Fix AttributeError that happened when Socks5Connection were terminated
+
 ## 0.14.6 (February 1st, 2022)
 
 - Fix SOCKS support for `http://` URLs. (#492)

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -206,7 +206,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
         )
         self._connect_lock = AsyncLock()
         self._connection: typing.Optional[AsyncConnectionInterface] = None
-        self._connection_failed = False
+        self._connect_failed = False
 
     async def handle_async_request(self, request: Request) -> Response:
         timeouts = request.extensions.get("timeout", {})

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -206,7 +206,7 @@ class Socks5Connection(ConnectionInterface):
         )
         self._connect_lock = Lock()
         self._connection: typing.Optional[ConnectionInterface] = None
-        self._connection_failed = False
+        self._connect_failed = False
 
     def handle_request(self, request: Request) -> Response:
         timeouts = request.extensions.get("timeout", {})


### PR DESCRIPTION
Playing with the latest httpcore and httpx versions I noticed an unexpected exception when the connection failed using a SOCKS proxy.

```
httpcore==0.14.6
httpx==0.22.0
```


```
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-8' coro=<Explorer.async_analyze() done, defined at /home/sirius/wapiti/wapitiCore/net/crawler.py:798> exception=AttributeError("'AsyncSocks5Connection' object has no attribute '_connect_failed'")>
Traceback (most recent call last):
  File "/home/sirius/wapiti/wapitiCore/net/crawler.py", line 823, in async_analyze
    page = await self._crawler.async_send(request)
  File "/home/sirius/wapiti/wapitiCore/net/crawler.py", line 592, in async_send
    page = await self.async_get(resource, headers=headers, follow_redirects=follow_redirects)
  File "/home/sirius/wapiti/wapitiCore/net/crawler.py", line 116, in inner_wrapper
    value = await function(*args, **kwargs)
  File "/home/sirius/wapiti/wapitiCore/net/crawler.py", line 467, in async_get
    response = await self.client.send(
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpx/_client.py", line 1593, in send
    response = await self._send_handling_auth(
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpx/_client.py", line 1621, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpx/_client.py", line 1658, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpx/_client.py", line 1695, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpx/_transports/default.py", line 353, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpcore/_async/connection_pool.py", line 220, in handle_async_request
    await self._close_expired_connections()
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpcore/_async/connection_pool.py", line 187, in _close_expired_connections
    if connection.has_expired():
  File "/home/sirius/.local/share/virtualenvs/wapiti-p7I6n6KS/lib/python3.8/site-packages/httpcore/_async/socks_proxy.py", line 317, in has_expired
    return self._connect_failed
AttributeError: 'AsyncSocks5Connection' object has no attribute '_connect_failed'
```
It turns out this is some kind of typo : `_connect_failed` is used everywhere in `AsyncSocks5Connection` but at the time of `__init__` this variable is named `_connection_failed`.

This PR just use the `_connect_failed` everywhere.