### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Build package & docs"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)
+- Drop Python 3.7 support. (#727)
 
 ## 0.17.3 (July 5th, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The networking backend interface has [been added to the public API](https://www.encode.io/httpcore/network-backends). Some classes which were previously private implementation detail are now part of the top-level public API. (#699)
 - Graceful handling of HTTP/2 GoAway frames, with requests being transparently retried on a new connection. (#730)
 - Add exceptions when a synchronous `trace callback` is passed to an asynchronous request or an asynchronous `trace callback` is passed to a synchronous request. (#717)
+- Drop Python 3.7 support. (#727)
 
 ## 0.17.2 (May 23th, 2023)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some things HTTP Core does do:
 
 ## Requirements
 
-Python 3.7+
+Python 3.8+
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Some things HTTP Core does do:
 
 ## Requirements
 
-Python 3.7+
+Python 3.8+
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "httpcore"
 dynamic = ["readme", "version"]
 description = "A minimal low-level HTTP client."
 license = "BSD-3-Clause"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },
 ]
@@ -21,7 +21,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff check --show-source $SOURCE_FILES
-${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py37 $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py38 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff check --show-source $SOURCE_FILES
-${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py38 $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black --target-version=py37 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
+${PREFIX}black --target-version=py38 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black --target-version=py38 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)


### PR DESCRIPTION
Python 3.7 EOL is approaching, this PR removes its support.

<img width="751" alt="image" src="https://github.com/encode/httpcore/assets/664889/210a724c-9447-48a5-b0ee-0c7008309e43">

Related to [#2744](https://github.com/encode/httpx/pull/2744).