### PR TITLE
connect_to and sni_hostname extensions for controlling

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -68,6 +68,43 @@ print(r.extensions["http_version"])
 
 ## Request Extensions
 
+### `"connect_to"`
+
+A string containing the desired hostname or ip address to open the tcp 
+socket.
+
+This will not affact which hostname is used for initiating the TLS stream, please
+look at `"sni_hostname"` for that.
+
+For example:
+
+```python
+# Use connect_to extention to target a specific server in a pool of servers.
+r = httpcore.request(
+    "GET",
+    "https://www.example.com",
+    extensions={"connect_to": "www1.example.com"}
+)
+```
+
+### `"sni_hostname"`
+
+A string containing the desired hostname or ip address use during TLS handshake.
+
+This will not affact which hostname is used for initiating the connection, please
+look at `"connect_to"` for that.
+
+For example:
+
+```python
+# The certificates in use by the server are for a different hostname.
+r = httpcore.request(
+    "GET",
+    "https://localhost",
+    extensions={"timeout": {"sni_hostname": "www.example.com"}}
+)
+```
+
 ### `"timeout"`
 
 A dictionary of `str: Optional[float]` timeout values.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -83,7 +83,7 @@ For example:
 r = httpcore.request(
     "GET",
     "https://www.example.com",
-    extensions={"connect_to": "www1.example.com"}
+    extensions={"connect_to": "93.184.216.34"}
 )
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -79,7 +79,7 @@ look at `"sni_hostname"` for that.
 For example:
 
 ```python
-# Use connect_to extention to target a specific server in a pool of servers.
+# Use connect_to extension to target a specific server in a pool of servers.
 r = httpcore.request(
     "GET",
     "https://www.example.com",

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -99,8 +99,11 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         while True:
             try:
                 if self._uds is None:
+                    connect_to = request.extensions.get(
+                        "connect_to", self._origin.host.decode("ascii")
+                    )
                     kwargs = {
-                        "host": self._origin.host.decode("ascii"),
+                        "host": connect_to,
                         "port": self._origin.port,
                         "local_address": self._local_address,
                         "timeout": timeout,
@@ -141,9 +144,12 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
             alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
             ssl_context.set_alpn_protocols(alpn_protocols)
 
+            sni_hostname = request.extensions.get(
+                "sni_hostname", self._origin.host.decode("ascii")
+            )
             kwargs = {
                 "ssl_context": ssl_context,
-                "server_hostname": self._origin.host.decode("ascii"),
+                "server_hostname": sni_hostname,
                 "timeout": timeout,
             }
             async with Trace("connection.start_tls", request, kwargs) as trace:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -277,9 +277,12 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                 alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
+                sni_hostname = request.extensions.get(
+                    "sni_hostname", self._remote_origin.host.decode("ascii")
+                )
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": sni_hostname,
                     "timeout": timeout,
                 }
                 async with Trace("connection.start_tls", request, kwargs) as trace:

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -226,9 +226,12 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         trace.return_value = stream
 
                     # Connect to the remote host using socks5
+                    connect_to = request.extensions.get(
+                        "connect_to", self._remote_origin.host.decode("ascii")
+                    )
                     kwargs = {
                         "stream": stream,
-                        "host": self._remote_origin.host.decode("ascii"),
+                        "host": connect_to,
                         "port": self._remote_origin.port,
                         "auth": self._proxy_auth,
                     }
@@ -250,9 +253,12 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
+                        sni_hostname = request.extensions.get(
+                            "sni_hostname", self._remote_origin.host.decode("ascii")
+                        )
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "server_hostname": sni_hostname,
                             "timeout": timeout,
                         }
                         async with Trace(

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -99,8 +99,11 @@ class HTTPConnection(ConnectionInterface):
         while True:
             try:
                 if self._uds is None:
+                    connect_to = request.extensions.get(
+                        "connect_to", self._origin.host.decode("ascii")
+                    )
                     kwargs = {
-                        "host": self._origin.host.decode("ascii"),
+                        "host": connect_to,
                         "port": self._origin.port,
                         "local_address": self._local_address,
                         "timeout": timeout,
@@ -141,9 +144,12 @@ class HTTPConnection(ConnectionInterface):
             alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
             ssl_context.set_alpn_protocols(alpn_protocols)
 
+            sni_hostname = request.extensions.get(
+                "sni_hostname", self._origin.host.decode("ascii")
+            )
             kwargs = {
                 "ssl_context": ssl_context,
-                "server_hostname": self._origin.host.decode("ascii"),
+                "server_hostname": sni_hostname,
                 "timeout": timeout,
             }
             with Trace("connection.start_tls", request, kwargs) as trace:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -277,9 +277,12 @@ class TunnelHTTPConnection(ConnectionInterface):
                 alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
+                sni_hostname = request.extensions.get(
+                    "sni_hostname", self._remote_origin.host.decode("ascii")
+                )
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": sni_hostname,
                     "timeout": timeout,
                 }
                 with Trace("connection.start_tls", request, kwargs) as trace:

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -226,9 +226,12 @@ class Socks5Connection(ConnectionInterface):
                         trace.return_value = stream
 
                     # Connect to the remote host using socks5
+                    connect_to = request.extensions.get(
+                        "connect_to", self._remote_origin.host.decode("ascii")
+                    )
                     kwargs = {
                         "stream": stream,
-                        "host": self._remote_origin.host.decode("ascii"),
+                        "host": connect_to,
                         "port": self._remote_origin.port,
                         "auth": self._proxy_auth,
                     }
@@ -250,9 +253,12 @@ class Socks5Connection(ConnectionInterface):
                         )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
+                        sni_hostname = request.extensions.get(
+                            "sni_hostname", self._remote_origin.host.decode("ascii")
+                        )
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "server_hostname": sni_hostname,
                             "timeout": timeout,
                         }
                         with Trace(


### PR DESCRIPTION
connect_to and sni_hostname extensions for controlling http/tls/ip hostnames separately.  for the messy world we live in.

I choose to not clutter the kwargs dictionary creation, to make the readers eyes less sore.

I think if you wanted to future proof this, you'd make connect_to an array instead of a single string, but I think it would be trivial to handle either  in the future if a decision is made to acknowledge a hostname can have multiple ip addresses :)

I will look at creating a test case can be made for these extensions.  But putting this in for early feedback.