### PR TITLE
Fix exception re-raise in `AsyncIOStream.start_tls`

### DIFF
--- a/httpcore/backends/asyncio.py
+++ b/httpcore/backends/asyncio.py
@@ -73,9 +73,9 @@ class AsyncIOStream(AsyncNetworkStream):
                         standard_compatible=False,
                         server_side=False,
                     )
-            except Exception as exc:  # pragma: nocover
+            except Exception:  # pragma: nocover
                 await self.aclose()
-                raise exc
+                raise
         return AsyncIOStream(ssl_stream)
 
     def get_extra_info(self, info: str) -> typing.Any:


### PR DESCRIPTION
In the previous implementation, the traceback would show "During handling of the above exception, another exception occurred" and include an extra frame.