### PR TITLE
Support async cancellations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## unreleased
 
 - The networking backend interface has [been added to the public API](https://www.encode.io/httpcore/network-backends). Some classes which were previously private implementation detail are now part of the top-level public API. (#699)
+- Support async cancellations, ensuring that the connection pool is left in a clean state when cancellations occur. (#726)
 - Graceful handling of HTTP/2 GoAway frames, with requests being transparently retried on a new connection. (#730)
 - Add exceptions when a synchronous `trace callback` is passed to an asynchronous request or an asynchronous `trace callback` is passed to a synchronous request. (#717)
 

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -23,7 +23,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._models import Origin, Request, Response
-from .._synchronization import AsyncLock
+from .._synchronization import AsyncLock, AsyncShieldCancellation
 from .._trace import Trace
 from .interfaces import AsyncConnectionInterface
 
@@ -115,8 +115,9 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
                 },
             )
         except BaseException as exc:
-            async with Trace("response_closed", logger, request) as trace:
-                await self._response_closed()
+            with AsyncShieldCancellation():
+                async with Trace("response_closed", logger, request) as trace:
+                    await self._response_closed()
             raise exc
 
     # Sending the request...

--- a/httpcore/_async/http11.py
+++ b/httpcore/_async/http11.py
@@ -320,7 +320,8 @@ class HTTP11ConnectionByteStream:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)
             # before raising that exception.
-            await self.aclose()
+            with AsyncShieldCancellation():
+                await self.aclose()
             raise exc
 
     async def aclose(self) -> None:

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -17,7 +17,7 @@ from .._exceptions import (
     RemoteProtocolError,
 )
 from .._models import Origin, Request, Response
-from .._synchronization import AsyncLock, AsyncSemaphore
+from .._synchronization import AsyncLock, AsyncSemaphore, AsyncShieldCancellation
 from .._trace import Trace
 from .interfaces import AsyncConnectionInterface
 
@@ -103,9 +103,15 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         async with self._init_lock:
             if not self._sent_connection_init:
-                kwargs = {"request": request}
-                async with Trace("send_connection_init", logger, request, kwargs):
-                    await self._send_connection_init(**kwargs)
+                try:
+                    kwargs = {"request": request}
+                    async with Trace("send_connection_init", logger, request, kwargs):
+                        await self._send_connection_init(**kwargs)
+                except BaseException as exc:
+                    with AsyncShieldCancellation():
+                        await self.aclose()
+                    raise exc
+
                 self._sent_connection_init = True
 
                 # Initially start with just 1 until the remote server provides
@@ -154,10 +160,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                     "stream_id": stream_id,
                 },
             )
-        except Exception as exc:  # noqa: PIE786
-            kwargs = {"stream_id": stream_id}
-            async with Trace("response_closed", logger, request, kwargs):
-                await self._response_closed(stream_id=stream_id)
+        except BaseException as exc:  # noqa: PIE786
+            with AsyncShieldCancellation():
+                kwargs = {"stream_id": stream_id}
+                async with Trace("response_closed", logger, request, kwargs):
+                    await self._response_closed(stream_id=stream_id)
 
             if isinstance(exc, h2.exceptions.ProtocolError):
                 # One case where h2 can raise a protocol error is when a

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -577,7 +577,8 @@ class HTTP2ConnectionByteStream:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)
             # before raising that exception.
-            await self.aclose()
+            with AsyncShieldCancellation():
+                await self.aclose()
             raise exc
 
     async def aclose(self) -> None:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -7,7 +7,7 @@ from .._backends.sync import SyncBackend
 from .._backends.base import SOCKET_OPTION, NetworkBackend
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Request, Response
-from .._synchronization import Event, Lock
+from .._synchronization import Event, Lock, ShieldCancellation
 from .connection import HTTPConnection
 from .interfaces import ConnectionInterface, RequestInterface
 
@@ -257,7 +257,8 @@ class ConnectionPool(RequestInterface):
                     status.unset_connection()
                     self._attempt_to_acquire_connection(status)
             except BaseException as exc:
