### PR TITLE
Bump black packages to fix build failure 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mkdocs-material-extensions==1.0.3
 mkdocstrings==0.17.0
 
 # Packaging
-twine==3.8.0
+twine==4.0.0
 wheel==0.37.1
 
 # Tests & Linting

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wheel==0.37.1
 # Tests & Linting
 anyio==3.5.0
 autoflake==1.4
-black==22.1.0
+black==22.3.0
 coverage==6.2
 flake8==4.0.1
 isort==5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 trio==0.19.0
 
 # Docs
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkdocs-autorefs==0.3.1
 mkdocs-material==8.2.3
 mkdocs-material-extensions==1.0.3


### PR DESCRIPTION
See comment at https://github.com/encode/httpcore/pull/535#issuecomment-1086956259

```
mkdocs==1.3.0
twine==4.0.0
black==22.3.0
```