### PR TITLE
Implementing `TypedDict` class for `request.extensions` 

### DIFF
--- a/httpcore/_api.py
+++ b/httpcore/_api.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Iterator, Optional, Union
 
-from ._models import URL, Response
+from ._models import URL, RequestExtensions, Response
 from ._sync.connection_pool import ConnectionPool
 
 
@@ -11,7 +11,7 @@ def request(
     *,
     headers: Union[dict, list, None] = None,
     content: Union[bytes, Iterator[bytes], None] = None,
-    extensions: Optional[dict] = None,
+    extensions: Optional[RequestExtensions] = None,
 ) -> Response:
     """
     Sends an HTTP request, returning the response.
@@ -52,7 +52,7 @@ def stream(
     *,
     headers: Union[dict, list, None] = None,
     content: Union[bytes, Iterator[bytes], None] = None,
-    extensions: Optional[dict] = None,
+    extensions: Optional[RequestExtensions] = None,
 ) -> Iterator[Response]:
     """
     Sends an HTTP request, returning the response within a content manager.

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,7 +1,7 @@
 import itertools
 import ssl
 from types import TracebackType
-from typing import Iterator, Optional, Type
+from typing import Any, Dict, Iterator, Optional, Type
 
 from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout
 from .._models import Origin, Request, Response
@@ -99,7 +99,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         while True:
             try:
                 if self._uds is None:
