### PR TITLE
Update types for h11 v0.13

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -8,8 +8,8 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    cast,
     Union,
+    cast,
 )
 
 import h11
@@ -199,7 +199,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
                 # TODO: Implement handling for paused
                 ...
             else:
-                return event
+                return cast(h11.Event, event)
 
     async def _response_closed(self) -> None:
         async with self._state_lock:

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -133,7 +133,8 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
         self, event: H11Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        await self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            await self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -127,8 +127,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
             event = h11.Data(data=chunk)
             await self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        await self._send_event(event, timeout=timeout)
+        await self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     async def _send_event(
         self, event: H11Event, timeout: Optional[float] = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -127,8 +127,7 @@ class HTTP11Connection(ConnectionInterface):
             event = h11.Data(data=chunk)
             self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        self._send_event(event, timeout=timeout)
+        self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     def _send_event(
         self, event: H11Event, timeout: Optional[float] = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -168,7 +168,9 @@ class HTTP11Connection(ConnectionInterface):
             elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
-    def _receive_event(self, timeout: Optional[float] = None) -> h11.Event:
+    def _receive_event(
+        self, timeout: Optional[float] = None
+    ) -> Union[h11.Event, h11.PAUSED]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
                 # The h11 type signature uses a private return type
@@ -177,7 +179,7 @@ class HTTP11Connection(ConnectionInterface):
                     self._h11_state.next_event(),
                 )
 
-            if event is h11.NEED_DATA:
+            if isinstance(event, h11.NEED_DATA):
                 data = self._network_stream.read(
                     self.READ_NUM_BYTES, timeout=timeout
                 )
@@ -195,11 +197,8 @@ class HTTP11Connection(ConnectionInterface):
                     raise RemoteProtocolError(msg)
 
                 self._h11_state.receive_data(data)
-            elif event is h11.PAUSED:
-                # TODO: Implement handling for paused
-                ...
             else:
-                return cast(h11.Event, event)
+                return event
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -184,7 +184,7 @@ class HTTP11Connection(ConnectionInterface):
                 # TODO: Implement handling for paused
                 ...
             else:
-                return event
+                return cast(h11.Event, event)
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,7 +1,16 @@
 import enum
 import time
 from types import TracebackType
-from typing import Iterable, Iterator, List, Optional, Tuple, Type, Union, cast
+from typing import (
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import h11
 
@@ -64,7 +73,9 @@ class HTTP11Connection(ConnectionInterface):
                 self._send_request_headers(**kwargs)
             with Trace("http11.send_request_body", request, kwargs) as trace:
                 self._send_request_body(**kwargs)
-            with Trace("http11.receive_response_headers", request, kwargs) as trace:
+            with Trace(
+                "http11.receive_response_headers", request, kwargs
+            ) as trace:
                 (
                     http_version,
                     status,
@@ -118,7 +129,9 @@ class HTTP11Connection(ConnectionInterface):
 
         self._send_event(h11.EndOfMessage(), timeout=timeout)
 
-    def _send_event(self, event: h11.Event, timeout: Optional[float] = None) -> None:
+    def _send_event(
+        self, event: h11.Event, timeout: Optional[float] = None
+    ) -> None:
         bytes_to_send = self._h11_state.send(event)
         if bytes_to_send is not None:
             self._network_stream.write(bytes_to_send, timeout=timeout)
@@ -165,7 +178,9 @@ class HTTP11Connection(ConnectionInterface):
                 )
 
             if event is h11.NEED_DATA:
-                data = self._network_stream.read(self.READ_NUM_BYTES, timeout=timeout)
+                data = self._network_stream.read(
+                    self.READ_NUM_BYTES, timeout=timeout
+                )
 
                 # If we feed this case through h11 we'll raise an exception like:
                 #

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -133,7 +133,8 @@ class HTTP11Connection(ConnectionInterface):
         self, event: H11Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<=0.13",
+        "h11>=0.11,<0.14",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.13",
+        "h11>=0.11,<=0.13",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",
@@ -73,7 +73,6 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Replaces #503, performing the additional work necessary for type checks to pass.

A cast is necessary because h11 does not expose the `Sentinel` type and uses it as a return type annotation instead of specifying the subtypes that can be returned.

```python
event = cast(
    Union[h11.Event, h11.NEED_DATA, h11.PAUSED],
    self._h11_state.next_event(),
)
```

I've opened a patch to h11 to update `next_event` to have a return type that is narrower and a part of their public API: https://github.com/python-hyper/h11/pull/144 — Note this is now merged resolving the need for a cast, but is not yet released.

There is currently no handling in `_receive_event` for the `h11.PAUSED` sentinel event. I am not sure what behavior you'd like to add there and have left a stub that should be filled in before this is merged. The documentation for `PAUSED` can be found at https://h11.readthedocs.io/en/latest/api.html#flow-control — Note this is not a concern and handling is performed [here](https://github.com/encode/httpcore/pull/526/files#diff-f1329e0e83048035c0a643ab5f3c666ae6565cba6393111fc0dc1afc4f2dbaa4R168).

Note this partially addresses #509 by allowing a newer version of h11 to be used, but does not close the issue as it requests that the upper pin be removed entirely.

Closes #503
Closes #498