### PR TITLE
Support `sni_hostname` extension with SOCKS proxy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Build package & docs"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)
+- Drop Python 3.7 support. (#727)
 
 ## 0.17.3 (July 5th, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The networking backend interface has [been added to the public API](https://www.encode.io/httpcore/network-backends). Some classes which were previously private implementation detail are now part of the top-level public API. (#699)
 - Graceful handling of HTTP/2 GoAway frames, with requests being transparently retried on a new connection. (#730)
 - Add exceptions when a synchronous `trace callback` is passed to an asynchronous request or an asynchronous `trace callback` is passed to a synchronous request. (#717)
+- Drop Python 3.7 support. (#727)
 
 ## 0.17.2 (May 23th, 2023)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some things HTTP Core does do:
 
 ## Requirements
 
-Python 3.7+
+Python 3.8+
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Some things HTTP Core does do:
 
 ## Requirements
 
-Python 3.7+
+Python 3.8+
 
 ## Installation
 

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -216,6 +216,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
 
     async def handle_async_request(self, request: Request) -> Response:
         timeouts = request.extensions.get("timeout", {})
+        sni_hostname = request.extensions.get("sni_hostname", None)
         timeout = timeouts.get("connect", None)
 
         async with self._connect_lock:
@@ -258,7 +259,8 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
 
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "server_hostname": sni_hostname
+                            or self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
                         async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -216,6 +216,7 @@ class Socks5Connection(ConnectionInterface):
 
     def handle_request(self, request: Request) -> Response:
         timeouts = request.extensions.get("timeout", {})
+        sni_hostname = request.extensions.get("sni_hostname", None)
         timeout = timeouts.get("connect", None)
 
         with self._connect_lock:
@@ -258,7 +259,8 @@ class Socks5Connection(ConnectionInterface):
 
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": self._remote_origin.host.decode("ascii"),
+                            "server_hostname": sni_hostname
+                            or self._remote_origin.host.decode("ascii"),
                             "timeout": timeout,
                         }
                         with Trace("start_tls", logger, request, kwargs) as trace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "httpcore"
 dynamic = ["readme", "version"]
 description = "A minimal low-level HTTP client."
 license = "BSD-3-Clause"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },
 ]
@@ -21,7 +21,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff check --show-source $SOURCE_FILES
-${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py37 $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py38 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff check --show-source $SOURCE_FILES
-${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff --target-version=py38 $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' --check --diff $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 scripts/unasync --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black --target-version=py37 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
+${PREFIX}black --target-version=py38 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,7 +9,7 @@ export SOURCE_FILES="httpcore tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black --target-version=py38 --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
+${PREFIX}black --exclude '/(_sync|sync_tests)/' $SOURCE_FILES
 
 # Run unasync last because its `--check` mode is not aware of code formatters.
 # (This means sync code isn't prettified, and that's mostly okay.)

--- a/tests/_async/test_socks_proxy.py
+++ b/tests/_async/test_socks_proxy.py
@@ -191,3 +191,61 @@ async def test_socks5_request_incorrect_auth():
         assert str(exc_info.value) == "Invalid username/password"
 
         assert not proxy.connections
+
+
+@pytest.mark.anyio
+async def test_socks5_sni_hostname():
+    """
+    Send an HTTP request via a SOCKS proxy utilizing `sni_hostname` extension.
+    """
+    network_backend = httpcore.AsyncMockBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with httpcore.AsyncSOCKSProxy(
+        proxy_url="socks5://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        # Sending an intial request, which once complete will return to the pool, IDLE.
+        async with proxy.stream("GET", "https://93.184.216.34/", headers=[(b'Host', 'example.com')], extensions={'sni_hostname': 'example.com'}) as response:
+            info = [repr(c) for c in proxy.connections]
+            assert info == [
+                "<AsyncSocks5Connection ['https://93.184.216.34:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
+            ]
+            await response.aread()
+
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+        info = [repr(c) for c in proxy.connections]
+        assert info == [
+            "<AsyncSocks5Connection ['https://93.184.216.34:443', HTTP/1.1, IDLE, Request Count: 1]>"
+        ]
+        assert proxy.connections[0].is_idle()
+        assert proxy.connections[0].is_available()
+        assert not proxy.connections[0].is_closed()
+
+        # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
+        assert not proxy.connections[0].can_handle_request(
+            httpcore.Origin(b"http", b"93.184.216.34", 80)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            httpcore.Origin(b"http", b"other.com", 80)
+        )
+        assert proxy.connections[0].can_handle_request(
+            httpcore.Origin(b"https", b"93.184.216.34", 443)
+        )
+        assert not proxy.connections[0].can_handle_request(
+            httpcore.Origin(b"https", b"other.com", 443)
+        )


### PR DESCRIPTION
* Support `sni_hostname` extension with SOCKS proxy.

* This is a complementary update of #696.
---------

Co-authored-by: Tom Christie <tom@tomchristie.com>

# Summary

A new extension, `sni_hostname` has enalbed users to specify the hostname which would be used during TLS handshake. However, the update was inconsistent, resulting in the incomplete extension. Currently, the `sni_hostname` extension are not handled if SOCKS proxy is in use. This PR would bridge this gap.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