-                self.response_closed(status)
+                with ShieldCancellation():
+                    self.response_closed(status)
                 raise exc
             else:
                 break
@@ -351,4 +352,5 @@ class ConnectionPoolByteStream:
             if hasattr(self._stream, "close"):
                 self._stream.close()
         finally:
-            self._pool.response_closed(self._status)
+            with ShieldCancellation():
+                self._pool.response_closed(self._status)

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -320,7 +320,8 @@ class HTTP11ConnectionByteStream:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)
             # before raising that exception.
-            self.close()
+            with ShieldCancellation():
+                self.close()
             raise exc
 
     def close(self) -> None:

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -23,7 +23,7 @@ from .._exceptions import (
     map_exceptions,
 )
 from .._models import Origin, Request, Response
-from .._synchronization import Lock
+from .._synchronization import Lock, ShieldCancellation
 from .._trace import Trace
 from .interfaces import ConnectionInterface
 
@@ -115,8 +115,9 @@ class HTTP11Connection(ConnectionInterface):
                 },
             )
         except BaseException as exc:
-            with Trace("response_closed", logger, request) as trace:
-                self._response_closed()
+            with ShieldCancellation():
+                with Trace("response_closed", logger, request) as trace:
+                    self._response_closed()
             raise exc
 
     # Sending the request...

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -577,7 +577,8 @@ class HTTP2ConnectionByteStream:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)
             # before raising that exception.
-            self.close()
+            with ShieldCancellation():
+                self.close()
             raise exc
 
     def close(self) -> None:

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -182,7 +182,7 @@ class AsyncShieldCancellation:
     def __init__(self) -> None:
         """
         Detect if we're running under 'asyncio' or 'trio' and create
-        a semaphore with the correct implementation.
+        a shielded scope with the correct implementation.
         """
         self._backend = sniffio.current_async_library()
 

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -171,7 +171,7 @@ class AsyncSemaphore:
             self._anyio_semaphore.release()
 
 
-class AsyncShieldCancellation:  # pragma: nocover
+class AsyncShieldCancellation:
     # For certain portions of our codebase where we're dealing with
     # closing connections during exception handling we want to shield
     # the operation from being cancelled.
@@ -263,7 +263,7 @@ class Semaphore:
         self._semaphore.release()
 
 
-class ShieldCancellation:  # pragma: nocover
+class ShieldCancellation:
     # Thread-synchronous codebases don't support cancellation semantics.
     # We have this class because we need to mirror the async and sync
     # cases within our package, but it's just a no-op.

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -202,9 +202,6 @@ class AsyncShieldCancellation:
             self._anyio_shield = anyio.CancelScope(shield=True)
 
     def __enter__(self) -> "AsyncShieldCancellation":
-        if not self._backend:
-            self.setup()
-
         if self._backend == "trio":
             self._trio_shield.__enter__()
         else:

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -171,7 +171,7 @@ class AsyncSemaphore:
             self._anyio_semaphore.release()
 
 
-class AsyncShieldCancellation:
+class AsyncShieldCancellation:  # pragma: nocover
     # For certain portions of our codebase where we're dealing with
     # closing connections during exception handling we want to shield
     # the operation from being cancelled.
@@ -263,7 +263,7 @@ class Semaphore:
         self._semaphore.release()
 
 
-class ShieldCancellation:
+class ShieldCancellation:  # pragma: nocover
     # Thread-synchronous codebases don't support cancellation semantics.
     # We have this class because we need to mirror the async and sync
     # cases within our package, but it's just a no-op.

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -171,6 +171,58 @@ class AsyncSemaphore:
             self._anyio_semaphore.release()
 
 
