### PR TITLE
Drop `RuntimeError` on closing a connection pool with active connections.

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -301,18 +301,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
         Close any connections in the pool.
         """
         async with self._pool_lock:
-            requests_still_in_flight = len(self._requests)
-
             for connection in self._pool:
                 await connection.aclose()
             self._pool = []
             self._requests = []
-
-            if requests_still_in_flight:
-                raise RuntimeError(
-                    f"The connection pool was closed while {requests_still_in_flight} "
-                    f"HTTP requests/responses were still in-flight."
-                )
 
     async def __aenter__(self) -> "AsyncConnectionPool":
         return self

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -301,18 +301,10 @@ class ConnectionPool(RequestInterface):
         Close any connections in the pool.
         """
         with self._pool_lock:
-            requests_still_in_flight = len(self._requests)
-
             for connection in self._pool:
                 connection.close()
             self._pool = []
             self._requests = []
-
-            if requests_still_in_flight:
-                raise RuntimeError(
-                    f"The connection pool was closed while {requests_still_in_flight} "
-                    f"HTTP requests/responses were still in-flight."
-                )
 
     def __enter__(self) -> "ConnectionPool":
         return self

--- a/httpcore/backends/asyncio.py
+++ b/httpcore/backends/asyncio.py
@@ -26,6 +26,7 @@ class AsyncIOStream(AsyncNetworkStream):
         exc_map = {
             TimeoutError: ReadTimeout,
             anyio.BrokenResourceError: ReadError,
+            anyio.ClosedResourceError: ReadError,
         }
         with map_exceptions(exc_map):
             with anyio.fail_after(timeout):
@@ -43,6 +44,7 @@ class AsyncIOStream(AsyncNetworkStream):
         exc_map = {
             TimeoutError: WriteTimeout,
             anyio.BrokenResourceError: WriteError,
+            anyio.ClosedResourceError: WriteError,
         }
         with map_exceptions(exc_map):
             with anyio.fail_after(timeout):

--- a/httpcore/backends/mock.py
+++ b/httpcore/backends/mock.py
@@ -2,6 +2,7 @@ import ssl
 import typing
 from typing import Optional
 
+from .._exceptions import ReadError
 from .base import AsyncNetworkBackend, AsyncNetworkStream, NetworkBackend, NetworkStream
 
 
@@ -17,8 +18,11 @@ class MockStream(NetworkStream):
     def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
         self._buffer = buffer
         self._http2 = http2
