### PR TITLE
Adding received CONNECT headers to response headers

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -321,7 +321,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
         response = await self._connection.handle_async_request(request)
         try:
             # Adding Received Headers from CONNECT
-            if getattr(connect_response, 'headers', None):
+            if getattr(connect_response, "headers", None):
                 response.headers += connect_response.headers
         except Exception:
             pass

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -317,7 +317,15 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     )
 
                 self._connected = True
-        return await self._connection.handle_async_request(request)
+
+        response = await self._connection.handle_async_request(request)
+        try:
+            # Adding Received Headers from CONNECT
+            if getattr(connect_response, 'headers', None):
+                response.headers += connect_response.headers
+        except Exception:
+            pass
+        return response
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._remote_origin

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -317,7 +317,15 @@ class TunnelHTTPConnection(ConnectionInterface):
                     )
 
                 self._connected = True
-        return self._connection.handle_request(request)
+
+        response = self._connection.handle_request(request)
+        try:
+            # Adding Received Headers from CONNECT
+            if getattr(connect_response, "headers", None):
+                response.headers += connect_response.headers
+        except Exception:
+            pass
+        return response
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._remote_origin


### PR DESCRIPTION
Adding possibility to analyze received Headers from proxy CONNECT requests on application level.

**Problem**: In some cases transports (proxies f.e.) provides additional data (Request-Id, Node Information, etc).

**Example**:
```
<!-- Proxy Headers -->
HTTP/1.1 200 OK   
X-Request-id: e99629fd-ea06-deb1-d37d-27396af70983  // Our target Data
X-Request-node: maelstorm   // Our target data

<-- Real request to Url -->
HTTP/2 200 
server: nginx
date: Thu, 18 May 2023 18:42:15 GMT
content-type: application/json
content-length: 185
```

**Approach**:
Add intermediate requests headers to final Response.


Very likely this solution isn't the best one. Thanks in advance for any feedback!
