### PR TITLE
Fix erronous pool timeout case

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -31,7 +31,8 @@ class RequestStatus:
     async def wait_for_connection(
         self, timeout: Optional[float] = None
     ) -> AsyncConnectionInterface:
-        await self._connection_acquired.wait(timeout=timeout)
+        if self.connection is None:
+            await self._connection_acquired.wait(timeout=timeout)
         assert self.connection is not None
         return self.connection
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -31,7 +31,8 @@ class RequestStatus:
     def wait_for_connection(
         self, timeout: Optional[float] = None
     ) -> ConnectionInterface:
-        self._connection_acquired.wait(timeout=timeout)
+        if self.connection is None:
+            self._connection_acquired.wait(timeout=timeout)
         assert self.connection is not None
         return self.connection
 


### PR DESCRIPTION
Refs #550.

Fixes an issue where a pool timeout can occur, even though a request has an assigned connection.

It's not clear to me if this is a complete resolution, or if something more substantial (see #653) is actually required.
But *either* way around I think this resolves an edge case for `pool timeout: 0` cases.

Needs a test case.