### PR TITLE
Chain exception re-raise in `map_exceptions`

### DIFF
--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -11,7 +11,7 @@ def map_exceptions(map: ExceptionMapping) -> Iterator[None]:
     except Exception as exc:  # noqa: PIE786
         for from_exc, to_exc in map.items():
             if isinstance(exc, from_exc):
-                raise to_exc(exc)
+                raise to_exc(exc) from exc
         raise  # pragma: nocover
 
 


### PR DESCRIPTION
Preserves the exception chain instead of displaying "During handling of the above exception, another exception occurred" in the traceback.

Related to https://github.com/encode/httpcore/pull/677