+class AsyncShieldCancellation:
+    # For certain portions of our codebase where we're dealing with
+    # closing connections during exception handling we want to shield
+    # the operation from being cancelled.
+    #
+    # with AsyncShieldCancellation():
+    #     ... # clean-up operations, shielded from cancellation.
+
+    def __init__(self) -> None:
+        """
+        Detect if we're running under 'asyncio' or 'trio' and create
+        a semaphore with the correct implementation.
+        """
+        self._backend = sniffio.current_async_library()
+
+        if self._backend == "trio":
+            if trio is None:  # pragma: nocover
+                raise RuntimeError(
+                    "Running under trio requires the 'trio' package to be installed."
+                )
+
+            self._trio_shield = trio.CancelScope(shield=True)
+        else:
+            if anyio is None:  # pragma: nocover
+                raise RuntimeError(
+                    "Running under asyncio requires the 'anyio' package to be installed."
+                )
+
+            self._anyio_shield = anyio.CancelScope(shield=True)
+
+    def __enter__(self) -> "AsyncShieldCancellation":
+        if not self._backend:
+            self.setup()
+
+        if self._backend == "trio":
+            self._trio_shield.__enter__()
+        else:
+            self._anyio_shield.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        if self._backend == "trio":
+            self._trio_shield.__exit__(exc_type, exc_value, traceback)
+        else:
+            self._anyio_shield.__exit__(exc_type, exc_value, traceback)
+
+
 # Our thread-based synchronization primitives...
 
 
@@ -212,3 +264,19 @@ class Semaphore:
 
     def release(self) -> None:
         self._semaphore.release()
+
+
+class ShieldCancellation:
+    # Thread-synchronous codebases don't support cancellation semantics.
+    # We have this class because we need to mirror the async and sync
+    # cases within our package, but it's just a no-op. 
+    def __enter__(self) -> "ShieldCancellation":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        pass

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -266,7 +266,7 @@ class Semaphore:
 class ShieldCancellation:
     # Thread-synchronous codebases don't support cancellation semantics.
     # We have this class because we need to mirror the async and sync
-    # cases within our package, but it's just a no-op. 
+    # cases within our package, but it's just a no-op.
     def __enter__(self) -> "ShieldCancellation":
         return self
 

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -1,0 +1,30 @@
+import typing
+
+import anyio
+import pytest
+
+import httpcore
+
+
+class SlowWriteStream(httpcore.AsyncNetworkStream):
+    async def write(
+        self, buffer: bytes, timeout: typing.Optional[float] = None
+    ) -> None:
+        await anyio.sleep(2)
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.anyio
+async def test_h11_response_closed():
+    """
+    An async timeout on an HTTP/1.1 connection should leave the connection
+    in a neatly closed state.
+    """
+    origin = httpcore.Origin(b"http", b"example.com", 80)
+    stream = SlowWriteStream()
+    async with httpcore.AsyncHTTP11Connection(origin, stream) as conn:
+        with anyio.move_on_after(0.001):
+            await conn.request("GET", "http://example.com")
+        assert conn.is_closed()

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -7,23 +7,73 @@ import httpcore
 
 
 class SlowWriteStream(httpcore.AsyncNetworkStream):
+    """
+    A stream that we can use to test cancellations during
+    the request writing.
+    """
+
     async def write(
         self, buffer: bytes, timeout: typing.Optional[float] = None
     ) -> None:
-        await anyio.sleep(2)
+        await anyio.sleep(999)
 
     async def aclose(self) -> None:
         pass
 
 
-@pytest.mark.anyio
-async def test_h11_response_closed():
+class SlowReadStream(httpcore.AsyncNetworkStream):
     """
-    An async timeout on an HTTP/1.1 connection should leave the connection
-    in a neatly closed state.
+    A stream that we can use to test cancellations during
+    the response reading.
+    """
+
+    def __init__(self, buffer: typing.List[bytes]):
+        self._buffer = buffer
+
+    async def write(self, buffer, timeout=None):
+        pass
+
+    async def read(
+        self, max_bytes: int, timeout: typing.Optional[float] = None
+    ) -> bytes:
+        if not self._buffer:
+            await anyio.sleep(999)
+        return self._buffer.pop(0)
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.anyio
+async def test_h11_timeout_during_request():
+    """
+    An async timeout on an HTTP/1.1 during the request writing
+    should leave the connection in a neatly closed state.
     """
     origin = httpcore.Origin(b"http", b"example.com", 80)
     stream = SlowWriteStream()
