### PR TITLE
Raise `ConnectionNotAvailable` instead of `RemoteProtocolError` on request with terminated HTTP/2 connections

### DIFF
--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -143,10 +143,14 @@ class HTTP2Connection(ConnectionInterface):
                 # a GOAWAY event. Other flows of control may then raise
                 # a protocol error at any point they interact with the 'h2_state'.
                 #
-                # In this case we'll have stored the event, and should raise
-                # it as a RemoteProtocolError.
+                # In this case we'll have stored the event, and should raise it.
                 if self._connection_error_event:
-                    raise RemoteProtocolError(self._connection_error_event)
+                    if isinstance(
+                        self._connection_error_event, h2.events.ConnectionTerminated
+                    ):
+                        raise ConnectionNotAvailable(self._connection_error_event)
+                    else:
+                        raise RemoteProtocolError(self._connection_error_event)
                 # If h2 raises a protocol error in some other state then we
                 # must somehow have made a protocol violation.
                 raise LocalProtocolError(exc)  # pragma: nocover
@@ -279,7 +283,7 @@ class HTTP2Connection(ConnectionInterface):
     ) -> None:
         with self._read_lock:
             if self._connection_error_event is not None:  # pragma: nocover
-                raise RemoteProtocolError(self._connection_error_event)
+                raise ConnectionNotAvailable(self._connection_error_event)
 
             # This conditional is a bit icky. We don't want to block reading if we've
             # actually got an event to return for a given stream. We need to do that
@@ -303,7 +307,12 @@ class HTTP2Connection(ConnectionInterface):
                     # and should be saved so it can be raised on all streams.
                     if hasattr(event, "error_code") and event_stream_id == 0:
                         self._connection_error_event = event
-                        raise RemoteProtocolError(event)
+                        if isinstance(
+                            self._connection_error_event, h2.events.ConnectionTerminated
+                        ):
+                            raise ConnectionNotAvailable(self._connection_error_event)
+                        else:
+                            raise RemoteProtocolError(event)
 
                     if event_stream_id in self._events:
                         self._events[event_stream_id].append(event)

--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -80,7 +80,7 @@ async def test_http2_connection_closed():
     ) as conn:
         await conn.request("GET", "https://example.com/")
 
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             await conn.request("GET", "https://example.com/")
 
         assert not conn.is_available()
@@ -217,9 +217,9 @@ async def test_http2_connection_with_goaway():
         ]
     )
     async with AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             await conn.request("GET", "https://example.com/")
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             await conn.request("GET", "https://example.com/")
 
 

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -80,7 +80,7 @@ def test_http2_connection_closed():
     ) as conn:
         conn.request("GET", "https://example.com/")
 
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             conn.request("GET", "https://example.com/")
 
         assert not conn.is_available()
@@ -217,9 +217,9 @@ def test_http2_connection_with_goaway():
         ]
     )
     with HTTP2Connection(origin=origin, stream=stream) as conn:
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             conn.request("GET", "https://example.com/")
-        with pytest.raises(RemoteProtocolError):
+        with pytest.raises(ConnectionNotAvailable):
             conn.request("GET", "https://example.com/")
 
 


### PR DESCRIPTION
Follow-up to https://github.com/encode/httpcore/pull/679#issuecomment-1543672906

Attempts to improve handling of HTTP/2 behavior when connections are terminated.

Refs #730