### PR TITLE
Version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.14.8
+## 0.15.0
 
 - Drop Python 3.6 support (#535)
 - Ensure HTTP proxy CONNECT requests include `timeout` configuration. (#506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Master branch
+## 0.14.8
 
+- Drop Python 3.6 support (#535)
 - Ensure HTTP proxy CONNECT requests include `timeout` configuration. (#506)
+- Switch to explicit `typing.Optional` for type hints (#513)
+- For `trio` map OSError exceptions to `ConnectError` (#543)
 
 ## 0.14.7 (February 4th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.15.0
+## 0.15.0 (May 17th, 2022)
 
 - Drop Python 3.6 support (#535)
 - Ensure HTTP proxy CONNECT requests include `timeout` configuration. (#506)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.7"
+__version__ = "0.14.8"
 
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.14.8"
+__version__ = "0.15.0"
 
 
 __locals = locals()


### PR DESCRIPTION
## 0.15.0

- Drop Python 3.6 support (#535)
- Ensure HTTP proxy CONNECT requests include `timeout` configuration. (#506)
- Switch to explicit `typing.Optional` for type hints (#513)
- For `trio` map OSError exceptions to `ConnectError` (#543)