+    async with httpcore.AsyncHTTP11Connection(origin, stream) as conn:
+        with anyio.move_on_after(0.001):
+            await conn.request("GET", "http://example.com")
+        assert conn.is_closed()
+
+
+@pytest.mark.anyio
+async def test_h11_timeout_during_response():
+    """
+    An async timeout on an HTTP/1.1 during the response reading
+    should leave the connection in a neatly closed state.
+    """
+    origin = httpcore.Origin(b"http", b"example.com", 80)
+    stream = SlowReadStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 1000\r\n",
+            b"\r\n",
+            b"Hello, world!...",
+        ]
+    )
     async with httpcore.AsyncHTTP11Connection(origin, stream) as conn:
         with anyio.move_on_after(0.001):
             await conn.request("GET", "http://example.com")

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -44,6 +44,59 @@ class SlowReadStream(httpcore.AsyncNetworkStream):
         pass
 
 
+class SlowWriteBackend(httpcore.AsyncNetworkBackend):
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[httpcore.SOCKET_OPTION]] = None,
+    ) -> httpcore.AsyncNetworkStream:
+        return SlowWriteStream()
+
+
+class SlowReadBackend(httpcore.AsyncNetworkBackend):
+    def __init__(self, buffer: typing.List[bytes]):
+        self._buffer = buffer
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[httpcore.SOCKET_OPTION]] = None,
+    ) -> httpcore.AsyncNetworkStream:
+        return SlowReadStream(self._buffer)
+
+
+@pytest.mark.anyio
+async def test_connection_pool_timeout_during_request():
+    network_backend = SlowWriteBackend()
+    async with httpcore.AsyncConnectionPool(network_backend=network_backend) as pool:
+        with anyio.move_on_after(0.001):
+            await pool.request("GET", "http://example.com")
+        assert not pool.connections
+
+
+@pytest.mark.anyio
+async def test_connection_pool_timeout_during_response():
+    network_backend = SlowReadBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 1000\r\n",
+            b"\r\n",
+            b"Hello, world!...",
+        ]
+    )
+    async with httpcore.AsyncConnectionPool(network_backend=network_backend) as pool:
+        with anyio.move_on_after(0.001):
+            await pool.request("GET", "http://example.com")
+        assert not pool.connections
+
+
 @pytest.mark.anyio
 async def test_h11_timeout_during_request():
     """

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -20,7 +20,7 @@ class SlowWriteStream(httpcore.AsyncNetworkStream):
         await anyio.sleep(999)
 
     async def aclose(self) -> None:
-        pass
+        await anyio.sleep(0)
 
 
 class HandshakeThenSlowWriteStream(httpcore.AsyncNetworkStream):
@@ -42,7 +42,7 @@ class HandshakeThenSlowWriteStream(httpcore.AsyncNetworkStream):
             await anyio.sleep(999)
 
     async def aclose(self) -> None:
-        pass
+        await anyio.sleep(0)
 
 
 class SlowReadStream(httpcore.AsyncNetworkStream):
@@ -65,7 +65,7 @@ class SlowReadStream(httpcore.AsyncNetworkStream):
         return self._buffer.pop(0)
 
     async def aclose(self):
-        pass
+        await anyio.sleep(0)
 
 
 class SlowWriteBackend(httpcore.AsyncNetworkBackend):


### PR DESCRIPTION
- [x] Add an `AsyncShieldCancellation` context manager.
- [x] Unit test HTTP/1.1 timeouts on connections.
- [x] Unit test HTTP/2 timeouts on connections.
- [x] Test timeouts on connection pools
- [x] Add to CHANGELOG.

Will close #719.