### PR TITLE
drop redundant pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,4 @@ mypy==0.931
 pytest==7.0.1
 pytest-httpbin==1.0.1
 pytest-trio==0.7.0
-pytest-asyncio==0.16.0
 werkzeug<2.1  # See: https://github.com/postmanlabs/httpbin/issues/673


### PR DESCRIPTION
fixes https://github.com/encode/httpcore/issues/548

the last use of pytest-asyncio was removed in f9b93918a54a49a4e917824ad38cf5bd8da21450