### PR TITLE
Add "trailing_headers" extension for HTTP/1.1

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -232,9 +232,13 @@ with httpcore.stream("GET", "https://www.example.com") as response:
 
 Trailing headers are a rarely used feature of HTTP, where supplementary headers may be sent at the end of the response data.
 
-The `trailing_headers` response extension is implemented as a list of `(byte, byte)` tuples containing any [trailing headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#chunked_transfer_encoding_using_a_trailing_header) sent at the end of the response. This list is only populated once the response is complete, and will be empty while streaming the response data.
+The `trailing_headers` response extenstion is implemented as a list of `(byte, byte)` tuples containing any [trailing headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#chunked_transfer_encoding_using_a_trailing_header) sent at the end of the response. This list is only populated once the response is complete, and will be empty while streaming the response data.
 
 ```python
+# The "TE: trailers" header should be used in order to indicate that we're
+# willing to accept trailing headers. This isn't required by the `httpcore`
+# package itself, but is mandated by the HTTP spec, and might be required
+# by some servers or proxies.
 response = httpcore.request("GET", "https://www.example.com", headers={"TE": "trailers"})
 
 # Show the standard response headers.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -227,3 +227,19 @@ with httpcore.stream("GET", "https://www.example.com") as response:
     ssl_object = network_stream.get_extra_info("ssl_object")
     print("TLS version", ssl_object.version())
 ```
+
+### `"trailing_headers"`
+
+Trailing headers are a rarely used feature of HTTP, where supplementary headers may be sent at the end of the response data.
+
+The `trailing_headers` response extenstion is implemented as a list of `(byte, byte)` tuples containing any [trailing headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#chunked_transfer_encoding_using_a_trailing_header) sent at the end of the response. This list is only populated once the response is complete, and will be empty while streaming the response data.
+
+```python
+response = httpcore.request("GET", "https://www.example.com")
+
+# Show the standard response headers.
+print(response.headers)
+
+# Show any trailing headers sent at the end of the response.
+print(response.extensions['trailing_headers'])
+```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -235,7 +235,7 @@ Trailing headers are a rarely used feature of HTTP, where supplementary headers 
 The `trailing_headers` response extenstion is implemented as a list of `(byte, byte)` tuples containing any [trailing headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#chunked_transfer_encoding_using_a_trailing_header) sent at the end of the response. This list is only populated once the response is complete, and will be empty while streaming the response data.
 
 ```python
-response = httpcore.request("GET", "https://www.example.com")
+response = httpcore.request("GET", "https://www.example.com", headers={"TE": "trailers"})
 
 # Show the standard response headers.
 print(response.headers)

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -181,7 +181,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
             elif isinstance(event, h11.EndOfMessage):
                 # Once we get an EndOfMessage event, the response data has finished.
                 if event.headers:
-                    trailing_headers.extend(event.headers)
+                    trailing_headers.extend(event.headers.raw_items())
                 break
             elif isinstance(event, h11.PAUSED):
                 # This can occur here on a successful CONNECT or Upgrade

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -1,7 +1,16 @@
 import enum
 import time
 from types import TracebackType
-from typing import AsyncIterable, AsyncIterator, List, Optional, Tuple, Type, Union
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import h11
 
@@ -17,13 +26,11 @@ from .._trace import Trace
 from ..backends.base import AsyncNetworkStream
 from .interfaces import AsyncConnectionInterface
 
-H11Event = Union[
+# A subset of `h11.Event` types supported by `_send_event`
+H11SendEvent = Union[
     h11.Request,
-    h11.Response,
-    h11.InformationalResponse,
     h11.Data,
     h11.EndOfMessage,
-    h11.ConnectionClosed,
 ]
 
 
@@ -127,14 +134,14 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
             event = h11.Data(data=chunk)
             await self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        await self._send_event(event, timeout=timeout)
+        await self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     async def _send_event(
-        self, event: H11Event, timeout: Optional[float] = None
+        self, event: h11.Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        await self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            await self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 
@@ -168,7 +175,9 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
             elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
-    async def _receive_event(self, timeout: Optional[float] = None) -> H11Event:
+    async def _receive_event(
+        self, timeout: Optional[float] = None
+    ) -> Union[h11.Event, Type[h11.PAUSED]]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
                 event = self._h11_state.next_event()
@@ -192,7 +201,8 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
 
                 self._h11_state.receive_data(data)
             else:
-                return event
+                # mypy fails to narrow the type in the above if statement above
+                return cast(Union[h11.Event, Type[h11.PAUSED]], event)
 
     async def _response_closed(self) -> None:
         async with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -181,7 +181,7 @@ class HTTP11Connection(ConnectionInterface):
             elif isinstance(event, h11.EndOfMessage):
                 # Once we get an EndOfMessage event, the response data has finished.
                 if event.headers:
-                    trailing_headers.extend(event.headers)
+                    trailing_headers.extend(event.headers.raw_items())
                 break
             elif isinstance(event, h11.PAUSED):
                 # This can occur here on a successful CONNECT or Upgrade

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,7 +1,16 @@
 import enum
 import time
 from types import TracebackType
-from typing import Iterable, Iterator, List, Optional, Tuple, Type, Union
+from typing import (
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import h11
 
@@ -17,13 +26,11 @@ from .._trace import Trace
 from ..backends.base import NetworkStream
 from .interfaces import ConnectionInterface
 
-H11Event = Union[
+# A subset of `h11.Event` types supported by `_send_event`
+H11SendEvent = Union[
     h11.Request,
-    h11.Response,
-    h11.InformationalResponse,
     h11.Data,
     h11.EndOfMessage,
-    h11.ConnectionClosed,
 ]
 
 
@@ -127,14 +134,14 @@ class HTTP11Connection(ConnectionInterface):
             event = h11.Data(data=chunk)
             self._send_event(event, timeout=timeout)
 
-        event = h11.EndOfMessage()
-        self._send_event(event, timeout=timeout)
+        self._send_event(h11.EndOfMessage(), timeout=timeout)
 
     def _send_event(
-        self, event: H11Event, timeout: Optional[float] = None
+        self, event: h11.Event, timeout: Optional[float] = None
     ) -> None:
         bytes_to_send = self._h11_state.send(event)
-        self._network_stream.write(bytes_to_send, timeout=timeout)
+        if bytes_to_send is not None:
+            self._network_stream.write(bytes_to_send, timeout=timeout)
 
     # Receiving the response...
 
@@ -168,7 +175,9 @@ class HTTP11Connection(ConnectionInterface):
             elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
                 break
 
-    def _receive_event(self, timeout: Optional[float] = None) -> H11Event:
+    def _receive_event(
+        self, timeout: Optional[float] = None
+    ) -> Union[h11.Event, Type[h11.PAUSED]]:
         while True:
             with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
                 event = self._h11_state.next_event()
@@ -192,7 +201,8 @@ class HTTP11Connection(ConnectionInterface):
 
                 self._h11_state.receive_data(data)
             else:
-                return event
+                # mypy fails to narrow the type in the above if statement above
+                return cast(Union[h11.Event, Type[h11.PAUSED]], event)
 
     def _response_closed(self) -> None:
         with self._state_lock:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -96,14 +96,16 @@ class HTTP11Connection(ConnectionInterface):
                     headers,
                 )
 
+            trailing_headers: List[Tuple[bytes, bytes]] = []
             return Response(
                 status=status,
                 headers=headers,
-                content=HTTP11ConnectionByteStream(self, request),
+                content=HTTP11ConnectionByteStream(self, request, trailing_headers),
                 extensions={
                     "http_version": http_version,
                     "reason_phrase": reason_phrase,
                     "network_stream": self._network_stream,
+                    "trailing_headers": trailing_headers,
                 },
             )
         except BaseException as exc:
@@ -164,15 +166,28 @@ class HTTP11Connection(ConnectionInterface):
 
         return http_version, event.status_code, event.reason, headers
 
-    def _receive_response_body(self, request: Request) -> Iterator[bytes]:
+    def _receive_response_body(
+        self, request: Request, trailing_headers: List[Tuple[bytes, bytes]]
+    ) -> Iterator[bytes]:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
         while True:
             event = self._receive_event(timeout=timeout)
             if isinstance(event, h11.Data):
+                # Each response will have zero, one, or more data events,
+                # containing the body of the response.
                 yield bytes(event.data)
-            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
+            elif isinstance(event, h11.EndOfMessage):
+                # Once we get an EndOfMessage event, the response data has finished.
+                if event.headers:
+                    trailing_headers.extend(event.headers)
+                break
+            elif isinstance(event, h11.PAUSED):
+                # This can occur here on a successful CONNECT or Upgrade
+                # response, where it is returned rather than EndOfMessage.
+                #
+                # See https://h11.readthedocs.io/en/latest/api.html#flow-control
                 break
 
     def _receive_event(
@@ -291,16 +306,24 @@ class HTTP11Connection(ConnectionInterface):
 
 
 class HTTP11ConnectionByteStream:
-    def __init__(self, connection: HTTP11Connection, request: Request) -> None:
+    def __init__(
+        self,
+        connection: HTTP11Connection,
+        request: Request,
+        trailing_headers: List[Tuple[bytes, bytes]],
+    ) -> None:
         self._connection = connection
         self._request = request
+        self._trailing_headers = trailing_headers
         self._closed = False
 
     def __iter__(self) -> Iterator[bytes]:
-        kwargs = {"request": self._request}
+        kwargs = {"request": self._request, "trailing_headers": self._trailing_headers}
         try:
             with Trace("http11.receive_response_body", self._request, kwargs):
-                for chunk in self._connection._receive_response_body(**kwargs):
+                for chunk in self._connection._receive_response_body(
+                    request=self._request, trailing_headers=self._trailing_headers
+                ):
                     yield chunk
         except BaseException as exc:
             # If we get an exception while streaming the response,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "h11>=0.11,<0.13",
+        "h11>=0.13,<0.15",
         "sniffio==1.*",
         "anyio==3.*",
         "certifi",

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -76,6 +76,44 @@ async def test_http11_connection_chunked_response():
 
 
 @pytest.mark.anyio
+async def test_http11_connection_trailing_headers_response():
+    origin = Origin(b"https", b"example.com", 443)
+    stream = AsyncMockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Transfer-Encoding: chunked\r\n",
+            b"Trailer: Surprise\r\n",
+            b"\r\n",
+            b"3\r\n",
+            b"Hel\r\n",
+            b"4\r\n",
+            b"lo, \r\n",
+            b"6\r\n",
+            b"world!\r\n",
+            b"0\r\n",
+            b"Surprise: You thought we were done here?\r\n",
+            b"\r\n",
+        ]
+    )
+    async with AsyncHTTP11Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        response = await conn.request(
+            "GET", "https://example.com/", headers={"TE": "trailers"}
+        )
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        assert response.headers == [
+            (b"Content-Type", b"plain/text"),
+            (b"Transfer-Encoding", b"chunked"),
+            (b"Trailer", b"Surprise"),
+        ]
+        trailing_headers = response.extensions["trailing_headers"]
+        assert trailing_headers == [(b"Surprise", b"You thought we were done here?")]
+
+
+@pytest.mark.anyio
 async def test_http11_connection_unread_response():
     """
     If the client releases the response without reading it to termination,

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -40,6 +40,42 @@ async def test_http11_connection():
 
 
 @pytest.mark.anyio
+async def test_http11_connection_chunked_response():
+    origin = Origin(b"https", b"example.com", 443)
+    stream = AsyncMockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Transfer-Encoding: chunked\r\n",
+            b"\r\n",
+            b"3\r\n",
+            b"Hel\r\n",
+            b"4\r\n",
+            b"lo, \r\n",
+            b"6\r\n",
+            b"world!\r\n",
+            b"0\r\n",
+            b"\r\n",
+        ]
+    )
+    async with AsyncHTTP11Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        response = await conn.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+        assert conn.is_idle()
+        assert not conn.is_closed()
+        assert conn.is_available()
+        assert not conn.has_expired()
+        assert (
+            repr(conn)
+            == "<AsyncHTTP11Connection ['https://example.com:443', IDLE, Request Count: 1]>"
+        )
+
+
+@pytest.mark.anyio
 async def test_http11_connection_unread_response():
     """
     If the client releases the response without reading it to termination,


### PR DESCRIPTION
See https://github.com/encode/httpx/issues/1149

Adding support in HTTP/2 should be similar, requiring the `h2.TrailersReceived` event to populate any trailing headers.

https://python-hyper.org/projects/h2/en/stable/api.html#h2.events.TrailersReceived