### PR TITLE
httpcore/backends/trio: map OSError exceptions

### DIFF
--- a/httpcore/backends/trio.py
+++ b/httpcore/backends/trio.py
@@ -111,6 +111,7 @@ class TrioBackend(AsyncNetworkBackend):
         exc_map = {
             trio.TooSlowError: ConnectTimeout,
             trio.BrokenResourceError: ConnectError,
+            OSError: ConnectError,
         }
         # Trio supports 'local_address' from 0.16.1 onwards.
         # We only include the keyword argument if a local_address
@@ -130,6 +131,7 @@ class TrioBackend(AsyncNetworkBackend):
         exc_map = {
             trio.TooSlowError: ConnectTimeout,
             trio.BrokenResourceError: ConnectError,
+            OSError: ConnectError,
         }
         with map_exceptions(exc_map):
             with trio.fail_after(timeout_or_inf):


### PR DESCRIPTION
The underlying socket implementations can raise OSError for situations
such as `getaddrinfo` failing to resolve an address.

Previously, these errors would not be mapped to httpcore exception types
for the trio backend.

Now, map OSError exceptions in the trio backend to ConnectError.

This will make trio consistent with the asyncio backend.

Signed-off-by: Vincent Fazio <vfazio@xes-inc.com>