### PR TITLE
Allow `ws` and `wss` schemes.

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -208,7 +208,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
             raise UnsupportedProtocol(
                 "Request URL is missing an 'http://' or 'https://' protocol."
             )
-        if scheme not in ("http", "https"):
+        if scheme not in ("http", "https", "ws", "wss"):
             raise UnsupportedProtocol(
                 f"Request URL has an unsupported protocol '{scheme}://'."
             )

--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -285,7 +285,13 @@ class URL:
 
     @property
     def origin(self) -> Origin:
-        default_port = {b"http": 80, b"https": 443, b"socks5": 1080}[self.scheme]
+        default_port = {
+            b"http": 80,
+            b"https": 443,
+            b"ws": 80,
+            b"wss": 443,
+            b"socks5": 1080,
+        }[self.scheme]
         return Origin(
             scheme=self.scheme, host=self.host, port=self.port or default_port
         )

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -208,7 +208,7 @@ class ConnectionPool(RequestInterface):
             raise UnsupportedProtocol(
                 "Request URL is missing an 'http://' or 'https://' protocol."
             )
-        if scheme not in ("http", "https"):
+        if scheme not in ("http", "https", "ws", "wss"):
             raise UnsupportedProtocol(
                 f"Request URL has an unsupported protocol '{scheme}://'."
             )

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -493,3 +493,37 @@ async def test_connection_pool_timeout():
             with pytest.raises(PoolTimeout):
                 extensions = {"timeout": {"pool": 0.0001}}
                 await pool.request("GET", "https://example.com/", extensions=extensions)
+
+
+@pytest.mark.anyio
+async def test_http11_upgrade_connection():
+    """
+    HTTP "101 Switching Protocols" indicates an upgraded connection.
+
+    We should return the response, so that the network stream
+    may be used for the upgraded connection.
+
+    https://httpwg.org/specs/rfc9110.html#status.101
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
+    """
+    network_backend = AsyncMockBackend(
+        [
+            b"HTTP/1.1 101 Switching Protocols\r\n",
+            b"Connection: upgrade\r\n",
+            b"Upgrade: custom\r\n",
+            b"\r\n",
+            b"...",
+        ]
+    )
+    async with AsyncConnectionPool(
+        network_backend=network_backend, max_connections=1
+    ) as pool:
+        async with pool.stream(
+            "GET",
+            "wss://example.com/",
+            headers={"Connection": "upgrade", "Upgrade": "custom"},
+        ) as response:
+            assert response.status == 101
+            network_stream = response.extensions["network_stream"]
+            content = await network_stream.read(max_bytes=1024)
+            assert content == b"..."

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -252,7 +252,7 @@ async def test_http11_upgrade_connection():
     https://httpwg.org/specs/rfc9110.html#status.101
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
     """
-    origin = Origin(b"https", b"example.com", 443)
+    origin = Origin(b"wss", b"example.com", 443)
     stream = AsyncMockStream(
         [
             b"HTTP/1.1 101 Switching Protocols\r\n",
@@ -267,7 +267,7 @@ async def test_http11_upgrade_connection():
     ) as conn:
         async with conn.stream(
             "GET",
-            "https://example.com/",
+            "wss://example.com/",
             headers={"Connection": "upgrade", "Upgrade": "custom"},
         ) as response:
             assert response.status == 101

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -493,3 +493,37 @@ def test_connection_pool_timeout():
             with pytest.raises(PoolTimeout):
                 extensions = {"timeout": {"pool": 0.0001}}
                 pool.request("GET", "https://example.com/", extensions=extensions)
+
+
+
+def test_http11_upgrade_connection():
+    """
+    HTTP "101 Switching Protocols" indicates an upgraded connection.
+
+    We should return the response, so that the network stream
+    may be used for the upgraded connection.
+
+    https://httpwg.org/specs/rfc9110.html#status.101
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
+    """
+    network_backend = MockBackend(
+        [
+            b"HTTP/1.1 101 Switching Protocols\r\n",
+            b"Connection: upgrade\r\n",
+            b"Upgrade: custom\r\n",
+            b"\r\n",
+            b"...",
+        ]
+    )
+    with ConnectionPool(
+        network_backend=network_backend, max_connections=1
+    ) as pool:
+        with pool.stream(
+            "GET",
+            "wss://example.com/",
+            headers={"Connection": "upgrade", "Upgrade": "custom"},
+        ) as response:
+            assert response.status == 101
+            network_stream = response.extensions["network_stream"]
+            content = network_stream.read(max_bytes=1024)
+            assert content == b"..."

--- a/tests/_sync/test_http11.py
+++ b/tests/_sync/test_http11.py
@@ -252,7 +252,7 @@ def test_http11_upgrade_connection():
     https://httpwg.org/specs/rfc9110.html#status.101
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
     """
-    origin = Origin(b"https", b"example.com", 443)
+    origin = Origin(b"wss", b"example.com", 443)
     stream = MockStream(
         [
             b"HTTP/1.1 101 Switching Protocols\r\n",
@@ -267,7 +267,7 @@ def test_http11_upgrade_connection():
     ) as conn:
         with conn.stream(
             "GET",
-            "https://example.com/",
+            "wss://example.com/",
             headers={"Connection": "upgrade", "Upgrade": "custom"},
         ) as response:
             assert response.status == 101


### PR DESCRIPTION
Allow URLs that use `ws` and `wss` schemes.
 
Refs https://github.com/encode/httpx/issues/304