### PR TITLE
Pin importlib-metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ black==22.8.0
 coverage==6.4.4
 flake8==3.9.2  # See: https://github.com/PyCQA/flake8/pull/1438
 isort==5.10.1
+importlib-metadata==4.13.0
 mypy==0.971
 pytest==7.1.3
 pytest-httpbin==2.0.0rc1


### PR DESCRIPTION
See https://github.com/encode/httpcore/pull/583

I've not understood yet *why* importlib-metadata==5.0 breaks the linting for us, or double checked *which* Python version it breaks for, but first step is to get our CI back to clear.