### PR TITLE
Internal refactor of HTTP/2 data stream handling.

### DIFF
--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -128,11 +128,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 status=status,
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
-                extensions={
-                    "http_version": b"HTTP/2",
-                    "network_stream": self._network_stream,
-                    "stream_id": stream_id,
-                },
+                extensions={"stream_id": stream_id, "http_version": b"HTTP/2"},
             )
         except Exception as exc:  # noqa: PIE786
             kwargs = {"stream_id": stream_id}

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -187,6 +187,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     # Sending the request...
 
     async def _send_request_headers(self, request: Request, stream_id: int) -> None:
+        """
+        Send the request headers to a given stream ID.
+        """
         end_stream = not has_body_headers(request)
 
         # In HTTP/2 the ':authority' pseudo-header is used instead of 'Host'.
@@ -215,18 +218,34 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         await self._write_outgoing_data(request)
 
     async def _send_request_body(self, request: Request, stream_id: int) -> None:
+        """
+        Iterate over the request body sending it to a given stream ID.
+        """
         if not has_body_headers(request):
             return
 
         assert isinstance(request.stream, typing.AsyncIterable)
         async for data in request.stream:
-            while data:
-                max_flow = await self._wait_for_outgoing_flow(request, stream_id)
-                chunk_size = min(len(data), max_flow)
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                self._h2_state.send_data(stream_id, chunk)
-                await self._write_outgoing_data(request)
+            await self._send_stream_data(request, stream_id, data)
+        await self._send_end_stream(request, stream_id)
 
+    async def _send_stream_data(
+        self, request: Request, stream_id: int, data: bytes
+    ) -> None:
+        """
+        Send a single chunk of data in one or more data frames.
+        """
+        while data:
+            max_flow = await self._wait_for_outgoing_flow(request, stream_id)
+            chunk_size = min(len(data), max_flow)
+            chunk, data = data[:chunk_size], data[chunk_size:]
+            self._h2_state.send_data(stream_id, chunk)
+            await self._write_outgoing_data(request)
+
+    async def _send_end_stream(self, request: Request, stream_id: int) -> None:
+        """
+        Send an empty data frame on on a given stream ID with the END_STREAM flag set.
+        """
         self._h2_state.end_stream(stream_id)
         await self._write_outgoing_data(request)
 
@@ -235,6 +254,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _receive_response(
         self, request: Request, stream_id: int
     ) -> typing.Tuple[int, typing.List[typing.Tuple[bytes, bytes]]]:
+        """
+        Return the response status code and headers for a given stream ID.
+        """
         while True:
             event = await self._receive_stream_event(request, stream_id)
             if isinstance(event, h2.events.ResponseReceived):
@@ -253,19 +275,41 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _receive_response_body(
         self, request: Request, stream_id: int
     ) -> typing.AsyncIterator[bytes]:
+        """
+        Iterator that returns the bytes of the response body for a given stream ID.
+        """
+        while True:
+            data = await self._recieve_stream_data(request, stream_id)
+            if data:
+                yield data
+            else:
+                break
+
+    async def _recieve_stream_data(self, request: Request, stream_id: int) -> bytes:
+        """
+        Return the bytes in the next data frame for the given stream ID,
+        or b'' when the stream ends.
+        """
         while True:
             event = await self._receive_stream_event(request, stream_id)
             if isinstance(event, h2.events.DataReceived):
                 amount = event.flow_controlled_length
                 self._h2_state.acknowledge_received_data(amount, stream_id)
                 await self._write_outgoing_data(request)
-                yield event.data
+                if event.data:
+                    return event.data  # type: ignore
             elif isinstance(event, (h2.events.StreamEnded, h2.events.StreamReset)):
                 break
+        return b""
 
     async def _receive_stream_event(
         self, request: Request, stream_id: int
     ) -> h2.events.Event:
+        """
+        Return the next available event for a given stream ID.
+
+        Will read more data from the network if required.
+        """
         while not self._events.get(stream_id):
             await self._receive_events(request, stream_id)
         event = self._events[stream_id].pop(0)
@@ -277,6 +321,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _receive_events(
         self, request: Request, stream_id: typing.Optional[int] = None
     ) -> None:
