### PR TITLE
Add exceptions for invalid trace callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## unreleased
 
 - The networking backend interface has [been added to the public API](https://www.encode.io/httpcore/network-backends). Some classes which were previously private implementation detail are now part of the top-level public API. (#699)
+- Add exceptions when a synchronous `trace callback` is passed to an asynchronous request or an asynchronous `trace callback` is passed to a synchronous request. (#717)
 
 ## 0.17.2 (May 23th, 2023)
 

--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -1,9 +1,10 @@
+import inspect
 import logging
 from types import TracebackType
 from typing import Any, Dict, Optional, Type
 
 from ._models import Request
-import inspect
+
 
 class Trace:
     def __init__(
@@ -27,9 +28,11 @@ class Trace:
     def trace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
             if inspect.iscoroutinefunction(self.trace_extension):
-                raise TypeError("If you are using a synchronous interface, "
-                                "the callback of the `trace` extension should "
-                                "be a normal function instead of an asynchronous function.")
+                raise TypeError(
+                    "If you are using a synchronous interface, "
+                    "the callback of the `trace` extension should "
+                    "be a normal function instead of an asynchronous function."
+                )
             prefix_and_name = f"{self.prefix}.{name}"
             self.trace_extension(prefix_and_name, info)
 
@@ -64,9 +67,11 @@ class Trace:
     async def atrace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
             if not inspect.iscoroutinefunction(self.trace_extension):
-                raise TypeError("If you're using an asynchronous interface, "
-                                "the callback of the `trace` extension should "
-                                "be an asynchronous function rather than a normal function.")
+                raise TypeError(
+                    "If you're using an asynchronous interface, "
+                    "the callback of the `trace` extension should "
+                    "be an asynchronous function rather than a normal function."
+                )
             prefix_and_name = f"{self.prefix}.{name}"
             await self.trace_extension(prefix_and_name, info)
 

--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -27,14 +27,14 @@ class Trace:
 
     def trace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
-            if inspect.iscoroutinefunction(self.trace_extension):  # pragma: no cover
+            prefix_and_name = f"{self.prefix}.{name}"
+            ret = self.trace_extension(prefix_and_name, info)
+            if inspect.iscoroutine(ret):
                 raise TypeError(
                     "If you are using a synchronous interface, "
                     "the callback of the `trace` extension should "
                     "be a normal function instead of an asynchronous function."
                 )
-            prefix_and_name = f"{self.prefix}.{name}"
-            self.trace_extension(prefix_and_name, info)
 
         if self.debug:
             if not info or "return_value" in info and info["return_value"] is None:
@@ -66,16 +66,15 @@ class Trace:
 
     async def atrace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
-            if not inspect.iscoroutinefunction(
-                self.trace_extension
-            ):  # pragma: no cover
+            prefix_and_name = f"{self.prefix}.{name}"
+            coro = self.trace_extension(prefix_and_name, info)
+            if not inspect.iscoroutine(coro):
                 raise TypeError(
                     "If you're using an asynchronous interface, "
                     "the callback of the `trace` extension should "
                     "be an asynchronous function rather than a normal function."
                 )
-            prefix_and_name = f"{self.prefix}.{name}"
-            await self.trace_extension(prefix_and_name, info)
+            await coro
 
         if self.debug:
             if not info or "return_value" in info and info["return_value"] is None:

--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -3,7 +3,7 @@ from types import TracebackType
 from typing import Any, Dict, Optional, Type
 
 from ._models import Request
-
+import inspect
 
 class Trace:
     def __init__(
@@ -26,6 +26,10 @@ class Trace:
 
     def trace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
+            if inspect.iscoroutinefunction(self.trace_extension):
+                raise TypeError("If you are using a synchronous interface, "
+                                "the callback of the `trace` extension should "
+                                "be a normal function instead of an asynchronous function.")
             prefix_and_name = f"{self.prefix}.{name}"
             self.trace_extension(prefix_and_name, info)
 
@@ -59,6 +63,10 @@ class Trace:
 
     async def atrace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
+            if not inspect.iscoroutinefunction(self.trace_extension):
+                raise TypeError("If you're using an asynchronous interface, "
+                                "the callback of the `trace` extension should "
+                                "be an asynchronous function rather than a normal function.")
             prefix_and_name = f"{self.prefix}.{name}"
             await self.trace_extension(prefix_and_name, info)
 

--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -29,7 +29,7 @@ class Trace:
         if self.trace_extension is not None:
             prefix_and_name = f"{self.prefix}.{name}"
             ret = self.trace_extension(prefix_and_name, info)
-            if inspect.iscoroutine(ret):
+            if inspect.iscoroutine(ret):  # pragma: no cover
                 raise TypeError(
                     "If you are using a synchronous interface, "
                     "the callback of the `trace` extension should "
@@ -68,7 +68,7 @@ class Trace:
         if self.trace_extension is not None:
             prefix_and_name = f"{self.prefix}.{name}"
             coro = self.trace_extension(prefix_and_name, info)
-            if not inspect.iscoroutine(coro):
+            if not inspect.iscoroutine(coro):  # pragma: no cover
                 raise TypeError(
                     "If you're using an asynchronous interface, "
                     "the callback of the `trace` extension should "

--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -27,7 +27,7 @@ class Trace:
 
     def trace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
-            if inspect.iscoroutinefunction(self.trace_extension):
+            if inspect.iscoroutinefunction(self.trace_extension):  # pragma: no cover
                 raise TypeError(
                     "If you are using a synchronous interface, "
                     "the callback of the `trace` extension should "
@@ -66,7 +66,9 @@ class Trace:
 
     async def atrace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
-            if not inspect.iscoroutinefunction(self.trace_extension):
+            if not inspect.iscoroutinefunction(
+                self.trace_extension
+            ):  # pragma: no cover
                 raise TypeError(
                     "If you're using an asynchronous interface, "
                     "the callback of the `trace` extension should "


### PR DESCRIPTION

# Examples

```python
import httpcore

async def log(a, b):
    print(a, b)

httpcore.request("GET", "https://google.com", extensions={"trace": log})
```

## Old output
```
RuntimeWarning: coroutine 'log' was never awaited
  self.trace_extension(prefix_and_name, info)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

## New output
```
TypeError: If you are using a synchronous interface, the callback of the `trace` extension should be a normal function instead of an asynchronous function.
```

```python
import trio

def log(a, b):
    print(a,b)

async def req():
    cl = httpcore.AsyncConnectionPool()
    await cl.request("GET", "https://google.com", extensions={"trace": log})

trio.run(req)
```

## Old output
```
TypeError: object NoneType can't be used in 'await' expression
```

## New output
```
TypeError: If you're using an asynchronous interface, the callback of the `trace` extension should be an asynchronous function rather than a normal function.
```