### PR TITLE
Update types for h11 v0.14

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -8,8 +8,8 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    cast,
     Union,
+    cast,
 )
 
 import h11
@@ -199,7 +199,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
                 # TODO: Implement handling for paused
                 ...
             else:
-                return event
+                return cast(h11.Event, event)
 
     async def _response_closed(self) -> None:
         async with self._state_lock:

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -26,13 +26,13 @@ from .._trace import Trace
 from ..backends.base import AsyncNetworkStream
 from .interfaces import AsyncConnectionInterface
 
-
 # A subset of `h11.Event` types supported by `_send_event`
 H11SendEvent = Union[
     h11.Request,
     h11.Data,
     h11.EndOfMessage,
 ]
+
 
 class HTTPConnectionState(enum.IntEnum):
     NEW = 0

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -27,6 +27,13 @@ from ..backends.base import AsyncNetworkStream
 from .interfaces import AsyncConnectionInterface
 
 
+# A subset of `h11.Event` types supported by `_send_event`
+H11SendEvent = Union[
+    h11.Request,
+    h11.Data,
+    h11.EndOfMessage,
+]
+
 class HTTPConnectionState(enum.IntEnum):
     NEW = 0
     ACTIVE = 1

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -133,7 +133,8 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
         self, event: H11Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        await self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            await self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -127,8 +127,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
             event = h11.Data(data=chunk)
             await self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        await self._send_event(event, timeout=timeout)
+        await self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     async def _send_event(
         self, event: H11Event, timeout: Optional[float] = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -170,16 +170,12 @@ class HTTP11Connection(ConnectionInterface):
 
     def _receive_event(
         self, timeout: Optional[float] = None
-    ) -> Union[h11.Event, h11.PAUSED]:
+    ) -> Union[h11.Event, Type[h11.PAUSED]]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
-                # The h11 type signature uses a private return type
-                event = cast(
-                    Union[h11.Event, h11.NEED_DATA, h11.PAUSED],
-                    self._h11_state.next_event(),
-                )
+                event =  self._h11_state.next_event()
 
-            if isinstance(event, h11.NEED_DATA):
+            if event is h11.NEED_DATA:
                 data = self._network_stream.read(
                     self.READ_NUM_BYTES, timeout=timeout
                 )
@@ -198,7 +194,8 @@ class HTTP11Connection(ConnectionInterface):
 
                 self._h11_state.receive_data(data)
             else:
-                return event
+                # mypy fails to narrow the type in the above if statement above
+                return cast(Union[h11.Event, Type[h11.PAUSED]], event)
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -26,7 +26,6 @@ from .._trace import Trace
 from ..backends.base import NetworkStream
 from .interfaces import ConnectionInterface
 
