### PR TITLE
Handle 1xx interim response codes

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -153,7 +153,12 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
 
         while True:
             event = await self._receive_event(timeout=timeout)
-            if isinstance(event, (h11.Response, h11.InformationalResponse)):
+            if isinstance(event, h11.Response):
+                break
+            if (
+                isinstance(event, h11.InformationalResponse)
+                and event.status_code == 101
+            ):
                 break
 
         http_version = b"HTTP/" + event.http_version

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -153,7 +153,12 @@ class HTTP11Connection(ConnectionInterface):
 
         while True:
             event = self._receive_event(timeout=timeout)
-            if isinstance(event, (h11.Response, h11.InformationalResponse)):
+            if isinstance(event, h11.Response):
+                break
+            if (
+                isinstance(event, h11.InformationalResponse)
+                and event.status_code == 101
+            ):
                 break
 
         http_version = b"HTTP/" + event.http_version

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -209,11 +209,53 @@ async def test_http11_request_to_incorrect_origin():
 
 
 @pytest.mark.anyio
-async def test_http11_upgrade_connection():
+async def test_http11_expect_continue():
+    """
+    HTTP "100 Continue" is an interim response.
+    We simply ignore it and return the final response.
+
+    https://httpwg.org/specs/rfc9110.html#status.100
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/100
+    """
     origin = Origin(b"https", b"example.com", 443)
     stream = AsyncMockStream(
         [
-            b"HTTP/1.1 101 OK\r\n",
+            b"HTTP/1.1 100 Continue\r\n",
+            b"\r\n",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+    async with AsyncHTTP11Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        response = await conn.request(
+            "GET",
+            "https://example.com/",
+            headers={"Expect": "continue"},
+        )
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_http11_upgrade_connection():
+    """
+    HTTP "101 Switching Protocols" indicates an upgraded connection.
+
+    We should return the response, so that the network stream
+    may be used for the upgraded connection.
+
+    https://httpwg.org/specs/rfc9110.html#status.101
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
+    """
+    origin = Origin(b"https", b"example.com", 443)
+    stream = AsyncMockStream(
+        [
+            b"HTTP/1.1 101 Switching Protocols\r\n",
             b"Connection: upgrade\r\n",
             b"Upgrade: custom\r\n",
             b"\r\n",
@@ -232,3 +274,39 @@ async def test_http11_upgrade_connection():
             network_stream = response.extensions["network_stream"]
             content = await network_stream.read(max_bytes=1024)
             assert content == b"..."
+
+
+@pytest.mark.anyio
+async def test_http11_early_hints():
+    """
+    HTTP "103 Early Hints" is an interim response.
+    We simply ignore it and return the final response.
+
+    https://datatracker.ietf.org/doc/rfc8297/
+    """
+    origin = Origin(b"https", b"example.com", 443)
+    stream = AsyncMockStream(
+        [
+            b"HTTP/1.1 103 Early Hints\r\n",
+            b"Link: </style.css>; rel=preload; as=style\r\n",
+            b"Link: </script.js.css>; rel=preload; as=style\r\n",
+            b"\r\n",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: text/html; charset=utf-8\r\n",
+            b"Content-Length: 30\r\n",
+            b"Link: </style.css>; rel=preload; as=style\r\n",
+            b"Link: </script.js>; rel=preload; as=script\r\n",
+            b"\r\n",
+            b"<html>Hello, world! ...</html>",
+        ]
+    )
+    async with AsyncHTTP11Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        response = await conn.request(
+            "GET",
+            "https://example.com/",
+            headers={"Expect": "continue"},
+        )
+        assert response.status == 200
+        assert response.content == b"<html>Hello, world! ...</html>"


### PR DESCRIPTION
This [discussion on httpx](https://github.com/encode/httpx/discussions/2438) indicates that the latest `httpcore` version has introduced a change in behaviour for "100 Continue" status codes.

This highlights that https://github.com/encode/httpcore/pull/581 has *fixed* our behaviour for "101 Switching Protocols" which is a *final* response code. But *breaks* our behaviour for "100 Continue", "102 Processing", and "103 Early Hints" statues codes, which are all *interim* response codes.

Our behaviour for now ought to treat any `1xx` response codes as interim responses, with the exception of "101 Switching Protocols".

- [x] Tests for 100 and 103 status codes.
- [x] Fix behaviour for 100 and 103 status codes.

Note that in this PR I've only added tests for 100 and 103, since that's sufficient.

We could feasibly have additional smarts around how we deal with the interim cases. For example we *could* defer sending request bodies on "Expect: continue" requests, until we see a "100 continue". But that's really a different story.