### PR TITLE
Raise H11 version support for v.0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+#         "Programming Language :: Python :: 3.6",  # remove py36 from active support
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
-#         "Programming Language :: Python :: 3.6",  # remove py36 from active support
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.13",
+        "h11>=0.11,<=0.13",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",


### PR DESCRIPTION
- Allows for concurrent installation with the latest Uvicorn version
- Drop support for Python v.3.6