+        """
+        Read some data from the network until we see one or more events
+        for a given stream ID.
+        """
         async with self._read_lock:
             if self._connection_error_event is not None:  # pragma: nocover
                 raise RemoteProtocolError(self._connection_error_event)
@@ -509,3 +557,23 @@ class HTTP2ConnectionByteStream:
             kwargs = {"stream_id": self._stream_id}
             async with Trace("http2.response_closed", self._request, kwargs):
                 await self._connection._response_closed(stream_id=self._stream_id)
+
+
+class HTTP2DataStream:
+    def __init__(
+        self, connection: AsyncHTTP2Connection, request: Request, stream_id: int
+    ) -> None:
+        self._connection = connection
+        self._request = request
+        self._stream_id = stream_id
+
+    async def read(self) -> bytes:
+        return await self._connection._recieve_stream_data(
+            self._request, self._stream_id
+        )
+
+    async def write(self, data: bytes) -> None:
+        await self._connection._send_stream_data(self._request, self._stream_id, data)
+
+    async def close(self) -> None:
+        await self._connection._send_end_stream(self._request, self._stream_id)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -129,7 +129,6 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
                 extensions={
-                    "data_stream": HTTP2DataStream(self, request, stream_id),
                     "http_version": b"HTTP/2",
                     "network_stream": self._network_stream,
                     "stream_id": stream_id,
@@ -284,13 +283,13 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         Iterator that returns the bytes of the response body for a given stream ID.
         """
         while True:
-            data = await self._recieve_stream_data(request, stream_id)
+            data = await self._receive_stream_data(request, stream_id)
             if data:
                 yield data
             else:
                 break
 
-    async def _recieve_stream_data(self, request: Request, stream_id: int) -> bytes:
+    async def _receive_stream_data(self, request: Request, stream_id: int) -> bytes:
         """
         Return the bytes in the next data frame for the given stream ID,
         or b'' when the stream ends.
@@ -562,29 +561,3 @@ class HTTP2ConnectionByteStream:
             kwargs = {"stream_id": self._stream_id}
             async with Trace("http2.response_closed", self._request, kwargs):
                 await self._connection._response_closed(stream_id=self._stream_id)
-
-
-class HTTP2DataStream:
-    """
-    A stream-like interface that allows read/write operations directly onto a
-    single HTTP/2 data stream. Allows for HTTP/2 bi-directional streaming.
-    Exposed via the response extensions as "data_stream".
-    """
-
-    def __init__(
-        self, connection: AsyncHTTP2Connection, request: Request, stream_id: int
-    ) -> None:
-        self._connection = connection
-        self._request = request
-        self._stream_id = stream_id
-
-    async def read(self) -> bytes:
-        return await self._connection._recieve_stream_data(
-            self._request, self._stream_id
-        )
-
-    async def write(self, data: bytes) -> None:
-        await self._connection._send_stream_data(self._request, self._stream_id, data)
-
-    async def close(self) -> None:
-        await self._connection._send_end_stream(self._request, self._stream_id)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -128,7 +128,12 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 status=status,
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
-                extensions={"stream_id": stream_id, "http_version": b"HTTP/2"},
+                extensions={
+                    "data_stream": HTTP2DataStream(self, request, stream_id),
+                    "http_version": b"HTTP/2",
+                    "network_stream": self._network_stream,
+                    "stream_id": stream_id,
+                },
             )
         except Exception as exc:  # noqa: PIE786
             kwargs = {"stream_id": stream_id}
@@ -560,6 +565,12 @@ class HTTP2ConnectionByteStream:
 
 
 class HTTP2DataStream:
+    """
+    A stream-like interface that allows read/write operations directly onto a
+    single HTTP/2 data stream. Allows for HTTP/2 bi-directional streaming.
+    Exposed via the response extensions as "data_stream".
+    """
+
     def __init__(
         self, connection: AsyncHTTP2Connection, request: Request, stream_id: int
     ) -> None:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -128,7 +128,12 @@ class HTTP2Connection(ConnectionInterface):
                 status=status,
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
-                extensions={"stream_id": stream_id, "http_version": b"HTTP/2"},
+                extensions={
+                    "data_stream": HTTP2DataStream(self, request, stream_id),
+                    "http_version": b"HTTP/2",
+                    "network_stream": self._network_stream,
+                    "stream_id": stream_id,
+                },
             )
         except Exception as exc:  # noqa: PIE786
             kwargs = {"stream_id": stream_id}
