### PR TITLE
Handle HTTP/1.1 half-closed connections gracefully.

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -86,7 +86,9 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
         try:
             kwargs = {"request": request}
             try:
-                async with Trace("send_request_headers", logger, request, kwargs) as trace:
+                async with Trace(
+                    "send_request_headers", logger, request, kwargs
+                ) as trace:
                     await self._send_request_headers(**kwargs)
                 async with Trace("send_request_body", logger, request, kwargs) as trace:
                     await self._send_request_body(**kwargs)

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -18,6 +18,7 @@ from .._exceptions import (
     ConnectionNotAvailable,
     LocalProtocolError,
     RemoteProtocolError,
+    WriteError,
     map_exceptions,
 )
 from .._models import Origin, Request, Response
@@ -76,13 +77,24 @@ class HTTP11Connection(ConnectionInterface):
 
         try:
             kwargs = {"request": request}
-            with Trace("http11.send_request_headers", request, kwargs) as trace:
-                self._send_request_headers(**kwargs)
-            with Trace("http11.send_request_body", request, kwargs) as trace:
-                self._send_request_body(**kwargs)
-            with Trace(
-                "http11.receive_response_headers", request, kwargs
-            ) as trace:
+            try:
+                trace_message = "http11.send_request_headers"
+                with Trace(trace_message, request, kwargs) as trace:
+                    self._send_request_headers(**kwargs)
+
+                trace_message = "http11.send_request_body"
+                with Trace(trace_message, request, kwargs) as trace:
+                    self._send_request_body(**kwargs)
+            except WriteError:
+                # If we get a write error while we're writing the request,
+                # then we supress this error and move on to attempting to
+                # read the response. Servers can sometimes close the request
+                # pre-emptively and then respond with a well formed HTTP
+                # error response.
+                pass
+
+            trace_message = "http11.receive_response_headers"
+            with Trace(trace_message, request, kwargs) as trace:
                 (
                     http_version,
                     status,

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -86,18 +86,20 @@ class HTTP11Connection(ConnectionInterface):
         try:
             kwargs = {"request": request}
             try:
-                with Trace("send_request_headers", logger, request, kwargs) as trace:
+                with Trace(
+                    "send_request_headers", logger, request, kwargs
+                ) as trace:
                     self._send_request_headers(**kwargs)
                 with Trace("send_request_body", logger, request, kwargs) as trace:
                     self._send_request_body(**kwargs)
-             except WriteError:
+            except WriteError:
                 # If we get a write error while we're writing the request,
                 # then we supress this error and move on to attempting to
                 # read the response. Servers can sometimes close the request
                 # pre-emptively and then respond with a well formed HTTP
                 # error response.
                 pass
- 
+
             with Trace(
                 "receive_response_headers", logger, request, kwargs
             ) as trace:

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -141,8 +141,8 @@ async def test_write_error_with_response_sent():
         assert response.content == b"Request body exceeded 1,000,000 bytes"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.anyio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 async def test_write_error_without_response_sent():
     """
     If a server fully closes the connection while the client is sending
@@ -188,6 +188,7 @@ async def test_write_error_without_response_sent():
 
 
 @pytest.mark.anyio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 async def test_http2_connection():
     origin = Origin(b"https", b"example.com", 443)
     network_backend = AsyncMockBackend(

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -12,7 +12,7 @@ from httpcore import (
     WriteError,
 )
 from httpcore.backends.base import AsyncNetworkStream
-from httpcore.backends.mock import AsyncMockBackend
+from httpcore.backends.mock import AsyncMockBackend, AsyncMockStream
 
 
 @pytest.mark.anyio
@@ -89,7 +89,7 @@ async def test_write_error_but_response_sent():
     will raise a `ConnectionNotAvailable` exception.
     """
 
-    class ErrorOnRequestTooLarge(AsyncMockBackend):
+    class ErrorOnRequestTooLargeStream(AsyncMockStream):
         def __init__(self, buffer: List[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
@@ -99,6 +99,16 @@ async def test_write_error_but_response_sent():
 
             if self.count > 1_000_000:
                 raise WriteError()
+
+    class ErrorOnRequestTooLarge(AsyncMockBackend):
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: Optional[float] = None,
+            local_address: Optional[str] = None,
+        ) -> AsyncMockStream:
+            return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 
     origin = Origin(b"https", b"example.com", 443)
     network_backend = ErrorOnRequestTooLarge(

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -85,6 +85,7 @@ async def test_concurrent_requests_not_available_on_http11_connections():
                 await conn.request("GET", "https://example.com/")
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.anyio
 async def test_write_error_but_response_sent():
     """

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -112,6 +112,7 @@ async def test_write_error_but_response_sent():
             port: int,
             timeout: typing.Optional[float] = None,
             local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
         ) -> AsyncMockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -93,11 +93,11 @@ async def test_write_error_but_response_sent():
     """
 
     class ErrorOnRequestTooLargeStream(AsyncMockStream):
-        def __init__(self, buffer: List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        async def write(self, buffer: bytes, timeout: Optional[float] = None) -> None:
+        async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -108,8 +108,8 @@ async def test_write_error_but_response_sent():
             self,
             host: str,
             port: int,
-            timeout: Optional[float] = None,
-            local_address: Optional[str] = None,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
         ) -> AsyncMockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -14,6 +14,7 @@ from httpcore import (
     ConnectError,
     ConnectionNotAvailable,
     Origin,
+    RemoteProtocolError,
     WriteError,
 )
 
@@ -87,10 +88,13 @@ async def test_concurrent_requests_not_available_on_http11_connections():
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.anyio
-async def test_write_error_but_response_sent():
+async def test_write_error_with_response_sent():
     """
-    Attempting to issue a request against an already active HTTP/1.1 connection
-    will raise a `ConnectionNotAvailable` exception.
+    If a server half-closes the connection while the client is sending
+    the request, it may still send a response. In this case the client
+    should successfully read and return the response.
+
+    See also the `test_write_error_without_response_sent` test above.
     """
 
     class ErrorOnRequestTooLargeStream(AsyncMockStream):
@@ -135,6 +139,52 @@ async def test_write_error_but_response_sent():
         response = await conn.request("POST", "https://example.com/", content=content)
         assert response.status == 413
         assert response.content == b"Request body exceeded 1,000,000 bytes"
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.anyio
+async def test_write_error_without_response_sent():
+    """
+    If a server fully closes the connection while the client is sending
+    the request, then client should raise an error.
+
+    See also the `test_write_error_with_response_sent` test above.
+    """
+
+    class ErrorOnRequestTooLargeStream(AsyncMockStream):
+        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+            super().__init__(buffer, http2)
+            self.count = 0
+
+        async def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
+            self.count += len(buffer)
+
+            if self.count > 1_000_000:
+                raise WriteError()
+
+    class ErrorOnRequestTooLarge(AsyncMockBackend):
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        ) -> AsyncMockStream:
+            return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = ErrorOnRequestTooLarge([])
+
+    async with AsyncHTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        with pytest.raises(RemoteProtocolError) as exc_info:
+            await conn.request("POST", "https://example.com/", content=content)
+        assert str(exc_info.value) == "Server disconnected without sending a response."
 
 
 @pytest.mark.anyio

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -97,7 +97,9 @@ async def test_write_error_but_response_sent():
             super().__init__(buffer, http2)
             self.count = 0
 
-        async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        async def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -14,6 +14,7 @@ from httpcore import (
     ConnectError,
     ConnectionNotAvailable,
     Origin,
+    RemoteProtocolError,
     WriteError,
 )
 
@@ -87,10 +88,13 @@ def test_concurrent_requests_not_available_on_http11_connections():
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 
-def test_write_error_but_response_sent():
+def test_write_error_with_response_sent():
     """
-    Attempting to issue a request against an already active HTTP/1.1 connection
-    will raise a `ConnectionNotAvailable` exception.
+    If a server half-closes the connection while the client is sending
+    the request, it may still send a response. In this case the client
+    should successfully read and return the response.
+
+    See also the `test_write_error_without_response_sent` test above.
     """
 
     class ErrorOnRequestTooLargeStream(MockStream):
@@ -135,6 +139,51 @@ def test_write_error_but_response_sent():
         response = conn.request("POST", "https://example.com/", content=content)
         assert response.status == 413
         assert response.content == b"Request body exceeded 1,000,000 bytes"
+
+
+
+def test_write_error_without_response_sent():
+    """
+    If a server fully closes the connection while the client is sending
+    the request, then client should raise an error.
+
+    See also the `test_write_error_with_response_sent` test above.
+    """
+
+    class ErrorOnRequestTooLargeStream(MockStream):
+        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+            super().__init__(buffer, http2)
+            self.count = 0
+
+        def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
+            self.count += len(buffer)
+
+            if self.count > 1_000_000:
+                raise WriteError()
+
+    class ErrorOnRequestTooLarge(MockBackend):
+        def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        ) -> MockStream:
+            return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = ErrorOnRequestTooLarge([])
+
+    with HTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        with pytest.raises(RemoteProtocolError) as exc_info:
+            conn.request("POST", "https://example.com/", content=content)
+        assert str(exc_info.value) == "Server disconnected without sending a response."
 
 
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -4,7 +4,13 @@ import hpack
 import hyperframe.frame
 import pytest
 
-from httpcore import HTTPConnection, ConnectError, ConnectionNotAvailable, Origin
+from httpcore import (
+    HTTPConnection,
+    ConnectError,
+    ConnectionNotAvailable,
+    Origin,
+    WriteError,
+)
 from httpcore.backends.base import NetworkStream
 from httpcore.backends.mock import MockBackend
 
@@ -74,6 +80,44 @@ def test_concurrent_requests_not_available_on_http11_connections():
         with conn.stream("GET", "https://example.com/"):
             with pytest.raises(ConnectionNotAvailable):
                 conn.request("GET", "https://example.com/")
+
+
+
+def test_write_error_but_response_sent():
+    """
+    Attempting to issue a request against an already active HTTP/1.1 connection
+    will raise a `ConnectionNotAvailable` exception.
+    """
+
+    class ErrorOnRequestTooLarge(MockBackend):
+        def __init__(self, buffer: List[bytes], http2: bool = False) -> None:
+            super().__init__(buffer, http2)
+            self.count = 0
+
+        def write(self, buffer: bytes, timeout: Optional[float] = None) -> None:
+            self.count += len(buffer)
+
+            if self.count > 1_000_000:
+                raise WriteError()
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = ErrorOnRequestTooLarge(
+        [
+            b"HTTP/1.1 413 Payload Too Large\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 37\r\n",
+            b"\r\n",
+            b"Request body exceeded 1,000,000 bytes",
+        ]
+    )
+
+    with HTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        response = conn.request("POST", "https://example.com/", content=content)
+        assert response.status == 413
+        assert response.content == b"Request body exceeded 1,000,000 bytes"
 
 
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -112,6 +112,7 @@ def test_write_error_but_response_sent():
             port: int,
             timeout: typing.Optional[float] = None,
             local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
         ) -> MockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -142,6 +142,7 @@ def test_write_error_with_response_sent():
 
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_write_error_without_response_sent():
     """
     If a server fully closes the connection while the client is sending
@@ -187,6 +188,7 @@ def test_write_error_without_response_sent():
 
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_http2_connection():
     origin = Origin(b"https", b"example.com", 443)
     network_backend = MockBackend(

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -93,11 +93,11 @@ def test_write_error_but_response_sent():
     """
 
     class ErrorOnRequestTooLargeStream(MockStream):
-        def __init__(self, buffer: List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        def write(self, buffer: bytes, timeout: Optional[float] = None) -> None:
+        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -108,8 +108,8 @@ def test_write_error_but_response_sent():
             self,
             host: str,
             port: int,
-            timeout: Optional[float] = None,
-            local_address: Optional[str] = None,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
         ) -> MockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -85,6 +85,7 @@ def test_concurrent_requests_not_available_on_http11_connections():
                 conn.request("GET", "https://example.com/")
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 
 def test_write_error_but_response_sent():
     """

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -97,7 +97,9 @@ def test_write_error_but_response_sent():
             super().__init__(buffer, http2)
             self.count = 0
 
-        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:


### PR DESCRIPTION
Handle cases like HTTP 413, where the request write fails part way through sending, but a properly formed HTTP error response is then sent.

Closes #723

Originally prompted via https://github.com/encode/httpx/discussions/2503