### PR TITLE
Fix proxy CONNECT timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Master branch
+
+- Ensure HTTP proxy CONNECT requests include `timeout` configuration. (#506)
+
 ## 0.14.7 (February 4th, 2022)
 
 - Requests which raise a PoolTimeout need to be removed from the pool queue. (#502)

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -250,7 +250,10 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     [(b"Host", target), (b"Accept", b"*/*")], self._proxy_headers
                 )
                 connect_request = Request(
-                    method=b"CONNECT", url=connect_url, headers=connect_headers
+                    method=b"CONNECT",
+                    url=connect_url,
+                    headers=connect_headers,
+                    extensions=request.extensions,
                 )
                 connect_response = await self._connection.handle_async_request(
                     connect_request

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -250,7 +250,10 @@ class TunnelHTTPConnection(ConnectionInterface):
                     [(b"Host", target), (b"Accept", b"*/*")], self._proxy_headers
                 )
                 connect_request = Request(
-                    method=b"CONNECT", url=connect_url, headers=connect_headers
+                    method=b"CONNECT",
+                    url=connect_url,
+                    headers=connect_headers,
+                    extensions=request.extensions,
                 )
                 connect_response = self._connection.handle_request(
                     connect_request


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/2073

The `CONNECT` request to an HTTP proxy was omitting the request extensions, which meant it had no timeout attached.