### PR TITLE
Fix incorrect docstring in test case

### DIFF
--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -146,8 +146,8 @@ async def test_http2_connection_with_rst_stream():
 @pytest.mark.anyio
 async def test_http2_connection_with_goaway():
     """
-    If a stream reset occurs, then no response will be returned,
-    but the connection will remain reusable for other requests.
+    If a GoAway frame occurs, then no response will be returned,
+    and the connection will not be reusable for other requests.
     """
     origin = Origin(b"https", b"example.com", 443)
     stream = AsyncMockStream(

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -146,8 +146,8 @@ def test_http2_connection_with_rst_stream():
 
 def test_http2_connection_with_goaway():
     """
-    If a stream reset occurs, then no response will be returned,
-    but the connection will remain reusable for other requests.
+    If a GoAway frame occurs, then no response will be returned,
+    and the connection will not be reusable for other requests.
     """
     origin = Origin(b"https", b"example.com", 443)
     stream = MockStream(


### PR DESCRIPTION
There are a pair of `RstStreamFrame` and `GoAwayFrame` tests here...

* `test_http2_connection_with_rst_stream`
* `test_http2_connection_with_goaway`

...which test a similar flow for both the stream reset and connection goaway cases.

The docstring in the goaway case appears to have been copied incorrectly from the stream reset case.