### PR TITLE
Revert "Fix async cancellation behaviour"

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -214,9 +214,9 @@ class AsyncConnectionPool(AsyncRequestInterface):
             )
 
         status = RequestStatus(request)
-        self._requests.append(status)
 
         async with self._pool_lock:
+            self._requests.append(status)
             await self._close_expired_connections()
             await self._attempt_to_acquire_connection(status)
 
@@ -229,8 +229,9 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 # If we timeout here, or if the task is cancelled, then make
                 # sure to remove the request from the queue before bubbling
                 # up the exception.
-                self._requests.remove(status)
-                raise exc
+                async with self._pool_lock:
+                    self._requests.remove(status)
+                    raise exc
 
             try:
                 response = await connection.handle_async_request(request)
@@ -273,11 +274,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
         assert status.connection is not None
         connection = status.connection
 
-        if status in self._requests:
-            self._requests.remove(status)
-
         async with self._pool_lock:
             # Update the state of the connection pool.
+            if status in self._requests:
+                self._requests.remove(status)
 
             if connection.is_closed() and connection in self._pool:
                 self._pool.remove(connection)


### PR DESCRIPTION
This reverts pull request #580.

Any accesses to modifying `._pool` or `._requests` should always be guarded by first holding the `._pool_lock`.
Pull request #580 was the wrong approach to resolving https://github.com/encode/httpcore/issues/564.

Closes #613, #615, #621, #624.

Reopens #564 - this is a lower priority bug. I believe I have the correct approach to resolving this, but will follow up with it separately to this pull request.
