### PR TITLE
Version 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.16.3
+
+- Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)
+- Forwarding HTTP proxies use a connection-per-remote-host. Required by some proxy implementations. (#637)
+- Don't raise `RuntimeError` when closing a connection pool with active connections. Removes some error cases when cancellations are used. (#631)
+- Lazy import `anyio`, so that it's no longer a hard dependancy, and isn't imported if unused. (#639)
+
 ## 0.16.2 (November 25th, 2022)
 
 - Revert 'Fix async cancellation behaviour', which introduced race conditions. (#627)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.16.4
+
+- Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)
+- Forwarding HTTP proxies use a connection-per-remote-host. Required by some proxy implementations. (#637)
+- Don't raise `RuntimeError` when closing a connection pool with active connections. Removes some error cases when cancellations are used. (#631)
+- Lazy import `anyio`, so that it's no longer a hard dependancy, and isn't imported if unused. (#639)
+
 ## 0.16.3
 
 - Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.16.3
+## 0.16.3 (December 20th, 2022)
 
 - Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)
 - Forwarding HTTP proxies use a connection-per-remote-host. Required by some proxy implementations. (#637)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.16.4
-
-- Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)
-- Forwarding HTTP proxies use a connection-per-remote-host. Required by some proxy implementations. (#637)
-- Don't raise `RuntimeError` when closing a connection pool with active connections. Removes some error cases when cancellations are used. (#631)
-- Lazy import `anyio`, so that it's no longer a hard dependancy, and isn't imported if unused. (#639)
-
 ## 0.16.3
 
 - Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"
 
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"
 
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.16.4"
+__version__ = "0.16.3"
 
 
 __locals = locals()


### PR DESCRIPTION
**TODO**:

- [x] Resolve #631
- [x] Resolve #637
- [x] Resolve #639
- [x] Create draft release - https://github.com/encode/httpcore/releases/tag/untagged-be7f27eaaf1debf72311
- [x] Add release date to changelog (I'll do this once we've had an approving review and am ready to hit go.)

**Proposed changelog...**
---

## 0.16.3

- Allow `ws` and `wss` schemes. Allows us to properly support websocket upgrade connections. (#625)
- Forwarding HTTP proxies use a connection-per-remote-host. Required by some proxy implementations. (#637)
- Don't raise `RuntimeError` when closing a connection pool with active connections. Removes some error cases when cancellations are used. (#631)
- Lazy import `anyio`, so that it's no longer a hard dependancy, and isn't imported if unused. (#639)