+        self._closed = False
 
     def read(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        if self._closed:
+            raise ReadError("Connection closed")
         if not self._buffer:
             return b""
         return self._buffer.pop(0)
@@ -27,7 +31,7 @@ class MockStream(NetworkStream):
         pass
 
     def close(self) -> None:
-        pass
+        self._closed = True
 
     def start_tls(
         self,
@@ -68,8 +72,11 @@ class AsyncMockStream(AsyncNetworkStream):
     def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
         self._buffer = buffer
         self._http2 = http2
+        self._closed = False
 
     async def read(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        if self._closed:
+            raise ReadError("Connection closed")
         if not self._buffer:
             return b""
         return self._buffer.pop(0)
@@ -78,7 +85,7 @@ class AsyncMockStream(AsyncNetworkStream):
         pass
 
     async def aclose(self) -> None:
-        pass
+        self._closed = True
 
     async def start_tls(
         self,

--- a/httpcore/backends/trio.py
+++ b/httpcore/backends/trio.py
@@ -27,6 +27,7 @@ class TrioStream(AsyncNetworkStream):
         exc_map: ExceptionMapping = {
             trio.TooSlowError: ReadTimeout,
             trio.BrokenResourceError: ReadError,
+            trio.ClosedResourceError: ReadError,
         }
         with map_exceptions(exc_map):
             with trio.fail_after(timeout_or_inf):
@@ -43,6 +44,7 @@ class TrioStream(AsyncNetworkStream):
         exc_map: ExceptionMapping = {
             trio.TooSlowError: WriteTimeout,
             trio.BrokenResourceError: WriteError,
+            trio.ClosedResourceError: WriteError,
         }
         with map_exceptions(exc_map):
             with trio.fail_after(timeout_or_inf):

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -3,7 +3,13 @@ from typing import List, Optional
 import pytest
 import trio as concurrency
 
-from httpcore import AsyncConnectionPool, ConnectError, PoolTimeout, UnsupportedProtocol
+from httpcore import (
+    AsyncConnectionPool,
+    ConnectError,
+    PoolTimeout,
+    ReadError,
+    UnsupportedProtocol,
+)
 from httpcore.backends.base import AsyncNetworkStream
 from httpcore.backends.mock import AsyncMockBackend
 
@@ -463,9 +469,10 @@ async def test_connection_pool_closed_while_request_in_flight():
     ) as pool:
         # Send a request, and then close the connection pool while the
         # response has not yet been streamed.
-        async with pool.stream("GET", "https://example.com/"):
-            with pytest.raises(RuntimeError):
-                await pool.aclose()
+        async with pool.stream("GET", "https://example.com/") as response:
+            await pool.aclose()
+            with pytest.raises(ReadError):
+                await response.aread()
 
 
 @pytest.mark.anyio

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -3,7 +3,13 @@ from typing import List, Optional
 import pytest
 from tests import concurrency
 
-from httpcore import ConnectionPool, ConnectError, PoolTimeout, UnsupportedProtocol
+from httpcore import (
+    ConnectionPool,
+    ConnectError,
+    PoolTimeout,
+    ReadError,
+    UnsupportedProtocol,
+)
 from httpcore.backends.base import NetworkStream
 from httpcore.backends.mock import MockBackend
 
@@ -463,9 +469,10 @@ def test_connection_pool_closed_while_request_in_flight():
     ) as pool:
         # Send a request, and then close the connection pool while the
         # response has not yet been streamed.
-        with pool.stream("GET", "https://example.com/"):
-            with pytest.raises(RuntimeError):
-                pool.close()
+        with pool.stream("GET", "https://example.com/") as response:
+            pool.close()
+            with pytest.raises(ReadError):
+                response.read()
 
 
 


### PR DESCRIPTION
Closes https://github.com/encode/httpcore/issues/564.

Closes #561 (The motivation given there becomes redundant. Errors will be raised against the connections themselves)

With this script...

**example.py**:

```python
import anyio
import httpcore


async def worker(client, tg):
    r = await client.request('HEAD', 'https://google.com')
    print(r)
    tg.cancel_scope.cancel()  # Cancel our other outstanding requests


async def main():
    async with httpcore.AsyncConnectionPool() as client, anyio.create_task_group() as tg:
        for _ in range(3):
            tg.start_soon(worker, client, tg)


if __name__ == "__main__":
    anyio.run(main)
```

**Before this change...**

```shell
$ venv/bin/python ./example.py 
<Response [301]>
Traceback (most recent call last):
  File "./example.py", line 18, in <module>
    anyio.run(main)
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 583, in run_until_complete
    return future.result()
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "./example.py", line 14, in main
    tg.start_soon(worker, client, tg)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection_pool.py", line 326, in __aexit__
    await self.aclose()
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection_pool.py", line 313, in aclose
    f"The connection pool was closed while {requests_still_in_flight} "
RuntimeError: The connection pool was closed while 2 HTTP requests/responses were still in-flight.
```

**After this change...**

```python
$ venv/bin/python ./example.py 
<Response [301]>
```

But, if we attempt close the connection pool and then later attempt to read from a connection, we *will* still get sensible behaviour...

**example.py**:

```python
import anyio
import httpcore


async def worker(client, tg):
    r = await client.request('HEAD', 'https://google.com')
    print(r)
    await client.aclose()  # Yikes, lookout.

async def main():
    async with httpcore.AsyncConnectionPool() as client, anyio.create_task_group() as tg:
        for _ in range(3):
            tg.start_soon(worker, client, tg)


if __name__ == "__main__":
    anyio.run(main)
```

**Output**:

```shell
$ venv/bin/python ./example.py 
<Response [301]>
Traceback (most recent call last):
  File "./example.py", line 17, in <module>
    anyio.run(main)
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 583, in run_until_complete
    return future.result()
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "./example.py", line 13, in main
    tg.start_soon(worker, client, tg)
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/anyio/_backends/_asyncio.py", line 702, in _run_wrapped_task
    await coro
  File "./example.py", line 6, in worker
    r = await client.request('HEAD', 'https://google.com')
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/interfaces.py", line 43, in request
    response = await self.handle_async_request(request)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection_pool.py", line 253, in handle_async_request
    raise exc
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection_pool.py", line 237, in handle_async_request
    response = await connection.handle_async_request(request)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection.py", line 90, in handle_async_request
    return await self._connection.handle_async_request(request)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/http11.py", line 112, in handle_async_request
    raise exc
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/http11.py", line 91, in handle_async_request
    ) = await self._receive_response_headers(**kwargs)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/http11.py", line 155, in _receive_response_headers
    event = await self._receive_event(timeout=timeout)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/http11.py", line 192, in _receive_event
    self.READ_NUM_BYTES, timeout=timeout
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/backends/asyncio.py", line 36, in read
    return b""
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc)
httpcore.ReadError
```