### PR TITLE
Use type package for `certifi`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ flake8==3.9.2  # See: https://github.com/PyCQA/flake8/pull/1438
 isort==5.10.1
 importlib-metadata==4.13.0
 mypy==0.981
+types-certifi==2021.10.8.3
 pytest==7.1.3
 pytest-httpbin==2.0.0rc1
 pytest-trio==0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ show_error_codes = True
 disallow_untyped_defs = False
 check_untyped_defs = True
 
-[mypy-certifi.*]
-ignore_missing_imports = True
-
 [mypy-h2.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Use third party type package for `certify`, `types-certify` from typeshed https://github.com/python/typeshed/tree/main/stubs/certifi.

Refs #618 #514