### PR TITLE
Socks5h

### DIFF
--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -291,6 +291,7 @@ class URL:
             b"ws": 80,
             b"wss": 443,
             b"socks5": 1080,
+            b"socks5h": 1080,
         }[self.scheme]
         return Origin(
             scheme=self.scheme, host=self.host, port=self.port or default_port

--- a/tests/_async/test_socks_proxy.py
+++ b/tests/_async/test_socks_proxy.py
@@ -192,3 +192,193 @@ async def test_socks5_request_incorrect_auth():
         assert str(exc_info.value) == "Invalid username/password"
 
         assert not proxy.connections
+
+
+@pytest.mark.anyio
+async def test_socks5h_request():
+    """
+    Send an HTTP request via a SOCKS proxy.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncSOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        async with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<AsyncSocks5Connection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            await response.aread()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<AsyncSocks5Connection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+        # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"example.com", 80)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"other.com", 80)
+        )
+        assert proxy.connections[0].can_handle_request(
+            Origin(b"https", b"example.com", 443)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"https", b"other.com", 443)
+        )
+
+
+@pytest.mark.anyio
+async def test_authenticated_socks5h_request():
+    """
+    Send an HTTP request via a SOCKS proxy.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+            #   v1 VALID USERNAME/PASSWORD
+            b"\x01\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncSOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        proxy_auth=(b"username", b"password"),
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        async with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<AsyncSocks5Connection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            await response.aread()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<AsyncSocks5Connection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+
+@pytest.mark.anyio
+async def test_socks5h_request_connect_failed():
+    """
+    Attempt to send an HTTP request via a SOCKS proxy, resulting in a connect failure.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5  NO RSV IP4   0  .0  .0  .0     :00
+            b"\x05\x05\x00\x01\x00\x00\x00\x00\x00\x00",
+        ]
+    )
+
+    async with AsyncSOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            await proxy.request("GET", "https://example.com/")
+        assert (
+            str(exc_info.value) == "Proxy Server could not connect: Connection refused."
+        )
+
+        assert not proxy.connections
+
+
+@pytest.mark.anyio
+async def test_socks5h_request_failed_to_provide_auth():
+    """
+    Attempt to send an HTTP request via an authenticated SOCKS proxy,
+    without providing authentication credentials.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+        ]
+    )
+
+    async with AsyncSOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            await proxy.request("GET", "https://example.com/")
+        assert (
+            str(exc_info.value)
+            == "Requested NO AUTHENTICATION REQUIRED from proxy server, but got USERNAME/PASSWORD."
+        )
+
+        assert not proxy.connections
+
+
+@pytest.mark.anyio
+async def test_socks5h_request_incorrect_auth():
+    """
+    Attempt to send an HTTP request via an authenticated SOCKS proxy,
+    wit incorrect authentication credentials.
+    """
+    network_backend = AsyncMockBackend(
+        [
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+            #   v1 INVALID USERNAME/PASSWORD
+            b"\x01\x01",
+        ]
+    )
+
+    async with AsyncSOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        proxy_auth=(b"invalid", b"invalid"),
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            await proxy.request("GET", "https://example.com/")
+        assert str(exc_info.value) == "Invalid username/password"
+
+        assert not proxy.connections

--- a/tests/_sync/test_socks_proxy.py
+++ b/tests/_sync/test_socks_proxy.py
@@ -192,3 +192,193 @@ def test_socks5_request_incorrect_auth():
         assert str(exc_info.value) == "Invalid username/password"
 
         assert not proxy.connections
+
+
+
+def test_socks5h_request():
+    """
+    Send an HTTP request via a SOCKS proxy.
+    """
+    network_backend = MockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with SOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<Socks5Connection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            response.read()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<Socks5Connection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+        # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"example.com", 80)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"http", b"other.com", 80)
+        )
+        assert proxy.connections[0].can_handle_request(
+            Origin(b"https", b"example.com", 443)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            Origin(b"https", b"other.com", 443)
+        )
+
+
+
+def test_authenticated_socks5h_request():
+    """
+    Send an HTTP request via a SOCKS proxy.
+    """
+    network_backend = MockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+            #   v1 VALID USERNAME/PASSWORD
+            b"\x01\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with SOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        proxy_auth=(b"username", b"password"),
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        with proxy.stream("GET", "https://example.com/") as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<Socks5Connection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            response.read()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<Socks5Connection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+
+
+def test_socks5h_request_connect_failed():
+    """
+    Attempt to send an HTTP request via a SOCKS proxy, resulting in a connect failure.
+    """
+    network_backend = MockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5  NO RSV IP4   0  .0  .0  .0     :00
+            b"\x05\x05\x00\x01\x00\x00\x00\x00\x00\x00",
+        ]
+    )
+
+    with SOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            proxy.request("GET", "https://example.com/")
+        assert (
+            str(exc_info.value) == "Proxy Server could not connect: Connection refused."
+        )
+
+        assert not proxy.connections
+
+
+
+def test_socks5h_request_failed_to_provide_auth():
+    """
+    Attempt to send an HTTP request via an authenticated SOCKS proxy,
+    without providing authentication credentials.
+    """
+    network_backend = MockBackend(
+        [
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+        ]
+    )
+
+    with SOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            proxy.request("GET", "https://example.com/")
+        assert (
+            str(exc_info.value)
+            == "Requested NO AUTHENTICATION REQUIRED from proxy server, but got USERNAME/PASSWORD."
+        )
+
+        assert not proxy.connections
+
+
+
+def test_socks5h_request_incorrect_auth():
+    """
+    Attempt to send an HTTP request via an authenticated SOCKS proxy,
+    wit incorrect authentication credentials.
+    """
+    network_backend = MockBackend(
+        [
+            #   v5 USERNAME/PASSWORD
+            b"\x05\x02",
+            #   v1 INVALID USERNAME/PASSWORD
+            b"\x01\x01",
+        ]
+    )
+
+    with SOCKSProxy(
+        proxy_url="socks5h://localhost:8080/",
+        proxy_auth=(b"invalid", b"invalid"),
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending a request, which the proxy rejects
+        with pytest.raises(ProxyError) as exc_info:
+            proxy.request("GET", "https://example.com/")
+        assert str(exc_info.value) == "Invalid username/password"
+
+        assert not proxy.connections


### PR DESCRIPTION
Add default port to allow socks5h to work. I have already tested this with a patched version of httpx I also added socks5h support to and it worked without issue.

![Screenshot 2023-04-24 at 4 08 02 PM](https://user-images.githubusercontent.com/63059772/234104761-a95ffff8-7135-489a-b7ee-dc0e1d6e7a6d.png)

Your [contributing guides](https://github.com/encode/.github/blob/a785584b6ebd8619120712076d445b3bcefc20cd/CONTRIBUTING.md) say to talk it over via chat or discussion group, however the register link for the chat always takes me to a blank page, and the discussion group link 404s.