-
 # A subset of `h11.Event` types supported by `_send_event`
 H11SendEvent = Union[
     h11.Request,
@@ -138,7 +137,7 @@ class HTTP11Connection(ConnectionInterface):
         self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     def _send_event(
-        self, event: H11SendEvent, timeout: Optional[float] = None
+        self, event: h11.Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
         if bytes_to_send is not None:
@@ -181,7 +180,7 @@ class HTTP11Connection(ConnectionInterface):
     ) -> Union[h11.Event, Type[h11.PAUSED]]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
-                event =  self._h11_state.next_event()
+                event = self._h11_state.next_event()
 
             if event is h11.NEED_DATA:
                 data = self._network_stream.read(

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -27,6 +27,14 @@ from ..backends.base import NetworkStream
 from .interfaces import ConnectionInterface
 
 
+# A subset of `h11.Event` types supported by `_send_event`
+H11SendEvent = Union[
+    h11.Request,
+    h11.Data,
+    h11.EndOfMessage,
+]
+
+
 class HTTPConnectionState(enum.IntEnum):
     NEW = 0
     ACTIVE = 1
@@ -130,7 +138,7 @@ class HTTP11Connection(ConnectionInterface):
         self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     def _send_event(
-        self, event: h11.Event, timeout: Optional[float] = None
+        self, event: H11SendEvent, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
         if bytes_to_send is not None:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -127,8 +127,7 @@ class HTTP11Connection(ConnectionInterface):
             event = h11.Data(data=chunk)
             self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        self._send_event(event, timeout=timeout)
+        self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     def _send_event(
         self, event: H11Event, timeout: Optional[float] = None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -168,7 +168,9 @@ class HTTP11Connection(ConnectionInterface):
             elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
-    def _receive_event(self, timeout: Optional[float] = None) -> h11.Event:
+    def _receive_event(
+        self, timeout: Optional[float] = None
+    ) -> Union[h11.Event, h11.PAUSED]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
                 # The h11 type signature uses a private return type
@@ -177,7 +179,7 @@ class HTTP11Connection(ConnectionInterface):
                     self._h11_state.next_event(),
                 )
 
-            if event is h11.NEED_DATA:
+            if isinstance(event, h11.NEED_DATA):
                 data = self._network_stream.read(
                     self.READ_NUM_BYTES, timeout=timeout
                 )
@@ -195,11 +197,8 @@ class HTTP11Connection(ConnectionInterface):
                     raise RemoteProtocolError(msg)
 
                 self._h11_state.receive_data(data)
-            elif event is h11.PAUSED:
-                # TODO: Implement handling for paused
-                ...
             else:
-                return cast(h11.Event, event)
+                return event
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -184,7 +184,7 @@ class HTTP11Connection(ConnectionInterface):
                 # TODO: Implement handling for paused
                 ...
             else:
-                return event
+                return cast(h11.Event, event)
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,7 +1,16 @@
 import enum
 import time
 from types import TracebackType
-from typing import Iterable, Iterator, List, Optional, Tuple, Type, Union, cast
+from typing import (
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import h11
 
@@ -64,7 +73,9 @@ class HTTP11Connection(ConnectionInterface):
                 self._send_request_headers(**kwargs)
             with Trace("http11.send_request_body", request, kwargs) as trace:
                 self._send_request_body(**kwargs)
-            with Trace("http11.receive_response_headers", request, kwargs) as trace:
+            with Trace(
+                "http11.receive_response_headers", request, kwargs
+            ) as trace:
                 (
                     http_version,
                     status,
@@ -118,7 +129,9 @@ class HTTP11Connection(ConnectionInterface):
 
         self._send_event(h11.EndOfMessage(), timeout=timeout)
 
-    def _send_event(self, event: h11.Event, timeout: Optional[float] = None) -> None:
+    def _send_event(
+        self, event: h11.Event, timeout: Optional[float] = None
+    ) -> None:
         bytes_to_send = self._h11_state.send(event)
         if bytes_to_send is not None:
             self._network_stream.write(bytes_to_send, timeout=timeout)
@@ -165,7 +178,9 @@ class HTTP11Connection(ConnectionInterface):
                 )
 
             if event is h11.NEED_DATA:
-                data = self._network_stream.read(self.READ_NUM_BYTES, timeout=timeout)
+                data = self._network_stream.read(
+                    self.READ_NUM_BYTES, timeout=timeout
+                )
 
                 # If we feed this case through h11 we'll raise an exception like:
                 #

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -133,7 +133,8 @@ class HTTP11Connection(ConnectionInterface):
         self, event: H11Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<=0.13",
+        "h11>=0.11,<0.14",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.13",
+        "h11>=0.11,<=0.13",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",
@@ -73,7 +73,6 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.14",
+        "h11>=0.11,<0.15",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.15",
+        "h11>=0.13,<0.15",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",


### PR DESCRIPTION
Extends and supersedes #526. 

Updates the types in `_send_event` and `recieve_event` for compatibility with h11 0.14.0.

Tests and `mypy` were run locally on h11 0.13.0 and 0.14.0.

Closes https://github.com/encode/httpcore/pull/503
Closes https://github.com/encode/httpcore/pull/498
Unblocks https://github.com/encode/httpcore/issues/509

### Differences from #526

#### Removes cast from the "hot loop"

h11 0.14.0 includes the upstream fix https://github.com/python-hyper/h11/commit/04cc0f781c47ebfb9f9b188a8e8aa423f276c0b1 allowing us to remove the cast and `isinstance` check from the hot loop which @graingert expressed concerns about in https://github.com/encode/httpcore/pull/526#discussion_r901134892.  A cast is still required for the return value as mypy is not type-narrowing on the `is` clause. We'd probably have to do a weird `isinstance/issubclass` combination to avoid the cast, which would bring us back to the original concerns about affected performance.

Interestingly, `mypy` passes with h11 0.13.0 so we may have been able to use this implementation without the upstream change.

#### Addresses narrower types

Updates the `_send_event` types to be narrower as mentioned in https://github.com/encode/httpcore/pull/526#discussion_r901136131. If overloads are added to the h11 library, this will allow us to remove an unnecessary null check as noted in https://github.com/encode/httpcore/pull/526#discussion_r901136483.

#### Bumps minimum h11 version

Bumps the minimum h11 version to 0.13.0 which is required for the `h11.Event` type. I imagine we could create a conditional stub for the type if support for older versions of h11 is important.
