### PR TITLE
Fixes pool poisoning

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -185,6 +185,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
             return self._connect_failed
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection is None and not self._connect_failed
+
     def info(self) -> str:
         if self._connection is None:
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -140,6 +140,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
         """
         return list(self._pool)
 
+    @property
+    def _is_pool_full(self) -> bool:
+        return len(self._pool) >= self._max_connections
+
     async def _attempt_to_acquire_connection(self, status: RequestStatus) -> bool:
         """
         Attempt to provide a connection that can handle the given origin.
@@ -164,6 +168,21 @@ class AsyncConnectionPool(AsyncRequestInterface):
         if len(self._pool) >= self._max_connections:
             for idx, connection in reversed(list(enumerate(self._pool))):
                 if connection.is_idle():
+                    await connection.aclose()
+                    self._pool.pop(idx)
+                    break
+
+        # Attempt to close CONNECTING connections that no one needs
+        if self._is_pool_full:
+            for idx, connection in enumerate(self._pool):  # Try to check old connections first
+                if not connection.is_connecting():
+                    continue
+                for req_status in self._requests:
+                    if req_status is status:  # skip current request
+                        continue
+                    if connection.can_handle_request(req_status.request.url.origin):
+                        break
+                else:  # There is no requests that can be handled by this connection
                     await connection.aclose()
                     self._pool.pop(idx)
                     break

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -269,6 +269,9 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
     def is_closed(self) -> bool:
         return self._state == HTTPConnectionState.CLOSED
 
+    def is_connecting(self) -> bool:
+        return self._state == HTTPConnectionState.NEW
+
     def info(self) -> str:
         origin = str(self._origin)
         return (

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -411,6 +411,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     def is_closed(self) -> bool:
         return self._state == HTTPConnectionState.CLOSED
 
+    def is_connecting(self) -> bool:
+        return False
+
     def info(self) -> str:
         origin = str(self._origin)
         return (

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -204,6 +204,9 @@ class AsyncForwardHTTPConnection(AsyncConnectionInterface):
     def is_closed(self) -> bool:
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection.is_connecting()
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{self.info()}]>"
 
@@ -335,6 +338,9 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
     def is_closed(self) -> bool:
         return self._connection.is_closed()
+
+    def is_connecting(self) -> bool:
+        return self._connection.is_connecting()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{self.info()}]>"

--- a/httpcore/_async/interfaces.py
+++ b/httpcore/_async/interfaces.py
@@ -133,3 +133,9 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         returned to the connection pool or not.
         """
         raise NotImplementedError()  # pragma: nocover
+
+    def is_connecting(self) -> bool:
+        """
+        Return `True` if the connection is currently connecting. For HTTP/2 connection always returns `False`
+        """
+        raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -329,6 +329,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
             return self._connect_failed
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection is None and not self._connect_failed
+
     def info(self) -> str:
         if self._connection is None:  # pragma: nocover
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -185,6 +185,9 @@ class HTTPConnection(ConnectionInterface):
             return self._connect_failed
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection is None and not self._connect_failed
+
     def info(self) -> str:
         if self._connection is None:
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -269,6 +269,9 @@ class HTTP11Connection(ConnectionInterface):
     def is_closed(self) -> bool:
         return self._state == HTTPConnectionState.CLOSED
 
+    def is_connecting(self) -> bool:
+        return self._state == HTTPConnectionState.NEW
+
     def info(self) -> str:
         origin = str(self._origin)
         return (

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -411,6 +411,9 @@ class HTTP2Connection(ConnectionInterface):
     def is_closed(self) -> bool:
         return self._state == HTTPConnectionState.CLOSED
 
+    def is_connecting(self) -> bool:
+        return False
+
     def info(self) -> str:
         origin = str(self._origin)
         return (

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -204,6 +204,9 @@ class ForwardHTTPConnection(ConnectionInterface):
     def is_closed(self) -> bool:
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection.is_connecting()
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{self.info()}]>"
 
@@ -335,6 +338,9 @@ class TunnelHTTPConnection(ConnectionInterface):
 
     def is_closed(self) -> bool:
         return self._connection.is_closed()
+
+    def is_connecting(self) -> bool:
+        return self._connection.is_connecting()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{self.info()}]>"

--- a/httpcore/_sync/interfaces.py
+++ b/httpcore/_sync/interfaces.py
@@ -133,3 +133,9 @@ class ConnectionInterface(RequestInterface):
         returned to the connection pool or not.
         """
         raise NotImplementedError()  # pragma: nocover
