### PR TITLE
Requests which raise a PoolTimeout need to be removed from the pool queue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## master
+
+- Requests which raise a PoolTimeout need to be removed from the pool queue.
+
 ## 0.14.6 (February 1st, 2022)
 
 - Fix SOCKS support for `http://` URLs. (#492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## master
 
-- Requests which raise a PoolTimeout need to be removed from the pool queue.
+- Requests which raise a PoolTimeout need to be removed from the pool queue. (#502)
 
 ## 0.14.6 (February 1st, 2022)
 

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 import trio as concurrency
 
-from httpcore import AsyncConnectionPool, ConnectError, UnsupportedProtocol
+from httpcore import AsyncConnectionPool, ConnectError, PoolTimeout, UnsupportedProtocol
 from httpcore.backends.mock import AsyncMockBackend
 
 
@@ -461,3 +461,30 @@ async def test_connection_pool_closed_while_request_in_flight():
         async with pool.stream("GET", "https://example.com/"):
             with pytest.raises(RuntimeError):
                 await pool.aclose()
+
+
+@pytest.mark.anyio
+async def test_connection_pool_timeout():
+    """
+    Ensure that exceeding max_connections can cause a request to timeout.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        network_backend=network_backend, max_connections=1
+    ) as pool:
+        # Send a request to a pool that is configured to only support a single
+        # connection, and then ensure that a second concurrent request
+        # fails with a timeout.
+        async with pool.stream("GET", "https://example.com/"):
+            with pytest.raises(PoolTimeout):
+                extensions = {"timeout": {"pool": 0.0001}}
+                await pool.request("GET", "https://example.com/", extensions=extensions)

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 from tests import concurrency
 
-from httpcore import ConnectionPool, ConnectError, UnsupportedProtocol
+from httpcore import ConnectionPool, ConnectError, PoolTimeout, UnsupportedProtocol
 from httpcore.backends.mock import MockBackend
 
 
@@ -461,3 +461,30 @@ def test_connection_pool_closed_while_request_in_flight():
         with pool.stream("GET", "https://example.com/"):
             with pytest.raises(RuntimeError):
                 pool.close()
+
+
+
+def test_connection_pool_timeout():
+    """
+    Ensure that exceeding max_connections can cause a request to timeout.
+    """
+    network_backend = MockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with ConnectionPool(
+        network_backend=network_backend, max_connections=1
+    ) as pool:
+        # Send a request to a pool that is configured to only support a single
+        # connection, and then ensure that a second concurrent request
+        # fails with a timeout.
+        with pool.stream("GET", "https://example.com/"):
+            with pytest.raises(PoolTimeout):
+                extensions = {"timeout": {"pool": 0.0001}}
+                pool.request("GET", "https://example.com/", extensions=extensions)


### PR DESCRIPTION
Since https://github.com/encode/httpcore/pull/491 we've started raising a `RuntimeError` if the connection pool is closed while still handling some requests.

This caused an error in the `httpx` test suite, where a pool timeout was being raised causing the client to close. In this case we *hadn't* removed the request from the connection pool.

This pull request resolves that, as well as resolving the case of task-cancellation-of-a-queued-waiting-request.