### PR TITLE
Add `retries` option passthrough to SOCKS proxy classes

### DIFF
--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -114,6 +114,7 @@ class AsyncSOCKSProxy(AsyncConnectionPool):
         keepalive_expiry: typing.Optional[float] = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
         network_backend: typing.Optional[AsyncNetworkBackend] = None,
     ) -> None:
         """
@@ -154,6 +155,7 @@ class AsyncSOCKSProxy(AsyncConnectionPool):
             http1=http1,
             http2=http2,
             network_backend=network_backend,
+            retries=retries,
         )
         self._ssl_context = ssl_context
         self._proxy_url = enforce_url(proxy_url, name="proxy_url")

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -114,6 +114,7 @@ class SOCKSProxy(ConnectionPool):
         keepalive_expiry: typing.Optional[float] = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
         network_backend: typing.Optional[NetworkBackend] = None,
     ) -> None:
         """
@@ -154,6 +155,7 @@ class SOCKSProxy(ConnectionPool):
             http1=http1,
             http2=http2,
             network_backend=network_backend,
+            retries=retries,
         )
         self._ssl_context = ssl_context
         self._proxy_url = enforce_url(proxy_url, name="proxy_url")


### PR DESCRIPTION
Required for https://github.com/encode/httpx/pull/2517

The `SOCKSProxy` and `AsyncSOCKSProxy` classes document a `retries` option but do not accept it.

This adds the parameter and passes it through to the connection pool.