### PR TITLE
Add 'httpcore.h2state' and 'httpcore.h2frame' loggers.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -40,16 +40,16 @@ class H2Logger:
     Enable logging from the `python-hyper/h2` package.
     """
 
-    def __init__(self, *vargs):
+    def __init__(self, *vargs: typing.Any):
         # We differentiate between the two different types of logging that
         # 'h2' exposes by using different logging instances for each.
         self._debug_logger = logging.getLogger("httpcore.h2state")
         self._trace_logger = logging.getLogger("httpcore.h2frames")
 
-    def debug(self, *vargs, **kwargs):
+    def debug(self, *vargs: typing.Any, **kwargs: typing.Any) -> None:
         self._debug_logger.debug(*vargs, **kwargs)
 
-    def trace(self, *vargs, **kwargs):
+    def trace(self, *vargs: typing.Any, **kwargs: typing.Any) -> None:
         # Instead of using a custom 'TRACE' log level we're using
         # the standard 'DEBUG' level.
         self._trace_logger.debug(*vargs, **kwargs)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import time
 import types
 import typing
@@ -34,9 +35,28 @@ class HTTPConnectionState(enum.IntEnum):
     CLOSED = 3
 
 
+class H2Logger:
+    """
+    Enable logging from the `python-hyper/h2` package.
+    """
+    def __init__(self, *vargs):
+        # We differentiate between the two different types of logging that
+        # 'h2' exposes by using different logging instances for each.
+        self._debug_logger = logging.getLogger("httpcore.h2state")
+        self._trace_logger = logging.getLogger("httpcore.h2frames")
+
+    def debug(self, *vargs, **kwargs):
+        self._debug_logger.debug(*vargs, **kwargs)
+
+    def trace(self, *vargs, **kwargs):
+        # Instead of using a custom 'TRACE' log level we're using
+        # the standard 'DEBUG' level.
+        self._trace_logger.debug(*vargs, **kwargs)
+
+
 class AsyncHTTP2Connection(AsyncConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
-    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False)
+    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False, logger=H2Logger())
 
     def __init__(
         self,

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -39,6 +39,7 @@ class H2Logger:
     """
     Enable logging from the `python-hyper/h2` package.
     """
+
     def __init__(self, *vargs):
         # We differentiate between the two different types of logging that
         # 'h2' exposes by using different logging instances for each.
@@ -56,7 +57,9 @@ class H2Logger:
 
 class AsyncHTTP2Connection(AsyncConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
-    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False, logger=H2Logger())
+    CONFIG = h2.config.H2Configuration(
+        validate_inbound_headers=False, logger=H2Logger()
+    )
 
     def __init__(
         self,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -39,6 +39,7 @@ class H2Logger:
     """
     Enable logging from the `python-hyper/h2` package.
     """
+
     def __init__(self, *vargs):
         # We differentiate between the two different types of logging that
         # 'h2' exposes by using different logging instances for each.
@@ -56,7 +57,9 @@ class H2Logger:
 
 class HTTP2Connection(ConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
-    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False, logger=H2Logger())
+    CONFIG = h2.config.H2Configuration(
+        validate_inbound_headers=False, logger=H2Logger()
+    )
 
     def __init__(
         self,

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -40,16 +40,16 @@ class H2Logger:
     Enable logging from the `python-hyper/h2` package.
     """
 
-    def __init__(self, *vargs):
+    def __init__(self, *vargs: typing.Any):
         # We differentiate between the two different types of logging that
         # 'h2' exposes by using different logging instances for each.
         self._debug_logger = logging.getLogger("httpcore.h2state")
         self._trace_logger = logging.getLogger("httpcore.h2frames")
 
-    def debug(self, *vargs, **kwargs):
+    def debug(self, *vargs: typing.Any, **kwargs: typing.Any) -> None:
         self._debug_logger.debug(*vargs, **kwargs)
 
-    def trace(self, *vargs, **kwargs):
+    def trace(self, *vargs: typing.Any, **kwargs: typing.Any) -> None:
         # Instead of using a custom 'TRACE' log level we're using
         # the standard 'DEBUG' level.
         self._trace_logger.debug(*vargs, **kwargs)

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import time
 import types
 import typing
