### PR TITLE
Chill-out, @stalebot. ☀️🤖☀️

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,13 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+ daysUntilStale: 180
+
+ # Number of days of inactivity before a stale issue is closed
+ daysUntilClose: 14
+
+ # Comment to post when marking an issue as stale. Set to `false` to disable
+ markComment: >
+   This issue has been automatically marked as stale because it has not had
+   recent activity. It will be closed if no further activity occurs. Thank you
+   for your contributions.
+ # Comment to post when closing a stale issue. Set to `false` to disable
+ closeComment: false


### PR DESCRIPTION
See also https://github.com/encode/httpx/pull/2150

---

Bump up the durations on the stalebot to 6 months inactivity.

Wouldn't mind the short durations *except* that stalebot will *repeatedly* attempt to close issues. An alternative would be to configure some exemptions, so that triaged issues don't come up for closing.

https://github.com/probot/stale