### PR TITLE
Enable TCP_NODELAY for all synchronous sockets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improve logging with per-module logger names. (#690)
 - Resolve race condition during import of `anyio` package. (#692)
+- Enable TCP_NODELAY for all synchronous sockets. (#651)
 
 ## 0.17.1 (May 17th, 2023)
 

--- a/httpcore/backends/sync.py
+++ b/httpcore/backends/sync.py
@@ -94,6 +94,7 @@ class SyncBackend(NetworkBackend):
             sock = socket.create_connection(
                 address, timeout, source_address=source_address
             )
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return SyncStream(sock)
 
     def connect_unix_socket(


### PR DESCRIPTION
The widely documented poor interaction between the Nagle algorithm and TCP's delayed ACK feature, when making short successive writes, leads to unnecessary delays (around 50ms on Linux). This happens in httpcore whenever a POST request is made, since the headers and body are sent as two separate calls.

The TCP_NODELAY can be enabled to disable Nagle's algorithm, and therefore avoid this delay.

The option is already enabled by default for all asyncio and Trio sockets. It is also enabled by CPython's http.client module (which urllib and requests use) and by many high-level HTTP libraries found in other languages, including libcurl, Java's Netty, Rust's reqwest and Go's standard library, to name a few.