### PR TITLE
Retry ConnectError/ConnectTimeout happened in stream.start_tls

### DIFF
--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -122,6 +122,25 @@ class HTTPConnection(ConnectionInterface):
                             **kwargs
                         )
                         trace.return_value = stream
+
+                if self._origin.scheme == b"https":
+                    ssl_context = (
+                        default_ssl_context()
+                        if self._ssl_context is None
+                        else self._ssl_context
+                    )
+                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                    ssl_context.set_alpn_protocols(alpn_protocols)
+
+                    kwargs = {
+                        "ssl_context": ssl_context,
+                        "server_hostname": self._origin.host.decode("ascii"),
+                        "timeout": timeout,
+                    }
+                    with Trace("connection.start_tls", request, kwargs) as trace:
+                        stream = stream.start_tls(**kwargs)
+                        trace.return_value = stream
+                return stream
             except (ConnectError, ConnectTimeout):
                 if retries_left <= 0:
                     raise
@@ -129,27 +148,6 @@ class HTTPConnection(ConnectionInterface):
                 delay = next(delays)
                 # TRACE 'retry'
                 self._network_backend.sleep(delay)
-            else:
-                break
-
-        if self._origin.scheme == b"https":
-            ssl_context = (
-                default_ssl_context()
-                if self._ssl_context is None
-                else self._ssl_context
-            )
-            alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-            ssl_context.set_alpn_protocols(alpn_protocols)
-
-            kwargs = {
-                "ssl_context": ssl_context,
-                "server_hostname": self._origin.host.decode("ascii"),
-                "timeout": timeout,
-            }
-            with Trace("connection.start_tls", request, kwargs) as trace:
-                stream = stream.start_tls(**kwargs)
-                trace.return_value = stream
-        return stream
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -1,3 +1,5 @@
+import ssl
+import typing
 from typing import List, Optional
 
 import hpack
@@ -124,8 +126,15 @@ async def test_request_to_incorrect_origin():
 
 
 class NeedsRetryBackend(AsyncMockBackend):
-    def __init__(self, buffer: List[bytes], http2: bool = False) -> None:
-        self._retry = 2
+    def __init__(
+        self,
+        buffer: List[bytes],
+        http2: bool = False,
+        connect_tcp_failures: int = 2,
+        start_tls_failures: int = 0,
+    ) -> None:
+        self._connect_tcp_failures = connect_tcp_failures
+        self._start_tls_failures = start_tls_failures
         super().__init__(buffer, http2)
 
     async def connect_tcp(
@@ -135,13 +144,50 @@ class NeedsRetryBackend(AsyncMockBackend):
         timeout: Optional[float] = None,
         local_address: Optional[str] = None,
     ) -> AsyncNetworkStream:
-        if self._retry > 0:
-            self._retry -= 1
+        if self._connect_tcp_failures > 0:
+            self._connect_tcp_failures -= 1
             raise ConnectError()
 
-        return await super().connect_tcp(
+        stream = await super().connect_tcp(
             host, port, timeout=timeout, local_address=local_address
         )
+        return self._NeedsRetryAsyncNetworkStream(self, stream)
+
+    class _NeedsRetryAsyncNetworkStream(AsyncNetworkStream):
+        def __init__(
+            self, backend: "NeedsRetryBackend", stream: AsyncNetworkStream
+        ) -> None:
+            self._backend = backend
+            self._stream = stream
+
+        async def read(
+            self, max_bytes: int, timeout: typing.Optional[float] = None
+        ) -> bytes:
+            return await self._stream.read(max_bytes, timeout)
+
+        async def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
+            await self._stream.write(buffer, timeout)
+
+        async def aclose(self) -> None:
+            await self._stream.aclose()
+
+        async def start_tls(
+            self,
+            ssl_context: ssl.SSLContext,
+            server_hostname: typing.Optional[str] = None,
+            timeout: typing.Optional[float] = None,
+        ) -> "AsyncNetworkStream":
+            if self._backend._start_tls_failures > 0:
+                self._backend._start_tls_failures -= 1
+                raise ConnectError()
+
+            stream = await self._stream.start_tls(ssl_context, server_hostname, timeout)
+            return self._backend._NeedsRetryAsyncNetworkStream(self._backend, stream)
+
+        def get_extra_info(self, info: str) -> typing.Any:
+            return self._stream.get_extra_info(info)
 
 
 @pytest.mark.anyio
@@ -163,6 +209,37 @@ async def test_connection_retries():
         assert response.status == 200
 
     network_backend = NeedsRetryBackend(content)
+    async with AsyncHTTPConnection(
+        origin=origin,
+        network_backend=network_backend,
+    ) as conn:
+        with pytest.raises(ConnectError):
+            await conn.request("GET", "https://example.com/")
+
+
+@pytest.mark.anyio
+async def test_connection_retries_tls():
+    origin = Origin(b"https", b"example.com", 443)
+    content = [
+        b"HTTP/1.1 200 OK\r\n",
+        b"Content-Type: plain/text\r\n",
+        b"Content-Length: 13\r\n",
+        b"\r\n",
+        b"Hello, world!",
+    ]
+
+    network_backend = NeedsRetryBackend(
+        content, connect_tcp_failures=0, start_tls_failures=2
+    )
+    async with AsyncHTTPConnection(
+        origin=origin, network_backend=network_backend, retries=3
+    ) as conn:
+        response = await conn.request("GET", "https://example.com/")
+        assert response.status == 200
+
+    network_backend = NeedsRetryBackend(
+        content, connect_tcp_failures=0, start_tls_failures=2
+    )
     async with AsyncHTTPConnection(
         origin=origin,
         network_backend=network_backend,


### PR DESCRIPTION
Hi,

We are experiencing a small rare issue which has the following trace:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/tls.py", line 130, in _call_sslobject_method
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ssl.py", line 979, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLSyscallError: Some I/O error occurred (_ssl.c:1002)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/httpcore/_exceptions.py", line 10, in map_exceptions
    yield
  File "/usr/local/lib/python3.11/site-packages/httpcore/backends/asyncio.py", line 78, in start_tls
    raise exc
  File "/usr/local/lib/python3.11/site-packages/httpcore/backends/asyncio.py", line 69, in start_tls
    ssl_stream = await anyio.streams.tls.TLSStream.wrap(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/tls.py", line 122, in wrap
    await wrapper._call_sslobject_method(ssl_object.do_handshake)
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/tls.py", line 151, in _call_sslobject_method
    raise BrokenResourceError from exc
anyio.BrokenResourceError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/httpx/_transports/default.py", line 60, in map_httpcore_exceptions
    yield
  File "/usr/local/lib/python3.11/site-packages/httpx/_transports/default.py", line 353, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpcore/_async/connection_pool.py", line 253, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.11/site-packages/httpcore/_async/connection_pool.py", line 237, in handle_async_request
    response = await connection.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpcore/_async/connection.py", line 86, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.11/site-packages/httpcore/_async/connection.py", line 63, in handle_async_request
    stream = await self._connect(request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpcore/_async/connection.py", line 150, in _connect
    stream = await stream.start_tls(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpcore/backends/asyncio.py", line 66, in start_tls
    with map_exceptions(exc_map):
  File "/usr/local/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.11/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc)
httpcore.ConnectError
```

We have retries enabled on AsyncTransport, but `ConnectError` didn't attempt to retry at all if it was raised in `stream.start_tls` method. 

It looks like that it is safe to retry such an error as well.