### PR TITLE
Omit `NotImplementedError` in coverage report

### DIFF
--- a/httpcore/_async/interfaces.py
+++ b/httpcore/_async/interfaces.py
@@ -79,18 +79,18 @@ class AsyncRequestInterface:
             await response.aclose()
 
     async def handle_async_request(self, request: Request) -> Response:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
 
 class AsyncConnectionInterface(AsyncRequestInterface):
     async def aclose(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def info(self) -> str:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def can_handle_request(self, origin: Origin) -> bool:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_available(self) -> bool:
         """
@@ -108,7 +108,7 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         required exceptions if multiple requests are attempted over a connection
         that ends up being established as HTTP/1.1.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def has_expired(self) -> bool:
         """
@@ -117,13 +117,13 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         This either means that the connection is idle and it has passed the
         expiry time on its keep-alive, or that server has sent an EOF.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_idle(self) -> bool:
         """
         Return `True` if the connection is currently idle.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_closed(self) -> bool:
         """
@@ -132,4 +132,4 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         Used when a response is closed to determine if the connection may be
         returned to the connection pool or not.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -11,13 +11,13 @@ SOCKET_OPTION = typing.Union[
 
 class NetworkStream:
     def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def close(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def start_tls(
         self,
@@ -25,10 +25,10 @@ class NetworkStream:
         server_hostname: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
     ) -> "NetworkStream":
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def get_extra_info(self, info: str) -> typing.Any:
-        return None  # pragma: nocover
+        return None
 
 
 class NetworkBackend:
@@ -40,7 +40,7 @@ class NetworkBackend:
         local_address: typing.Optional[str] = None,
         socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
     ) -> NetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def connect_unix_socket(
         self,
@@ -48,25 +48,25 @@ class NetworkBackend:
         timeout: typing.Optional[float] = None,
         socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
     ) -> NetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def sleep(self, seconds: float) -> None:
-        time.sleep(seconds)  # pragma: nocover
+        time.sleep(seconds)
 
 
 class AsyncNetworkStream:
     async def read(
         self, max_bytes: int, timeout: typing.Optional[float] = None
     ) -> bytes:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     async def write(
         self, buffer: bytes, timeout: typing.Optional[float] = None
     ) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     async def aclose(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     async def start_tls(
         self,
@@ -74,10 +74,10 @@ class AsyncNetworkStream:
         server_hostname: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
     ) -> "AsyncNetworkStream":
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def get_extra_info(self, info: str) -> typing.Any:
-        return None  # pragma: nocover
+        return None
 
 
 class AsyncNetworkBackend:
@@ -89,7 +89,7 @@ class AsyncNetworkBackend:
         local_address: typing.Optional[str] = None,
         socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
     ) -> AsyncNetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     async def connect_unix_socket(
         self,
@@ -97,7 +97,7 @@ class AsyncNetworkBackend:
         timeout: typing.Optional[float] = None,
         socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
     ) -> AsyncNetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     async def sleep(self, seconds: float) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()

--- a/httpcore/_backends/base.py
+++ b/httpcore/_backends/base.py
@@ -28,7 +28,7 @@ class NetworkStream:
         raise NotImplementedError()
 
     def get_extra_info(self, info: str) -> typing.Any:
-        return None
+        return None  # pragma: no cover
 
 
 class NetworkBackend:
@@ -51,7 +51,7 @@ class NetworkBackend:
         raise NotImplementedError()
 
     def sleep(self, seconds: float) -> None:
-        time.sleep(seconds)
+        time.sleep(seconds)  # pragma: no cover
 
 
 class AsyncNetworkStream:

--- a/httpcore/_sync/interfaces.py
+++ b/httpcore/_sync/interfaces.py
@@ -79,18 +79,18 @@ class RequestInterface:
             response.close()
 
     def handle_request(self, request: Request) -> Response:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
 
 class ConnectionInterface(RequestInterface):
     def close(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def info(self) -> str:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def can_handle_request(self, origin: Origin) -> bool:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_available(self) -> bool:
         """
@@ -108,7 +108,7 @@ class ConnectionInterface(RequestInterface):
         required exceptions if multiple requests are attempted over a connection
         that ends up being established as HTTP/1.1.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def has_expired(self) -> bool:
         """
@@ -117,13 +117,13 @@ class ConnectionInterface(RequestInterface):
         This either means that the connection is idle and it has passed the
         expiry time on its keep-alive, or that server has sent an EOF.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_idle(self) -> bool:
         """
         Return `True` if the connection is currently idle.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()
 
     def is_closed(self) -> bool:
         """
@@ -132,4 +132,4 @@ class ConnectionInterface(RequestInterface):
         Used when a response is closed to determine if the connection may be
         returned to the connection pool or not.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ include = ["httpcore/*", "tests/*"]
 
 [tool.coverage.report]
 exclude_also = [
-    "raise NotImplementedError"
+    "raise NotImplementedError()"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,11 @@ omit = [
 ]
 include = ["httpcore/*", "tests/*"]
 
+[tool.coverage.report]
+exclude_also = [
+    "raise NotImplementedError"
+]
+
 [tool.ruff]
 exclude = [
     "httpcore/_sync",


### PR DESCRIPTION
# Summary

Let's avoid using pragma no cover for every `NotImplementedError`. We probably don't want to test `NotImplementedError` cases, so we can just leave them out of the coverage configuration.

