### PR TITLE
Fan out loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.17.1 (May 17th, 2023)
+
+- If 'retries' is set, then allow retries if an SSL handshake error occurs. (#669)
+- Improve correctness of tracebacks on network exceptions, by raising properly chained exceptions. (#678)
+- Prevent connection-hanging behaviour when HTTP/2 connections are closed by a server-sent 'GoAway' frame. (#679)
+- Fix edge-case exception when removing requests from the connection pool. (#680)
+
 ## 0.17.0 (March 16th, 2023)
 
 - Add DEBUG level logging. (#648)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## development
+
+- Improve logging with per-module logger names. (#690)
+
 ## 0.17.1 (May 17th, 2023)
 
 - If 'retries' is set, then allow retries if an SSL handshake error occurs. (#669)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -20,22 +20,22 @@ httpcore.request('GET', 'https://www.example.com')
 Will send debug level output to the console, or wherever `stdout` is directed too...
 
 ```
-DEBUG [2023-01-09 14:44:00] httpcore - connection.connect_tcp.started host='www.example.com' port=443 local_address=None timeout=None
-DEBUG [2023-01-09 14:44:00] httpcore - connection.connect_tcp.complete return_value=<httpcore.backends.sync.SyncStream object at 0x109ba6610>
-DEBUG [2023-01-09 14:44:00] httpcore - connection.start_tls.started ssl_context=<ssl.SSLContext object at 0x109e427b0> server_hostname='www.example.com' timeout=None
-DEBUG [2023-01-09 14:44:00] httpcore - connection.start_tls.complete return_value=<httpcore.backends.sync.SyncStream object at 0x109e8b050>
-DEBUG [2023-01-09 14:44:00] httpcore - http11.send_request_headers.started request=<Request [b'GET']>
-DEBUG [2023-01-09 14:44:00] httpcore - http11.send_request_headers.complete
-DEBUG [2023-01-09 14:44:00] httpcore - http11.send_request_body.started request=<Request [b'GET']>
-DEBUG [2023-01-09 14:44:00] httpcore - http11.send_request_body.complete
-DEBUG [2023-01-09 14:44:00] httpcore - http11.receive_response_headers.started request=<Request [b'GET']>
-DEBUG [2023-01-09 14:44:00] httpcore - http11.receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Age', b'572646'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Mon, 09 Jan 2023 14:44:00 GMT'), (b'Etag', b'"3147526947+ident"'), (b'Expires', b'Mon, 16 Jan 2023 14:44:00 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECS (nyb/1D18)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'1256')])
-DEBUG [2023-01-09 14:44:00] httpcore - http11.receive_response_body.started request=<Request [b'GET']>
-DEBUG [2023-01-09 14:44:00] httpcore - http11.receive_response_body.complete
-DEBUG [2023-01-09 14:44:00] httpcore - http11.response_closed.started
-DEBUG [2023-01-09 14:44:00] httpcore - http11.response_closed.complete
-DEBUG [2023-01-09 14:44:00] httpcore - connection.close.started
-DEBUG [2023-01-09 14:44:00] httpcore - connection.close.complete
+DEBUG [2023-01-09 14:44:00] httpcore.connection - connect_tcp.started host='www.example.com' port=443 local_address=None timeout=None
+DEBUG [2023-01-09 14:44:00] httpcore.connection - connect_tcp.complete return_value=<httpcore.backends.sync.SyncStream object at 0x109ba6610>
+DEBUG [2023-01-09 14:44:00] httpcore.connection - start_tls.started ssl_context=<ssl.SSLContext object at 0x109e427b0> server_hostname='www.example.com' timeout=None
+DEBUG [2023-01-09 14:44:00] httpcore.connection - start_tls.complete return_value=<httpcore.backends.sync.SyncStream object at 0x109e8b050>
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - send_request_headers.started request=<Request [b'GET']>
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - send_request_headers.complete
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - send_request_body.started request=<Request [b'GET']>
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - send_request_body.complete
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - receive_response_headers.started request=<Request [b'GET']>
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Age', b'572646'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Mon, 09 Jan 2023 14:44:00 GMT'), (b'Etag', b'"3147526947+ident"'), (b'Expires', b'Mon, 16 Jan 2023 14:44:00 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECS (nyb/1D18)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'1256')])
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - receive_response_body.started request=<Request [b'GET']>
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - receive_response_body.complete
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - response_closed.started
+DEBUG [2023-01-09 14:44:00] httpcore.http11 - response_closed.complete
+DEBUG [2023-01-09 14:44:00] httpcore.connection - close.started
+DEBUG [2023-01-09 14:44:00] httpcore.connection - close.complete
 ```
 
 The exact formatting of the debug logging may be subject to change across different versions of `httpcore`. If you need to rely on a particular format it is recommended that you pin installation of the package to a fixed version.

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -82,7 +82,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 
 __locals = locals()

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import ssl
 from types import TracebackType
 from typing import Iterator, Optional, Type
@@ -14,6 +15,9 @@ from .http11 import AsyncHTTP11Connection
 from .interfaces import AsyncConnectionInterface
 
 RETRIES_BACKOFF_FACTOR = 0.5  # 0s, 0.5s, 1s, 2s, 4s, etc.
+
+
+logger = logging.getLogger("httpcore.connection")
 
 
 def exponential_backoff(factor: float) -> Iterator[float]:
@@ -105,9 +109,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                         "local_address": self._local_address,
                         "timeout": timeout,
                     }
-                    async with Trace(
-                        "connection.connect_tcp", request, kwargs
-                    ) as trace:
+                    async with Trace("connect_tcp", logger, request, kwargs) as trace:
                         stream = await self._network_backend.connect_tcp(**kwargs)
                         trace.return_value = stream
                 else:
@@ -116,7 +118,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                         "timeout": timeout,
                     }
                     async with Trace(
-                        "connection.connect_unix_socket", request, kwargs
+                        "connect_unix_socket", logger, request, kwargs
                     ) as trace:
                         stream = await self._network_backend.connect_unix_socket(
                             **kwargs
@@ -137,7 +139,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                         "server_hostname": self._origin.host.decode("ascii"),
                         "timeout": timeout,
                     }
-                    async with Trace("connection.start_tls", request, kwargs) as trace:
+                    async with Trace("start_tls", logger, request, kwargs) as trace:
                         stream = await stream.start_tls(**kwargs)
                         trace.return_value = stream
                 return stream
@@ -146,15 +148,15 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                     raise
                 retries_left -= 1
                 delay = next(delays)
-                # TRACE 'retry'
-                await self._network_backend.sleep(delay)
+                async with Trace("retry", logger, request, kwargs) as trace:
+                    await self._network_backend.sleep(delay)
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin
 
     async def aclose(self) -> None:
         if self._connection is not None:
-            async with Trace("connection.close", None, {}):
+            async with Trace("close", logger, None, {}):
                 await self._connection.aclose()
 
     def is_available(self) -> bool:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -1,3 +1,4 @@
+import logging
 import ssl
 from base64 import b64encode
 from typing import List, Mapping, Optional, Sequence, Tuple, Union
@@ -23,6 +24,9 @@ from .interfaces import AsyncConnectionInterface
 
 HeadersAsSequence = Sequence[Tuple[Union[bytes, str], Union[bytes, str]]]
 HeadersAsMapping = Mapping[Union[bytes, str], Union[bytes, str]]
+
+
+logger = logging.getLogger("httpcore.proxy")
 
 
 def merge_headers(
@@ -285,7 +289,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     "server_hostname": self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
-                async with Trace("connection.start_tls", request, kwargs) as trace:
+                async with Trace("start_tls", logger, request, kwargs) as trace:
                     stream = await stream.start_tls(**kwargs)
                     trace.return_value = stream
 

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -1,3 +1,4 @@
+import logging
 import ssl
 import typing
 
@@ -13,6 +14,9 @@ from ..backends.base import AsyncNetworkBackend, AsyncNetworkStream
 from .connection_pool import AsyncConnectionPool
 from .http11 import AsyncHTTP11Connection
 from .interfaces import AsyncConnectionInterface
+
+logger = logging.getLogger("httpcore.socks")
+
 
 AUTH_METHODS = {
     b"\x00": "NO AUTHENTICATION REQUIRED",
@@ -223,7 +227,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         "port": self._proxy_origin.port,
                         "timeout": timeout,
                     }
-                    with Trace("connection.connect_tcp", request, kwargs) as trace:
+                    with Trace("connect_tcp", logger, request, kwargs) as trace:
                         stream = await self._network_backend.connect_tcp(**kwargs)
                         trace.return_value = stream
 
@@ -235,7 +239,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         "auth": self._proxy_auth,
                     }
                     with Trace(
-                        "connection.setup_socks5_connection", request, kwargs
+                        "setup_socks5_connection", logger, request, kwargs
                     ) as trace:
                         await _init_socks5_connection(**kwargs)
                         trace.return_value = stream
@@ -257,9 +261,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                             "server_hostname": self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
-                        async with Trace(
-                            "connection.start_tls", request, kwargs
-                        ) as trace:
+                        async with Trace("start_tls", logger, request, kwargs) as trace:
                             stream = await stream.start_tls(**kwargs)
                             trace.return_value = stream
 

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import time
 from types import TracebackType
 from typing import (
@@ -25,6 +26,9 @@ from .._synchronization import Lock
 from .._trace import Trace
 from ..backends.base import NetworkStream
 from .interfaces import ConnectionInterface
+
+logger = logging.getLogger("httpcore.http11")
+
 
 # A subset of `h11.Event` types supported by `_send_event`
 H11SendEvent = Union[
@@ -80,12 +84,12 @@ class HTTP11Connection(ConnectionInterface):
 
         try:
             kwargs = {"request": request}
-            with Trace("http11.send_request_headers", request, kwargs) as trace:
+            with Trace("send_request_headers", logger, request, kwargs) as trace:
                 self._send_request_headers(**kwargs)
-            with Trace("http11.send_request_body", request, kwargs) as trace:
+            with Trace("send_request_body", logger, request, kwargs) as trace:
                 self._send_request_body(**kwargs)
             with Trace(
-                "http11.receive_response_headers", request, kwargs
+                "receive_response_headers", logger, request, kwargs
             ) as trace:
                 (
                     http_version,
@@ -111,7 +115,7 @@ class HTTP11Connection(ConnectionInterface):
                 },
             )
         except BaseException as exc:
-            with Trace("http11.response_closed", request) as trace:
+            with Trace("response_closed", logger, request) as trace:
                 self._response_closed()
             raise exc
 
@@ -308,7 +312,7 @@ class HTTP11ConnectionByteStream:
     def __iter__(self) -> Iterator[bytes]:
         kwargs = {"request": self._request}
         try:
-            with Trace("http11.receive_response_body", self._request, kwargs):
+            with Trace("receive_response_body", logger, self._request, kwargs):
                 for chunk in self._connection._receive_response_body(**kwargs):
                     yield chunk
         except BaseException as exc:
@@ -321,5 +325,5 @@ class HTTP11ConnectionByteStream:
     def close(self) -> None:
         if not self._closed:
             self._closed = True
-            with Trace("http11.response_closed", self._request):
+            with Trace("response_closed", logger, self._request):
                 self._connection._response_closed()

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import time
 import types
 import typing
@@ -19,6 +20,8 @@ from .._synchronization import Lock, Semaphore
 from .._trace import Trace
 from ..backends.base import NetworkStream
 from .interfaces import ConnectionInterface
+
+logger = logging.getLogger("httpcore.http2")
 
 
 def has_body_headers(request: Request) -> bool:
@@ -85,7 +88,7 @@ class HTTP2Connection(ConnectionInterface):
         with self._init_lock:
             if not self._sent_connection_init:
                 kwargs = {"request": request}
-                with Trace("http2.send_connection_init", request, kwargs):
+                with Trace("send_connection_init", logger, request, kwargs):
                     self._send_connection_init(**kwargs)
                 self._sent_connection_init = True
 
@@ -112,12 +115,12 @@ class HTTP2Connection(ConnectionInterface):
 
         try:
             kwargs = {"request": request, "stream_id": stream_id}
-            with Trace("http2.send_request_headers", request, kwargs):
+            with Trace("send_request_headers", logger, request, kwargs):
                 self._send_request_headers(request=request, stream_id=stream_id)
-            with Trace("http2.send_request_body", request, kwargs):
+            with Trace("send_request_body", logger, request, kwargs):
                 self._send_request_body(request=request, stream_id=stream_id)
             with Trace(
-                "http2.receive_response_headers", request, kwargs
+                "receive_response_headers", logger, request, kwargs
             ) as trace:
                 status, headers = self._receive_response(
                     request=request, stream_id=stream_id
@@ -132,7 +135,7 @@ class HTTP2Connection(ConnectionInterface):
             )
         except Exception as exc:  # noqa: PIE786
             kwargs = {"stream_id": stream_id}
-            with Trace("http2.response_closed", request, kwargs):
+            with Trace("response_closed", logger, request, kwargs):
                 self._response_closed(stream_id=stream_id)
 
             if isinstance(exc, h2.exceptions.ProtocolError):
@@ -292,7 +295,7 @@ class HTTP2Connection(ConnectionInterface):
                 for event in events:
                     if isinstance(event, h2.events.RemoteSettingsChanged):
                         with Trace(
-                            "http2.receive_remote_settings", request
+                            "receive_remote_settings", logger, request
                         ) as trace:
                             self._receive_remote_settings_change(event)
                             trace.return_value = event
@@ -491,7 +494,7 @@ class HTTP2ConnectionByteStream:
     def __iter__(self) -> typing.Iterator[bytes]:
         kwargs = {"request": self._request, "stream_id": self._stream_id}
         try:
-            with Trace("http2.receive_response_body", self._request, kwargs):
+            with Trace("receive_response_body", logger, self._request, kwargs):
                 for chunk in self._connection._receive_response_body(
                     request=self._request, stream_id=self._stream_id
                 ):
@@ -507,5 +510,5 @@ class HTTP2ConnectionByteStream:
         if not self._closed:
             self._closed = True
             kwargs = {"stream_id": self._stream_id}
-            with Trace("http2.response_closed", self._request, kwargs):
+            with Trace("response_closed", logger, self._request, kwargs):
                 self._connection._response_closed(stream_id=self._stream_id)

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -1,3 +1,4 @@
+import logging
 import ssl
 from base64 import b64encode
 from typing import List, Mapping, Optional, Sequence, Tuple, Union
@@ -23,6 +24,9 @@ from .interfaces import ConnectionInterface
 
 HeadersAsSequence = Sequence[Tuple[Union[bytes, str], Union[bytes, str]]]
 HeadersAsMapping = Mapping[Union[bytes, str], Union[bytes, str]]
+
+
+logger = logging.getLogger("httpcore.proxy")
 
 
 def merge_headers(
@@ -285,7 +289,7 @@ class TunnelHTTPConnection(ConnectionInterface):
                     "server_hostname": self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
-                with Trace("connection.start_tls", request, kwargs) as trace:
+                with Trace("start_tls", logger, request, kwargs) as trace:
                     stream = stream.start_tls(**kwargs)
                     trace.return_value = stream
 

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -1,3 +1,4 @@
+import logging
 import ssl
 import typing
 
@@ -13,6 +14,9 @@ from ..backends.base import NetworkBackend, NetworkStream
 from .connection_pool import ConnectionPool
 from .http11 import HTTP11Connection
 from .interfaces import ConnectionInterface
+
+logger = logging.getLogger("httpcore.socks")
+
 
 AUTH_METHODS = {
     b"\x00": "NO AUTHENTICATION REQUIRED",
@@ -223,7 +227,7 @@ class Socks5Connection(ConnectionInterface):
                         "port": self._proxy_origin.port,
                         "timeout": timeout,
                     }
-                    with Trace("connection.connect_tcp", request, kwargs) as trace:
+                    with Trace("connect_tcp", logger, request, kwargs) as trace:
                         stream = self._network_backend.connect_tcp(**kwargs)
                         trace.return_value = stream
 
@@ -235,7 +239,7 @@ class Socks5Connection(ConnectionInterface):
                         "auth": self._proxy_auth,
                     }
                     with Trace(
-                        "connection.setup_socks5_connection", request, kwargs
+                        "setup_socks5_connection", logger, request, kwargs
                     ) as trace:
                         _init_socks5_connection(**kwargs)
                         trace.return_value = stream
@@ -257,9 +261,7 @@ class Socks5Connection(ConnectionInterface):
                             "server_hostname": self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
-                        with Trace(
-                            "connection.start_tls", request, kwargs
-                        ) as trace:
+                        with Trace("start_tls", logger, request, kwargs) as trace:
                             stream = stream.start_tls(**kwargs)
                             trace.return_value = stream
 

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -184,48 +184,48 @@ async def test_debug_request(caplog):
 
     assert caplog.record_tuples == [
         (
-            "httpcore",
+            "httpcore.connection",
             logging.DEBUG,
-            "connection.connect_tcp.started host='example.com' port=80 local_address=None timeout=None",
+            "connect_tcp.started host='example.com' port=80 local_address=None timeout=None",
         ),
         (
-            "httpcore",
+            "httpcore.connection",
             logging.DEBUG,
-            "connection.connect_tcp.complete return_value=<httpcore.AsyncMockStream>",
+            "connect_tcp.complete return_value=<httpcore.AsyncMockStream>",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.send_request_headers.started request=<Request [b'GET']>",
+            "send_request_headers.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.send_request_headers.complete"),
+        ("httpcore.http11", logging.DEBUG, "send_request_headers.complete"),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.send_request_body.started request=<Request [b'GET']>",
+            "send_request_body.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.send_request_body.complete"),
+        ("httpcore.http11", logging.DEBUG, "send_request_body.complete"),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_headers.started request=<Request [b'GET']>",
+            "receive_response_headers.started request=<Request [b'GET']>",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_headers.complete return_value="
+            "receive_response_headers.complete return_value="
             "(b'HTTP/1.1', 200, b'OK', [(b'Content-Type', b'plain/text'), (b'Content-Length', b'13')])",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_body.started request=<Request [b'GET']>",
+            "receive_response_body.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.receive_response_body.complete"),
-        ("httpcore", logging.DEBUG, "http11.response_closed.started"),
-        ("httpcore", logging.DEBUG, "http11.response_closed.complete"),
-        ("httpcore", logging.DEBUG, "connection.close.started"),
-        ("httpcore", logging.DEBUG, "connection.close.complete"),
+        ("httpcore.http11", logging.DEBUG, "receive_response_body.complete"),
+        ("httpcore.http11", logging.DEBUG, "response_closed.started"),
+        ("httpcore.http11", logging.DEBUG, "response_closed.complete"),
+        ("httpcore.connection", logging.DEBUG, "close.started"),
+        ("httpcore.connection", logging.DEBUG, "close.complete"),
     ]
 
 

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -184,48 +184,48 @@ def test_debug_request(caplog):
 
     assert caplog.record_tuples == [
         (
-            "httpcore",
+            "httpcore.connection",
             logging.DEBUG,
-            "connection.connect_tcp.started host='example.com' port=80 local_address=None timeout=None",
+            "connect_tcp.started host='example.com' port=80 local_address=None timeout=None",
         ),
         (
-            "httpcore",
+            "httpcore.connection",
             logging.DEBUG,
-            "connection.connect_tcp.complete return_value=<httpcore.MockStream>",
+            "connect_tcp.complete return_value=<httpcore.MockStream>",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.send_request_headers.started request=<Request [b'GET']>",
+            "send_request_headers.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.send_request_headers.complete"),
+        ("httpcore.http11", logging.DEBUG, "send_request_headers.complete"),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.send_request_body.started request=<Request [b'GET']>",
+            "send_request_body.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.send_request_body.complete"),
+        ("httpcore.http11", logging.DEBUG, "send_request_body.complete"),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_headers.started request=<Request [b'GET']>",
+            "receive_response_headers.started request=<Request [b'GET']>",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_headers.complete return_value="
+            "receive_response_headers.complete return_value="
             "(b'HTTP/1.1', 200, b'OK', [(b'Content-Type', b'plain/text'), (b'Content-Length', b'13')])",
         ),
         (
-            "httpcore",
+            "httpcore.http11",
             logging.DEBUG,
-            "http11.receive_response_body.started request=<Request [b'GET']>",
+            "receive_response_body.started request=<Request [b'GET']>",
         ),
-        ("httpcore", logging.DEBUG, "http11.receive_response_body.complete"),
-        ("httpcore", logging.DEBUG, "http11.response_closed.started"),
-        ("httpcore", logging.DEBUG, "http11.response_closed.complete"),
-        ("httpcore", logging.DEBUG, "connection.close.started"),
-        ("httpcore", logging.DEBUG, "connection.close.complete"),
+        ("httpcore.http11", logging.DEBUG, "receive_response_body.complete"),
+        ("httpcore.http11", logging.DEBUG, "response_closed.started"),
+        ("httpcore.http11", logging.DEBUG, "response_closed.complete"),
+        ("httpcore.connection", logging.DEBUG, "close.started"),
+        ("httpcore.connection", logging.DEBUG, "close.complete"),
     ]
 
 


### PR DESCRIPTION
This pull request improves our logging behaviour by fanning out different logger names...

*code*:

```python
import httpcore
import logging


logging.basicConfig(
    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
)
logging.getLogger("httpcore").setLevel(logging.DEBUG)


httpcore.request("GET", "https://www.example.com/")
```

*console*:

```shell
$ venv/bin/python example.py 
DEBUG [2023-05-18 13:01:06] httpcore.connection - connect_tcp.started host='www.example.com' port=443 local_address=None timeout=None
DEBUG [2023-05-18 13:01:06] httpcore.connection - connect_tcp.complete return_value=<httpcore.backends.sync.SyncStream object at 0x10ec1c640>
DEBUG [2023-05-18 13:01:06] httpcore.connection - start_tls.started ssl_context=<ssl.SSLContext object at 0x10ea821c0> server_hostname='www.example.com' timeout=None
DEBUG [2023-05-18 13:01:06] httpcore.connection - start_tls.complete return_value=<httpcore.backends.sync.SyncStream object at 0x10ec1c610>
DEBUG [2023-05-18 13:01:06] httpcore.http11 - send_request_headers.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:06] httpcore.http11 - send_request_headers.complete
DEBUG [2023-05-18 13:01:06] httpcore.http11 - send_request_body.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:06] httpcore.http11 - send_request_body.complete
DEBUG [2023-05-18 13:01:06] httpcore.http11 - receive_response_headers.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:07] httpcore.http11 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Age', b'457465'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Thu, 18 May 2023 12:01:07 GMT'), (b'Etag', b'"3147526947+ident"'), (b'Expires', b'Thu, 25 May 2023 12:01:07 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECS (nyb/1D13)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'1256')])
DEBUG [2023-05-18 13:01:07] httpcore.http11 - receive_response_body.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:07] httpcore.http11 - receive_response_body.complete
DEBUG [2023-05-18 13:01:07] httpcore.http11 - response_closed.started
DEBUG [2023-05-18 13:01:07] httpcore.http11 - response_closed.complete
DEBUG [2023-05-18 13:01:07] httpcore.connection - close.started
DEBUG [2023-05-18 13:01:07] httpcore.connection - close.complete
```

<details>
<summary>(output prior to this change)...</summary>

```shell
$ venv/bin/python example.py 
DEBUG [2023-05-18 13:01:06] httpcore - connection.connect_tcp.started host='www.example.com' port=443 local_address=None timeout=None
DEBUG [2023-05-18 13:01:06] httpcore - connection.connect_tcp.complete return_value=<httpcore.backends.sync.SyncStream object at 0x10ec1c640>
DEBUG [2023-05-18 13:01:06] httpcore - connection.start_tls.started ssl_context=<ssl.SSLContext object at 0x10ea821c0> server_hostname='www.example.com' timeout=None
DEBUG [2023-05-18 13:01:06] httpcore - connection.start_tls.complete return_value=<httpcore.backends.sync.SyncStream object at 0x10ec1c610>
DEBUG [2023-05-18 13:01:06] httpcore - http11.send_request_headers.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:06] httpcore - http11.send_request_headers.complete
DEBUG [2023-05-18 13:01:06] httpcore - http11.send_request_body.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:06] httpcore - http11.send_request_body.complete
DEBUG [2023-05-18 13:01:06] httpcore - http11.receive_response_headers.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:07] httpcore - http11.receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Age', b'457465'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Thu, 18 May 2023 12:01:07 GMT'), (b'Etag', b'"3147526947+ident"'), (b'Expires', b'Thu, 25 May 2023 12:01:07 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECS (nyb/1D13)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'1256')])
DEBUG [2023-05-18 13:01:07] httpcore - http11.receive_response_body.started request=<Request [b'GET']>
DEBUG [2023-05-18 13:01:07] httpcore - http11.receive_response_body.complete
DEBUG [2023-05-18 13:01:07] httpcore - http11.response_closed.started
DEBUG [2023-05-18 13:01:07] httpcore - http11.response_closed.complete
DEBUG [2023-05-18 13:01:07] httpcore - connection.close.started
DEBUG [2023-05-18 13:01:07] httpcore - connection.close.complete
```
</details>

This allows better control of logging, and also reads more clearly to me.

*(parameters passed to the "trace" extension are unaffected by this change.)*

**TODO**

- [x] Implementation
- [x] Update docs
- [x] Include in CHANGELOG