### PR TITLE
Replace use of deprecated `socket.error` > `OSError`

### DIFF
--- a/httpcore/backends/sync.py
+++ b/httpcore/backends/sync.py
@@ -20,7 +20,7 @@ class SyncStream(NetworkStream):
         self._sock = sock
 
     def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
-        exc_map = {socket.timeout: ReadTimeout, socket.error: ReadError}
+        exc_map = {socket.timeout: ReadTimeout, OSError: ReadError}
         with map_exceptions(exc_map):
             self._sock.settimeout(timeout)
             return self._sock.recv(max_bytes)
@@ -29,7 +29,7 @@ class SyncStream(NetworkStream):
         if not buffer:
             return
 
-        exc_map = {socket.timeout: WriteTimeout, socket.error: WriteError}
+        exc_map = {socket.timeout: WriteTimeout, OSError: WriteError}
         with map_exceptions(exc_map):
             while buffer:
                 self._sock.settimeout(timeout)
@@ -45,7 +45,7 @@ class SyncStream(NetworkStream):
         server_hostname: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
     ) -> NetworkStream:
-        exc_map = {socket.timeout: ConnectTimeout, socket.error: ConnectError}
+        exc_map = {socket.timeout: ConnectTimeout, OSError: ConnectError}
         with map_exceptions(exc_map):
             try:
                 self._sock.settimeout(timeout)
@@ -81,7 +81,7 @@ class SyncBackend(NetworkBackend):
     ) -> NetworkStream:
         address = (host, port)
         source_address = None if local_address is None else (local_address, 0)
-        exc_map = {socket.timeout: ConnectTimeout, socket.error: ConnectError}
+        exc_map = {socket.timeout: ConnectTimeout, OSError: ConnectError}
         with map_exceptions(exc_map):
             sock = socket.create_connection(
                 address, timeout, source_address=source_address
@@ -91,7 +91,7 @@ class SyncBackend(NetworkBackend):
     def connect_unix_socket(
         self, path: str, timeout: typing.Optional[float] = None
     ) -> NetworkStream:  # pragma: nocover
-        exc_map = {socket.timeout: ConnectTimeout, socket.error: ConnectError}
+        exc_map = {socket.timeout: ConnectTimeout, OSError: ConnectError}
         with map_exceptions(exc_map):
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(timeout)


### PR DESCRIPTION
As discussed in #607, leave `socket.timeout` alone.