### PR TITLE
Bump GH actions to support Node.js 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       name: deploy
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: 3.7
       - name: "Install dependencies"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,8 +17,8 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"


### PR DESCRIPTION
This PR updates checkout/setup-python GH actions according to these deprecation warnings.

https://github.com/encode/httpcore/actions/runs/5004898315
<img width="1105" alt="image" src="https://github.com/encode/httpcore/assets/664889/2d35fa63-d4e4-4979-94de-182a0c9079cc">

https://github.com/encode/httpcore/actions/runs/5005203672
<img width="1122" alt="image" src="https://github.com/encode/httpcore/assets/664889/1cdf14ce-f41e-4f19-88e6-6cc09e9055f3">
