### PR TITLE
Accept http headers up to 100kB

### DIFF
--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -43,6 +43,7 @@ class HTTPConnectionState(enum.IntEnum):
 
 class AsyncHTTP11Connection(AsyncConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
+    MAX_INCOMPLETE_EVENT_SIZE = 100 * 1024
 
     def __init__(
         self,
@@ -57,7 +58,10 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
         self._state = HTTPConnectionState.NEW
         self._state_lock = AsyncLock()
         self._request_count = 0
-        self._h11_state = h11.Connection(our_role=h11.CLIENT)
+        self._h11_state = h11.Connection(
+            our_role=h11.CLIENT,
+            max_incomplete_event_size=self.MAX_INCOMPLETE_EVENT_SIZE,
+        )
 
     async def handle_async_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -43,6 +43,7 @@ class HTTPConnectionState(enum.IntEnum):
 
 class HTTP11Connection(ConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
+    MAX_INCOMPLETE_EVENT_SIZE = 100 * 1024
 
     def __init__(
         self,
@@ -57,7 +58,10 @@ class HTTP11Connection(ConnectionInterface):
         self._state = HTTPConnectionState.NEW
         self._state_lock = Lock()
         self._request_count = 0
-        self._h11_state = h11.Connection(our_role=h11.CLIENT)
+        self._h11_state = h11.Connection(
+            our_role=h11.CLIENT,
+            max_incomplete_event_size=self.MAX_INCOMPLETE_EVENT_SIZE,
+        )
 
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):

--- a/tests/_sync/test_http11.py
+++ b/tests/_sync/test_http11.py
@@ -310,3 +310,27 @@ def test_http11_early_hints():
         )
         assert response.status == 200
         assert response.content == b"<html>Hello, world! ...</html>"
+
+
+
+def test_http11_header_sub_100kb():
+    """
+    A connection should be able to handle a http header size up to 100kB.
+    """
+    origin = Origin(b"https", b"example.com", 443)
+    stream = MockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",  # 17
+            b"Content-Type: plain/text\r\n",  # 43
+            b"Cookie: " + b"x" * (100 * 1024 - 72) + b"\r\n",  # 102381
+            b"Content-Length: 0\r\n",  # 102400
+            b"\r\n",
+            b"",
+        ]
+    )
+    with HTTP11Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        response = conn.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b""


### PR DESCRIPTION
Increase the default allowable http header size to 100kB similar to curl.

Raised in discussion https://github.com/encode/httpx/discussions/2520