### PR TITLE
Remove global `ignore_missing_imports` mypy option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ flake8==3.9.2  # See: https://github.com/PyCQA/flake8/pull/1438
 isort==5.10.1
 importlib-metadata==4.13.0
 mypy==0.981
+types-certifi==2021.10.8.3
 pytest==7.1.3
 pytest-httpbin==2.0.0rc1
 pytest-trio==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ flake8==3.9.2  # See: https://github.com/PyCQA/flake8/pull/1438
 isort==5.10.1
 importlib-metadata==4.13.0
 mypy==0.981
-types-certifi==2021.10.8.3
 pytest==7.1.3
 pytest-httpbin==2.0.0rc1
 pytest-trio==0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ show_error_codes = True
 disallow_untyped_defs = False
 check_untyped_defs = True
 
+[mypy-certifi.*]
+ignore_missing_imports = True
+
 [mypy-h2.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,23 @@ exclude = httpcore/_sync,tests/_sync
 
 [mypy]
 strict = True
-ignore_missing_imports = True
 show_error_codes = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False
 check_untyped_defs = True
+
+[mypy-certifi.*]
+ignore_missing_imports = True
+
+[mypy-h2.*]
+ignore_missing_imports = True
+
+[mypy-hpack.*]
+ignore_missing_imports = True
+
+[mypy-trio.*]
+ignore_missing_imports = True
 
 [tool:isort]
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ show_error_codes = True
 disallow_untyped_defs = False
 check_untyped_defs = True
 
-[mypy-certifi.*]
-ignore_missing_imports = True
-
 [mypy-h2.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
The mypy [docs](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker) says the following about using a global `ignore_missing_imports` option:

> We recommend using this approach only as a last resort: it’s equivalent to adding a # type: ignore to all unresolved imports in your codebase.

This change explicitly states which modules to ignore instead.

Refs #514 