@@ -560,6 +565,12 @@ class HTTP2ConnectionByteStream:
 
 
 class HTTP2DataStream:
+    """
+    A stream-like interface that allows read/write operations directly onto a
+    single HTTP/2 data stream. Allows for HTTP/2 bi-directional streaming.
+    Exposed via the response extensions as "data_stream".
+    """
+
     def __init__(
         self, connection: HTTP2Connection, request: Request, stream_id: int
     ) -> None:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -128,11 +128,7 @@ class HTTP2Connection(ConnectionInterface):
                 status=status,
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
-                extensions={
-                    "http_version": b"HTTP/2",
-                    "network_stream": self._network_stream,
-                    "stream_id": stream_id,
-                },
+                extensions={"stream_id": stream_id, "http_version": b"HTTP/2"},
             )
         except Exception as exc:  # noqa: PIE786
             kwargs = {"stream_id": stream_id}

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -129,7 +129,6 @@ class HTTP2Connection(ConnectionInterface):
                 headers=headers,
                 content=HTTP2ConnectionByteStream(self, request, stream_id=stream_id),
                 extensions={
-                    "data_stream": HTTP2DataStream(self, request, stream_id),
                     "http_version": b"HTTP/2",
                     "network_stream": self._network_stream,
                     "stream_id": stream_id,
@@ -284,13 +283,13 @@ class HTTP2Connection(ConnectionInterface):
         Iterator that returns the bytes of the response body for a given stream ID.
         """
         while True:
-            data = self._recieve_stream_data(request, stream_id)
+            data = self._receive_stream_data(request, stream_id)
             if data:
                 yield data
             else:
                 break
 
-    def _recieve_stream_data(self, request: Request, stream_id: int) -> bytes:
+    def _receive_stream_data(self, request: Request, stream_id: int) -> bytes:
         """
         Return the bytes in the next data frame for the given stream ID,
         or b'' when the stream ends.
@@ -562,29 +561,3 @@ class HTTP2ConnectionByteStream:
             kwargs = {"stream_id": self._stream_id}
             with Trace("http2.response_closed", self._request, kwargs):
                 self._connection._response_closed(stream_id=self._stream_id)
-
-
-class HTTP2DataStream:
-    """
-    A stream-like interface that allows read/write operations directly onto a
-    single HTTP/2 data stream. Allows for HTTP/2 bi-directional streaming.
-    Exposed via the response extensions as "data_stream".
-    """
-
-    def __init__(
-        self, connection: HTTP2Connection, request: Request, stream_id: int
-    ) -> None:
-        self._connection = connection
-        self._request = request
-        self._stream_id = stream_id
-
-    def read(self) -> bytes:
-        return self._connection._recieve_stream_data(
-            self._request, self._stream_id
-        )
-
-    def write(self, data: bytes) -> None:
-        self._connection._send_stream_data(self._request, self._stream_id, data)
-
-    def close(self) -> None:
-        self._connection._send_end_stream(self._request, self._stream_id)

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -187,6 +187,9 @@ class HTTP2Connection(ConnectionInterface):
     # Sending the request...
 
     def _send_request_headers(self, request: Request, stream_id: int) -> None:
+        """
+        Send the request headers to a given stream ID.
+        """
         end_stream = not has_body_headers(request)
 
         # In HTTP/2 the ':authority' pseudo-header is used instead of 'Host'.
@@ -215,18 +218,34 @@ class HTTP2Connection(ConnectionInterface):
         self._write_outgoing_data(request)
 
     def _send_request_body(self, request: Request, stream_id: int) -> None:
+        """
+        Iterate over the request body sending it to a given stream ID.
+        """
         if not has_body_headers(request):
             return
 
         assert isinstance(request.stream, typing.Iterable)
         for data in request.stream:
-            while data:
-                max_flow = self._wait_for_outgoing_flow(request, stream_id)
-                chunk_size = min(len(data), max_flow)
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                self._h2_state.send_data(stream_id, chunk)
-                self._write_outgoing_data(request)
+            self._send_stream_data(request, stream_id, data)
+        self._send_end_stream(request, stream_id)
 
+    def _send_stream_data(
+        self, request: Request, stream_id: int, data: bytes
+    ) -> None:
+        """
+        Send a single chunk of data in one or more data frames.
+        """
+        while data:
+            max_flow = self._wait_for_outgoing_flow(request, stream_id)
+            chunk_size = min(len(data), max_flow)
+            chunk, data = data[:chunk_size], data[chunk_size:]
+            self._h2_state.send_data(stream_id, chunk)
+            self._write_outgoing_data(request)
+
+    def _send_end_stream(self, request: Request, stream_id: int) -> None:
+        """
+        Send an empty data frame on on a given stream ID with the END_STREAM flag set.
+        """
         self._h2_state.end_stream(stream_id)
         self._write_outgoing_data(request)
 
@@ -235,6 +254,9 @@ class HTTP2Connection(ConnectionInterface):
     def _receive_response(
         self, request: Request, stream_id: int
     ) -> typing.Tuple[int, typing.List[typing.Tuple[bytes, bytes]]]:
+        """
+        Return the response status code and headers for a given stream ID.
+        """
         while True:
             event = self._receive_stream_event(request, stream_id)
             if isinstance(event, h2.events.ResponseReceived):
@@ -253,19 +275,41 @@ class HTTP2Connection(ConnectionInterface):
     def _receive_response_body(
         self, request: Request, stream_id: int
     ) -> typing.Iterator[bytes]:
+        """
+        Iterator that returns the bytes of the response body for a given stream ID.
+        """
+        while True:
+            data = self._recieve_stream_data(request, stream_id)
+            if data:
+                yield data
+            else:
+                break
+
+    def _recieve_stream_data(self, request: Request, stream_id: int) -> bytes:
+        """
+        Return the bytes in the next data frame for the given stream ID,
+        or b'' when the stream ends.
+        """
         while True:
             event = self._receive_stream_event(request, stream_id)
             if isinstance(event, h2.events.DataReceived):
                 amount = event.flow_controlled_length
                 self._h2_state.acknowledge_received_data(amount, stream_id)
                 self._write_outgoing_data(request)
-                yield event.data
+                if event.data:
+                    return event.data  # type: ignore
             elif isinstance(event, (h2.events.StreamEnded, h2.events.StreamReset)):
                 break
+        return b""
 
     def _receive_stream_event(
         self, request: Request, stream_id: int
     ) -> h2.events.Event:
+        """
+        Return the next available event for a given stream ID.
+
+        Will read more data from the network if required.
+        """
         while not self._events.get(stream_id):
             self._receive_events(request, stream_id)
         event = self._events[stream_id].pop(0)
@@ -277,6 +321,10 @@ class HTTP2Connection(ConnectionInterface):
     def _receive_events(
         self, request: Request, stream_id: typing.Optional[int] = None
     ) -> None:
+        """
+        Read some data from the network until we see one or more events
+        for a given stream ID.
+        """
         with self._read_lock:
             if self._connection_error_event is not None:  # pragma: nocover
                 raise RemoteProtocolError(self._connection_error_event)
@@ -509,3 +557,23 @@ class HTTP2ConnectionByteStream:
             kwargs = {"stream_id": self._stream_id}
             with Trace("http2.response_closed", self._request, kwargs):
                 self._connection._response_closed(stream_id=self._stream_id)
+
+
+class HTTP2DataStream:
+    def __init__(
+        self, connection: HTTP2Connection, request: Request, stream_id: int
+    ) -> None:
+        self._connection = connection
+        self._request = request
+        self._stream_id = stream_id
+
+    def read(self) -> bytes:
+        return self._connection._recieve_stream_data(
+            self._request, self._stream_id
+        )
+
+    def write(self, data: bytes) -> None:
+        self._connection._send_stream_data(self._request, self._stream_id, data)
+
+    def close(self) -> None:
+        self._connection._send_end_stream(self._request, self._stream_id)


### PR DESCRIPTION
Adds the following internal methods...

* `._send_stream_data(...)`
* `._send_end_stream(...)`
* `._receive_stream_data(...)`

Which are called into by the existing `._send_request_body()` and `_receive_response_body()` methods.

This is an internal refactoring, so doesn't need calling out in our release notes.

Motivation... precursor to adding a `"data_stream"` extension allowing for `read/write` operations onto a bidirectional HTTP/2 stream.