### PR TITLE
Version 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.18.0 (September 8th, 2023)
 
-- Add support for HTTPS proxies. (#745, # 786)
-- Handle `sni_hostname` extension with SOCKS proxy. (#774)
-- Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
-- Handle HTTP/1.1 half-closed connections gracefully. (#641)
+- Add support for HTTPS proxies. (#745, #786)
 - Drop Python 3.7 support. (#727)
+- Handle `sni_hostname` extension with SOCKS proxy. (#774)
+- Handle HTTP/1.1 half-closed connections gracefully. (#641)
+- Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 
 ## 0.17.3 (July 5th, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 0.17.4 (August 1st, 2023)
 
 - Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.17.4 (August 1st, 2023)
+## 0.18.0
 
 - Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.18.0
+## 0.18.0 (September 8th, 2023)
 
 - Add support for HTTPS proxies. (#745, # 786)
 - Handle `sni_hostname` extension with SOCKS proxy. (#774)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -130,7 +130,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.17.4"
+__version__ = "0.18.0"
 
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -130,7 +130,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"
 
 
 __locals = locals()


### PR DESCRIPTION
# Changelog

## 0.18.0

- Add support for HTTPS proxies. (#745, # 786)
- Handle `sni_hostname` extension with SOCKS proxy. (#774)
- Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
- Handle HTTP/1.1 half-closed connections gracefully. (#641)
- Drop Python 3.7 support. (#727)

## TODO

- [ ] Update release date