-                    kwargs = {
+                    kwargs: Dict[str, Any] = {
                         "host": self._origin.host.decode("ascii"),
                         "port": self._origin.port,
                         "local_address": self._local_address,

--- a/httpcore/_async/interfaces.py
+++ b/httpcore/_async/interfaces.py
@@ -5,6 +5,7 @@ from .._models import (
     URL,
     Origin,
     Request,
+    RequestExtensions,
     Response,
     enforce_bytes,
     enforce_headers,
@@ -21,7 +22,7 @@ class AsyncRequestInterface:
         *,
         headers: Union[dict, list, None] = None,
         content: Union[bytes, AsyncIterator[bytes], None] = None,
-        extensions: Optional[dict] = None,
+        extensions: Optional[RequestExtensions] = None,
     ) -> Response:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
@@ -53,7 +54,7 @@ class AsyncRequestInterface:
         *,
         headers: Union[dict, list, None] = None,
         content: Union[bytes, AsyncIterator[bytes], None] = None,
-        extensions: Optional[dict] = None,
+        extensions: Optional[RequestExtensions] = None,
     ) -> AsyncIterator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -216,7 +216,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
             if self._connection is None:
                 try:
                     # Connect to the proxy
-                    kwargs = {
+                    kwargs: typing.Dict[str, typing.Any] = {
                         "host": self._proxy_origin.host.decode("ascii"),
                         "port": self._proxy_origin.port,
                         "timeout": timeout,

--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -2,6 +2,7 @@ from typing import (
     Any,
     AsyncIterable,
     AsyncIterator,
+    Callable,
     Iterable,
     Iterator,
     List,
@@ -13,7 +14,30 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+try:
+    from typing import TypedDict
+except ImportError:  # pragma: nocover
+    from typing_extensions import TypedDict
+
 # Functions for typechecking...
+
+
+class TimeoutExtensions(TypedDict, total=False):
+    """A dictionary of optional information about the request timeout"""
+
+    connect: float
+    read: float
+    write: float
+    pool: float
+
+
+class RequestExtensions(TypedDict, total=False):
+    """A dictionary of optional extra information included on the request.
+    Possible keys include `"timeout"`, and `"trace"`.
+    """
+
+    timeout: TimeoutExtensions
+    trace: Callable
 
 
 HeadersAsSequence = Sequence[Tuple[Union[bytes, str], Union[bytes, str]]]
@@ -320,7 +344,7 @@ class Request:
         *,
         headers: Union[dict, list, None] = None,
         content: Union[bytes, Iterable[bytes], AsyncIterable[bytes], None] = None,
-        extensions: Optional[dict] = None,
+        extensions: Optional[RequestExtensions] = None,
     ) -> None:
         """
         Parameters:

--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -14,10 +14,8 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-try:
-    from typing import TypedDict
-except ImportError:  # pragma: nocover
-    from typing_extensions import TypedDict
+# This ensures backwards compatibility with Python versions below 3.8
+from typing_extensions import TypedDict
 
 # Functions for typechecking...
 
@@ -53,6 +51,7 @@ def enforce_bytes(value: Union[bytes, str], *, name: str) -> bytes:
     the plain ASCII range. chr(0)...chr(127). If you need to use characters
     outside that range then be precise, and use a byte-wise argument.
     """
+
     if isinstance(value, str):
         try:
             return value.encode("ascii")
@@ -365,7 +364,7 @@ class Request:
         self.stream: Union[Iterable[bytes], AsyncIterable[bytes]] = enforce_stream(
             content, name="content"
         )
-        self.extensions = {} if extensions is None else extensions
+        self.extensions = RequestExtensions() if extensions is None else extensions
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{self.method!r}]>"

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -1,7 +1,7 @@
 import itertools
 import ssl
 from types import TracebackType
-from typing import Iterator, Optional, Type
+from typing import Any, Dict, Iterator, Optional, Type
 
 from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout
 from .._models import Origin, Request, Response
@@ -99,7 +99,7 @@ class HTTPConnection(ConnectionInterface):
         while True:
             try:
                 if self._uds is None:
-                    kwargs = {
+                    kwargs: Dict[str, Any] = {
                         "host": self._origin.host.decode("ascii"),
                         "port": self._origin.port,
                         "local_address": self._local_address,

--- a/httpcore/_sync/interfaces.py
+++ b/httpcore/_sync/interfaces.py
@@ -5,6 +5,7 @@ from .._models import (
     URL,
     Origin,
     Request,
+    RequestExtensions,
     Response,
     enforce_bytes,
     enforce_headers,
@@ -21,7 +22,7 @@ class RequestInterface:
         *,
         headers: Union[dict, list, None] = None,
         content: Union[bytes, Iterator[bytes], None] = None,
-        extensions: Optional[dict] = None,
+        extensions: Optional[RequestExtensions] = None,
     ) -> Response:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
@@ -53,7 +54,7 @@ class RequestInterface:
         *,
         headers: Union[dict, list, None] = None,
         content: Union[bytes, Iterator[bytes], None] = None,
-        extensions: Optional[dict] = None,
+        extensions: Optional[RequestExtensions] = None,
     ) -> Iterator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -216,7 +216,7 @@ class Socks5Connection(ConnectionInterface):
             if self._connection is None:
                 try:
                     # Connect to the proxy
-                    kwargs = {
+                    kwargs: typing.Dict[str, typing.Any] = {
                         "host": self._proxy_origin.host.decode("ascii"),
                         "port": self._proxy_origin.port,
                         "timeout": timeout,

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pytest-httpbin==1.0.1
 pytest-trio==0.7.0
 pytest-asyncio==0.16.0
 werkzeug<2.1  # See: https://github.com/postmanlabs/httpbin/issues/673
+typing_extensions==4.2.0

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -490,5 +490,8 @@ async def test_connection_pool_timeout():
         # fails with a timeout.
         async with pool.stream("GET", "https://example.com/"):
             with pytest.raises(PoolTimeout):
-                extensions = {"timeout": {"pool": 0.0001}}
-                await pool.request("GET", "https://example.com/", extensions=extensions)
+                await pool.request(
+                    "GET",
+                    "https://example.com/",
+                    extensions={"timeout": {"pool": 0.0001}},
+                )

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -490,5 +490,8 @@ def test_connection_pool_timeout():
         # fails with a timeout.
         with pool.stream("GET", "https://example.com/"):
             with pytest.raises(PoolTimeout):
-                extensions = {"timeout": {"pool": 0.0001}}
-                pool.request("GET", "https://example.com/", extensions=extensions)
+                pool.request(
+                    "GET",
+                    "https://example.com/",
+                    extensions={"timeout": {"pool": 0.0001}},
+                )


### PR DESCRIPTION
Implementing a `TypedDict` object for `request.extensions` as in #523. 

For maintaining the optional flags over the extensions the `total` flag was set to false.
I also added the `Dict[str, Any]` for the kwargs as mypy would not recognize the unpacking of kwargs.