@@ -34,9 +35,28 @@ class HTTPConnectionState(enum.IntEnum):
     CLOSED = 3
 
 
+class H2Logger:
+    """
+    Enable logging from the `python-hyper/h2` package.
+    """
+    def __init__(self, *vargs):
+        # We differentiate between the two different types of logging that
+        # 'h2' exposes by using different logging instances for each.
+        self._debug_logger = logging.getLogger("httpcore.h2state")
+        self._trace_logger = logging.getLogger("httpcore.h2frames")
+
+    def debug(self, *vargs, **kwargs):
+        self._debug_logger.debug(*vargs, **kwargs)
+
+    def trace(self, *vargs, **kwargs):
+        # Instead of using a custom 'TRACE' log level we're using
+        # the standard 'DEBUG' level.
+        self._trace_logger.debug(*vargs, **kwargs)
+
+
 class HTTP2Connection(ConnectionInterface):
     READ_NUM_BYTES = 64 * 1024
-    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False)
+    CONFIG = h2.config.H2Configuration(validate_inbound_headers=False, logger=H2Logger())
 
     def __init__(
         self,


### PR DESCRIPTION
Add `httpcore.h2state` and `httpcore.h2frame` loggers, to expose more HTTP/2 debugging information.

Also related: https://github.com/python-hyper/h2/pull/1279

**example.py:**

```python
import httpx
import logging

logging.basicConfig(
    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
    level=logging.INFO
)
logging.getLogger("httpcore.h2frames").setLevel(logging.DEBUG)

with httpx.Client(http2=True) as client:
    client.get("https://www.example.com/")
```

**console:**

```shell
$ python -m venv venv
$ venv/bin/pip install git+https://github.com/python-hyper/h2.git@frame-level-logging  # `h2`, updated with frame-level logging
$ venv/bin/pip install git+https://github.com/encode/httpcore.git@add-h2-logging  # `httpcore`, updated to include h2 loggers.
$ venv/bin/pip install httpx
$ venv/bin/python example.py 
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: SettingsFrame(stream_id=0, flags=[]): settings={<SettingCodes.HEADER_TABLE_SIZE: 1>: 4096, <SettingCodes.ENABLE_PUSH: 2>: 0, <SettingCodes.INITIAL_WINDOW_SIZE: 4>: 65535, <SettingCodes.MAX_FRAME_SIZE: 5>: 16384, <SettingCodes.MAX_CONCURRENT_STREAMS: 3>: 100, <SettingCodes.MAX_HEADER_LIST_SIZE: 6>: 65536}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: WindowUpdateFrame(stream_id=0, flags=[]): window_increment=16777216
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: HeadersFrame(stream_id=1, flags=['END_HEADERS', 'END_STREAM']): exclusive=False, depends_on=0, stream_weight=0, data=<hex:82418cf1e3c2e5f23a6b...>
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: WindowUpdateFrame(stream_id=1, flags=[]): window_increment=16777216
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: SettingsFrame(stream_id=0, flags=[]): settings={1: 4096, 3: 100, 4: 1048576, 5: 16384, 6: 16384}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: SettingsFrame(stream_id=0, flags=['ACK']): settings={}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: WindowUpdateFrame(stream_id=0, flags=[]): window_increment=983041
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: SettingsFrame(stream_id=0, flags=['ACK']): settings={}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: HeadersFrame(stream_id=1, flags=['END_HEADERS']): exclusive=False, depends_on=0, stream_weight=0, data=<hex:3fe11f885a839bd9ab52...>
INFO [2023-05-17 11:34:12] httpx - HTTP Request: GET https://www.example.com/ "HTTP/2 200 OK"
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: DataFrame(stream_id=1, flags=['END_STREAM']): <hex:1f8b0800c215a85d0003...>
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: GoAwayFrame(stream_id=0, flags=[]): last_stream_id=0, error_code=0, additional_data=b''
```