+
+    def is_connecting(self) -> bool:
+        """
+        Return `True` if the connection is currently connecting. For HTTP/2 connection always returns `False`
+        """
+        raise NotImplementedError()  # pragma: nocover

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -329,6 +329,9 @@ class Socks5Connection(ConnectionInterface):
             return self._connect_failed
         return self._connection.is_closed()
 
+    def is_connecting(self) -> bool:
+        return self._connection is None and not self._connect_failed
+
     def info(self) -> str:
         if self._connection is None:  # pragma: nocover
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -29,6 +29,7 @@ async def test_http_connection():
         assert not conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connecting()
         assert repr(conn) == "<AsyncHTTPConnection [CONNECTING]>"
 
         async with conn.stream("GET", "https://example.com/") as response:
@@ -45,6 +46,7 @@ async def test_http_connection():
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -33,6 +33,7 @@ async def test_http11_connection():
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', IDLE, Request Count: 1]>"
@@ -63,6 +64,7 @@ async def test_http11_connection_unread_response():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -85,6 +87,7 @@ async def test_http11_connection_with_remote_protocol_error():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -114,6 +117,7 @@ async def test_http11_connection_with_incomplete_response():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -146,6 +150,7 @@ async def test_http11_connection_with_local_protocol_error():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"

--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -43,6 +43,7 @@ async def test_http2_connection():
         assert conn.is_available()
         assert not conn.is_closed()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             conn.info() == "'https://example.com:443', HTTP/2, IDLE, Request Count: 1"
         )

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -47,6 +47,7 @@ async def test_proxy_forwarding():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(
@@ -102,6 +103,7 @@ async def test_proxy_tunneling():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(
@@ -193,6 +195,7 @@ async def test_proxy_tunneling_http2():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(

--- a/tests/_async/test_socks_proxy.py
+++ b/tests/_async/test_socks_proxy.py
@@ -46,6 +46,7 @@ async def test_socks5_request():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(
@@ -107,6 +108,7 @@ async def test_authenticated_socks5_request():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
 
 @pytest.mark.anyio

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -29,6 +29,7 @@ def test_http_connection():
         assert not conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connecting()
         assert repr(conn) == "<HTTPConnection [CONNECTING]>"
 
         with conn.stream("GET", "https://example.com/") as response:
@@ -45,6 +46,7 @@ def test_http_connection():
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -1,18 +1,20 @@
-from typing import List, Optional
+import contextlib
+import time
+from typing import List, Optional, Type
 
 import pytest
-from tests import concurrency
 
 from httpcore import (
     ConnectionPool,
     ConnectError,
     PoolTimeout,
+    ReadTimeout,
     ReadError,
     UnsupportedProtocol,
 )
 from httpcore.backends.base import NetworkStream
-from httpcore.backends.mock import MockBackend
-
+from httpcore.backends.mock import MockBackend, HangingStream
+from tests import concurrency
 
 
 def test_connection_pool_with_keepalive():
@@ -500,6 +502,81 @@ def test_connection_pool_timeout():
             with pytest.raises(PoolTimeout):
                 extensions = {"timeout": {"pool": 0.0001}}
                 pool.request("GET", "https://example.com/", extensions=extensions)
+
+
+
+def test_pool_under_load():
+    """
+    Pool must remain operational after some peak load.
+    """
+    network_backend = MockBackend([], resp_stream_cls=HangingStream)
+
+    def fetch(_pool: ConnectionPool, *exceptions: Type[BaseException]):
+        with contextlib.suppress(*exceptions):
+            with pool.stream(
+                    "GET",
+                    "http://a.com/",
+                    extensions={
+                        "timeout": {
+                            "connect": 0.1,
+                            "read": 0.1,
+                            "pool": 0.1,
+                            "write": 0.1,
+                        },
+                    },
+            ) as response:
+                response.read()
+
+    with ConnectionPool(
+        max_connections=1, network_backend=network_backend
+    ) as pool:
+        with concurrency.open_nursery() as nursery:
+            for _ in range(300):
+                # Sending many requests to the same url. All of them but one will have PoolTimeout. One will
+                # be finished with ReadTimeout
+                nursery.start_soon(fetch, pool, PoolTimeout, ReadTimeout)
+        if pool.connections:  # There is one connection in pool in "CONNECTING" state
+            assert pool.connections[0].is_connecting()
+        with pytest.raises(ReadTimeout):  # ReadTimeout indicates that connection could be retrieved
+            fetch(pool)
+
+
+
+def test_pool_timeout_connection_cleanup():
+    """
+    Test that pool cleans up connections after zero pool timeout. In case of stale
+    connection after timeout pool must not hang.
+    """
+    network_backend = MockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ] * 2,
+    )
+
+    with ConnectionPool(
+        network_backend=network_backend, max_connections=2
+    ) as pool:
+        timeout = {
+            "connect": 0.1,
+            "read": 0.1,
+            "pool": 0,
+            "write": 0.1,
+        }
+        with contextlib.suppress(PoolTimeout):
+            pool.request("GET", "https://example.com/", extensions={"timeout": timeout})
+
+        # wait for a considerable amount of time to make sure all requests time out
+        time.sleep(0.1)
+
+        pool.request("GET", "https://example.com/", extensions={"timeout": {**timeout, 'pool': 0.1}})
+
+        if pool.connections:
+            for conn in pool.connections:
+                assert not conn.is_connecting()
 
 
 

--- a/tests/_sync/test_http11.py
+++ b/tests/_sync/test_http11.py
@@ -33,6 +33,7 @@ def test_http11_connection():
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', IDLE, Request Count: 1]>"
@@ -63,6 +64,7 @@ def test_http11_connection_unread_response():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -85,6 +87,7 @@ def test_http11_connection_with_remote_protocol_error():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -114,6 +117,7 @@ def test_http11_connection_with_incomplete_response():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
@@ -146,6 +150,7 @@ def test_http11_connection_with_local_protocol_error():
         assert conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -43,6 +43,7 @@ def test_http2_connection():
         assert conn.is_available()
         assert not conn.is_closed()
         assert not conn.has_expired()
+        assert not conn.is_connecting()
         assert (
             conn.info() == "'https://example.com:443', HTTP/2, IDLE, Request Count: 1"
         )

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -47,6 +47,7 @@ def test_proxy_forwarding():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(
@@ -102,6 +103,7 @@ def test_proxy_tunneling():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(
@@ -193,6 +195,7 @@ def test_proxy_tunneling_http2():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(

--- a/tests/_sync/test_socks_proxy.py
+++ b/tests/_sync/test_socks_proxy.py
@@ -46,6 +46,7 @@ def test_socks5_request():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(
@@ -107,6 +108,7 @@ def test_authenticated_socks5_request():
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].is_connecting()
 
 
 


### PR DESCRIPTION
Fixes encode/httpcore#550

Implemented approach with cleaning up zombie connections before creating new connection for both sync and async implementations. Added new status `is_connecting` to `AsyncConnectionInterface` and `ConnectionInterface`. Added tests for pool poisoning and new code.

Other possible solutions:
- https://github.com/encode/httpcore/issues/550#issuecomment-1382257435 prevents stale connections from happening, not sure that it is safe to reuse connection after PoolTimeout in common
- https://github.com/encode/httpcore/issues/550#issuecomment-1384977626 in place clean up, need review