### PR TITLE
Ensure HTTP/2 connections are gracefully closed on async cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix the unstarted http/2 connection cancellations. (#757)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)
 
 ## 0.17.3 (5th July 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix the unstarted http/2 connection cancellations. (#757)
+- Ensure that the cancellation of HTTP/2 connections does not break the state. (#757)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)
 
 ## 0.17.3 (5th July 2023)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -128,13 +128,15 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         await self._max_streams_semaphore.acquire()
                 except BaseException:
                     with AsyncShieldCancellation():
-                        await self._state_housekeeping()
+                        async with self._state_lock:
+                            await self._state_housekeeping()
                     raise
         try:
             await self._max_streams_semaphore.acquire()
         except BaseException:  # pragma: no cover
             with AsyncShieldCancellation():
-                await self._state_housekeeping()
+                async with self._state_lock:
+                    await self._state_housekeeping()
             raise
 
         try:

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -123,10 +123,19 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 )
                 self._max_streams_semaphore = AsyncSemaphore(local_settings_max_streams)
 
-                for _ in range(local_settings_max_streams - self._max_streams):
-                    await self._max_streams_semaphore.acquire()
-
-        await self._max_streams_semaphore.acquire()
+                try:
+                    for _ in range(local_settings_max_streams - self._max_streams):
+                        await self._max_streams_semaphore.acquire()
+                except BaseException:
+                    with AsyncShieldCancellation():
+                        await self._state_housekeeping()
+                    raise
+        try:
+            await self._max_streams_semaphore.acquire()
+        except BaseException:  # pragma: no cover
+            with AsyncShieldCancellation():
+                await self._state_housekeeping()
+            raise
 
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
@@ -405,16 +414,19 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         await self._max_streams_semaphore.release()
         del self._events[stream_id]
         async with self._state_lock:
-            if self._connection_terminated and not self._events:
-                await self.aclose()
+            await self._state_housekeeping()
 
-            elif self._state == HTTPConnectionState.ACTIVE and not self._events:
-                self._state = HTTPConnectionState.IDLE
-                if self._keepalive_expiry is not None:
-                    now = time.monotonic()
-                    self._expire_at = now + self._keepalive_expiry
-                if self._used_all_stream_ids:  # pragma: nocover
-                    await self.aclose()
+    async def _state_housekeeping(self) -> None:
+        if self._connection_terminated and not self._events:
+            await self.aclose()
+
+        elif self._state == HTTPConnectionState.ACTIVE and not self._events:
+            self._state = HTTPConnectionState.IDLE
+            if self._keepalive_expiry is not None:
+                now = time.monotonic()
+                self._expire_at = now + self._keepalive_expiry
+            if self._used_all_stream_ids:  # pragma: nocover
+                await self.aclose()
 
     async def aclose(self) -> None:
         # Note that this method unilaterally closes the connection, and does

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -128,13 +128,15 @@ class HTTP2Connection(ConnectionInterface):
                         self._max_streams_semaphore.acquire()
                 except BaseException:
                     with ShieldCancellation():
-                        self._state_housekeeping()
+                        with self._state_lock:
+                            self._state_housekeeping()
                     raise
         try:
             self._max_streams_semaphore.acquire()
         except BaseException:  # pragma: no cover
             with ShieldCancellation():
-                self._state_housekeeping()
+                with self._state_lock:
+                    self._state_housekeeping()
             raise
 
         try:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -123,10 +123,19 @@ class HTTP2Connection(ConnectionInterface):
                 )
                 self._max_streams_semaphore = Semaphore(local_settings_max_streams)
 
-                for _ in range(local_settings_max_streams - self._max_streams):
-                    self._max_streams_semaphore.acquire()
-
-        self._max_streams_semaphore.acquire()
+                try:
+                    for _ in range(local_settings_max_streams - self._max_streams):
+                        self._max_streams_semaphore.acquire()
+                except BaseException:
+                    with ShieldCancellation():
+                        self._state_housekeeping()
+                    raise
+        try:
+            self._max_streams_semaphore.acquire()
+        except BaseException:  # pragma: no cover
+            with ShieldCancellation():
+                self._state_housekeeping()
+            raise
 
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
@@ -405,16 +414,19 @@ class HTTP2Connection(ConnectionInterface):
         self._max_streams_semaphore.release()
         del self._events[stream_id]
         with self._state_lock:
-            if self._connection_terminated and not self._events:
-                self.close()
+            self._state_housekeeping()
 
-            elif self._state == HTTPConnectionState.ACTIVE and not self._events:
-                self._state = HTTPConnectionState.IDLE
-                if self._keepalive_expiry is not None:
-                    now = time.monotonic()
-                    self._expire_at = now + self._keepalive_expiry
-                if self._used_all_stream_ids:  # pragma: nocover
-                    self.close()
+    def _state_housekeeping(self) -> None:
+        if self._connection_terminated and not self._events:
+            self.close()
+
+        elif self._state == HTTPConnectionState.ACTIVE and not self._events:
+            self._state = HTTPConnectionState.IDLE
+            if self._keepalive_expiry is not None:
+                now = time.monotonic()
+                self._expire_at = now + self._keepalive_expiry
+            if self._used_all_stream_ids:  # pragma: nocover
+                self.close()
 
     def close(self) -> None:
         # Note that this method unilaterally closes the connection, and does

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -244,11 +244,12 @@ async def test_h2_timeout_during_response():
 
 @pytest.mark.anyio
 async def test_h2_unstarted_requests(monkeypatch):
-
-    async def slow_acquire(self) -> None:
+    async def slow_acquire(self: httpcore._synchronization.AsyncSemaphore) -> None:
         await anyio.sleep(999)
 
-    monkeypatch.setattr(httpcore._synchronization.AsyncSemaphore, "acquire", slow_acquire)
+    monkeypatch.setattr(
+        httpcore._synchronization.AsyncSemaphore, "acquire", slow_acquire
+    )
 
     origin = httpcore.Origin(b"http", b"example.com", 80)
     stream = HandshakeThenSlowWriteStream()

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -243,7 +243,7 @@ async def test_h2_timeout_during_response():
 
 
 @pytest.mark.anyio
-async def test_h2_unstarted_requests(monkeypatch):
+async def test_h2_unstarted_request_cancellation(monkeypatch):
     async def slow_acquire(self: httpcore._synchronization.AsyncSemaphore) -> None:
         await anyio.sleep(999)
 


### PR DESCRIPTION
Closes #756

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

# TODO

- [x] Add failing tests
- [x] Gracefully handle cancellation for unstarted http/2 requests 
- [x] Update changelog 
