### PR TITLE
Optional async dependencies

### DIFF
--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -63,6 +63,8 @@ class AsyncEvent:
         Detect if we're running under 'asyncio' or 'trio' and create
         a lock with the correct implementation.
         """
+        import sniffio
+
         self._backend = sniffio.current_async_library()
         if self._backend == "trio":
             import trio
@@ -113,6 +115,8 @@ class AsyncSemaphore:
         Detect if we're running under 'asyncio' or 'trio' and create
         a semaphore with the correct implementation.
         """
+        import sniffio
+
         self._backend = sniffio.current_async_library()
         if self._backend == "trio":
             import trio

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -2,8 +2,6 @@ import threading
 from types import TracebackType
 from typing import Optional, Type
 
-import sniffio
-
 from ._exceptions import ExceptionMapping, PoolTimeout, map_exceptions
 
 # Our async synchronization primatives use either 'anyio' or 'trio' depending
@@ -21,6 +19,8 @@ class AsyncLock:
         Detect if we're running under 'asyncio' or 'trio' and create
         a lock with the correct implementation.
         """
+        import sniffio
+
         self._backend = sniffio.current_async_library()
         if self._backend == "trio":
             import trio

--- a/httpcore/backends/auto.py
+++ b/httpcore/backends/auto.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
-import sniffio
-
 from .base import AsyncNetworkBackend, AsyncNetworkStream
 
 
 class AutoBackend(AsyncNetworkBackend):
     async def _init_backend(self) -> None:
         if not (hasattr(self, "_backend")):
+            import sniffio
+
             backend = sniffio.current_async_library()
             if backend == "trio":
                 from .trio import TrioBackend

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,13 @@ setup(
     zip_safe=False,
     install_requires=[
         "h11>=0.13,<0.15",
-        "sniffio==1.*",
-        "anyio>=3.0,<5.0",
         "certifi",
     ],
     extras_require={
         "http2": ["h2>=3,<5"],
-        "socks": ["socksio==1.*"]
+        "socks": ["socksio==1.*"],
+        "asyncio": ["sniffio==1.*", "anyio>=3.0,<5.0"],
+        "trio": ["sniffio==1.*", "trio>=0.21.0,<0.23.0"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Drafting up a proposal here for having the async dependancies be optional.

- [x] Make dependancies required for `asyncio` or `trio` optional.
- [ ] Clear runtime warning if not included.
- [ ] Update docs.

We've got the option here of an `httpx` 1.0 release, with a very light (default) dependency footprint...

* `httpx`
  * `httpcore`
    * `h11`
    * `certifi`

(We can also drop `idna` into an optional.)