### PR TITLE
Version 0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.14.7
 
-- Fix AttributeError that happened when Socks5Connection were terminated
+- Requests which raise a PoolTimeout need to be removed from the pool queue. (#502)
+- Fix AttributeError that happened when Socks5Connection were terminated. (#501)
 
 ## 0.14.6 (February 1st, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.14.7
+## 0.14.7 (February 4th, 2022)
 
 - Requests which raise a PoolTimeout need to be removed from the pool queue. (#502)
 - Fix AttributeError that happened when Socks5Connection were terminated. (#501)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.6"
+__version__ = "0.14.7"
 
 
 __locals = locals()


### PR DESCRIPTION
https://github.com/encode/httpcore/releases/edit/untagged-5bb4ab3a7dc459eb230f

## 0.14.7 (February 4th, 2022)

 - Requests which raise a PoolTimeout need to be removed from the pool queue. (#502)
 - Fix AttributeError that happened when Socks5Connection were terminated. (#501)