### PR TITLE
Handle HTTP/2 half-closed connections gracefully.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Handle HTTP/2 half-closed connections gracefully. (#777)
 - Change the type of `Extensions` from `Mapping[Str, Any]` to `MutableMapping[Str, Any]`. (#762)
 - Handle HTTP/1.1 half-closed connections gracefully. (#641)
 - Drop Python 3.7 support. (#727)

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -138,10 +138,16 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         try:
             kwargs = {"request": request, "stream_id": stream_id}
-            async with Trace("send_request_headers", logger, request, kwargs):
-                await self._send_request_headers(request=request, stream_id=stream_id)
-            async with Trace("send_request_body", logger, request, kwargs):
-                await self._send_request_body(request=request, stream_id=stream_id)
+            try:
+                async with Trace("send_request_headers", logger, request, kwargs):
+                    await self._send_request_headers(
+                        request=request, stream_id=stream_id
+                    )
+                async with Trace("send_request_body", logger, request, kwargs):
+                    await self._send_request_body(request=request, stream_id=stream_id)
+            except h2.exceptions.StreamClosedError:
+                pass
+
             async with Trace(
                 "receive_response_headers", logger, request, kwargs
             ) as trace:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -138,10 +138,16 @@ class HTTP2Connection(ConnectionInterface):
 
         try:
             kwargs = {"request": request, "stream_id": stream_id}
-            with Trace("send_request_headers", logger, request, kwargs):
-                self._send_request_headers(request=request, stream_id=stream_id)
-            with Trace("send_request_body", logger, request, kwargs):
-                self._send_request_body(request=request, stream_id=stream_id)
+            try:
+                with Trace("send_request_headers", logger, request, kwargs):
+                    self._send_request_headers(
+                        request=request, stream_id=stream_id
+                    )
+                with Trace("send_request_body", logger, request, kwargs):
+                    self._send_request_body(request=request, stream_id=stream_id)
+            except h2.exceptions.StreamClosedError:
+                pass
+
             with Trace(
                 "receive_response_headers", logger, request, kwargs
             ) as trace:

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -269,10 +269,10 @@ async def test_write_error_without_response_sent_http2():
         content = b"x" * 10_000_000
         with pytest.raises(RemoteProtocolError) as exc_info:
             await conn.request("POST", "https://example.com/", content=content)
-        assert (
-            str(exc_info.value)
-            == "<StreamReset stream_id:1, error_code:ErrorCodes.NO_ERROR, remote_reset:True>"
-        )
+        assert str(exc_info.value) in [
+            "<StreamReset stream_id:1, error_code:ErrorCodes.NO_ERROR, remote_reset:True>",
+            "<StreamReset stream_id:1, error_code:0, remote_reset:True>",
+        ]
 
 
 @pytest.mark.anyio

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -13,6 +13,7 @@ from httpcore import (
     AsyncNetworkStream,
     ConnectError,
     ConnectionNotAvailable,
+    LocalProtocolError,
     Origin,
     RemoteProtocolError,
     WriteError,
@@ -141,6 +142,56 @@ async def test_write_error_with_response_sent():
         assert response.content == b"Request body exceeded 1,000,000 bytes"
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.anyio
+async def test_write_error_with_response_sent_http2():
+    """
+    If a server half-closes the connection while the client is sending
+    the request, it may still send a response. In this case the client
+    should successfully read and return the response.
+
+    See also the `test_write_error_without_response_sent_http2` test above.
+    """
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = AsyncMockBackend(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.WindowUpdateFrame(
+                stream_id=0, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.WindowUpdateFrame(
+                stream_id=1, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"413"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize()
+            + hyperframe.frame.DataFrame(
+                stream_id=1,
+                data=b"Request body exceeded 1,000,000 bytes",
+                flags=["END_STREAM"],
+            ).serialize()
+            + hyperframe.frame.RstStreamFrame(stream_id=1, error_code=0).serialize(),
+        ],
+        http2=True,
+    )
+
+    async with AsyncHTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        response = await conn.request("POST", "https://example.com/", content=content)
+        assert response.status == 413
+        assert response.content == b"Request body exceeded 1,000,000 bytes"
+
+
 @pytest.mark.anyio
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 async def test_write_error_without_response_sent():
@@ -185,6 +236,40 @@ async def test_write_error_without_response_sent():
         with pytest.raises(RemoteProtocolError) as exc_info:
             await conn.request("POST", "https://example.com/", content=content)
         assert str(exc_info.value) == "Server disconnected without sending a response."
+
+
+@pytest.mark.anyio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_write_error_without_response_sent_http2():
+    """
+    If a server fully closes the connection while the client is sending
+    the request, then client should raise an error.
+
+    See also the `test_write_error_with_response_sent_http2` test above.
+    """
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = AsyncMockBackend(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.WindowUpdateFrame(
+                stream_id=0, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.WindowUpdateFrame(
+                stream_id=1, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.RstStreamFrame(stream_id=1, error_code=0).serialize(),
+        ],
+        http2=True,
+    )
+
+    async with AsyncHTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        with pytest.raises(LocalProtocolError) as exc_info:
+            await conn.request("POST", "https://example.com/", content=content)
+        assert str(exc_info.value) == "1"
 
 
 @pytest.mark.anyio

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -269,10 +269,10 @@ def test_write_error_without_response_sent_http2():
         content = b"x" * 10_000_000
         with pytest.raises(RemoteProtocolError) as exc_info:
             conn.request("POST", "https://example.com/", content=content)
-        assert (
-            str(exc_info.value)
-            == "<StreamReset stream_id:1, error_code:ErrorCodes.NO_ERROR, remote_reset:True>"
-        )
+        assert str(exc_info.value) in [
+            "<StreamReset stream_id:1, error_code:ErrorCodes.NO_ERROR, remote_reset:True>",
+            "<StreamReset stream_id:1, error_code:0, remote_reset:True>",
+        ]
 
 
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -13,7 +13,6 @@ from httpcore import (
     NetworkStream,
     ConnectError,
     ConnectionNotAvailable,
-    LocalProtocolError,
     Origin,
     RemoteProtocolError,
     WriteError,
@@ -235,6 +234,7 @@ def test_write_error_without_response_sent():
         content = b"x" * 10_000_000
         with pytest.raises(RemoteProtocolError) as exc_info:
             conn.request("POST", "https://example.com/", content=content)
+
         assert str(exc_info.value) == "Server disconnected without sending a response."
 
 
@@ -267,9 +267,12 @@ def test_write_error_without_response_sent_http2():
         origin=origin, network_backend=network_backend, keepalive_expiry=5.0
     ) as conn:
         content = b"x" * 10_000_000
-        with pytest.raises(LocalProtocolError) as exc_info:
+        with pytest.raises(RemoteProtocolError) as exc_info:
             conn.request("POST", "https://example.com/", content=content)
-        assert str(exc_info.value) == "1"
+        assert (
+            str(exc_info.value)
+            == "<StreamReset stream_id:1, error_code:ErrorCodes.NO_ERROR, remote_reset:True>"
+        )
 
 
 

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -13,6 +13,7 @@ from httpcore import (
     NetworkStream,
     ConnectError,
     ConnectionNotAvailable,
+    LocalProtocolError,
     Origin,
     RemoteProtocolError,
     WriteError,
@@ -141,6 +142,56 @@ def test_write_error_with_response_sent():
         assert response.content == b"Request body exceeded 1,000,000 bytes"
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+
+def test_write_error_with_response_sent_http2():
+    """
+    If a server half-closes the connection while the client is sending
+    the request, it may still send a response. In this case the client
+    should successfully read and return the response.
+
+    See also the `test_write_error_without_response_sent_http2` test above.
+    """
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = MockBackend(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.WindowUpdateFrame(
+                stream_id=0, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.WindowUpdateFrame(
+                stream_id=1, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"413"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize()
+            + hyperframe.frame.DataFrame(
+                stream_id=1,
+                data=b"Request body exceeded 1,000,000 bytes",
+                flags=["END_STREAM"],
+            ).serialize()
+            + hyperframe.frame.RstStreamFrame(stream_id=1, error_code=0).serialize(),
+        ],
+        http2=True,
+    )
+
+    with HTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        response = conn.request("POST", "https://example.com/", content=content)
+        assert response.status == 413
+        assert response.content == b"Request body exceeded 1,000,000 bytes"
+
+
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_write_error_without_response_sent():
@@ -185,6 +236,40 @@ def test_write_error_without_response_sent():
         with pytest.raises(RemoteProtocolError) as exc_info:
             conn.request("POST", "https://example.com/", content=content)
         assert str(exc_info.value) == "Server disconnected without sending a response."
+
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_write_error_without_response_sent_http2():
+    """
+    If a server fully closes the connection while the client is sending
+    the request, then client should raise an error.
+
+    See also the `test_write_error_with_response_sent_http2` test above.
+    """
+
+    origin = Origin(b"https", b"example.com", 443)
+    network_backend = MockBackend(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.WindowUpdateFrame(
+                stream_id=0, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.WindowUpdateFrame(
+                stream_id=1, window_increment=2147418112
+            ).serialize()
+            + hyperframe.frame.RstStreamFrame(stream_id=1, error_code=0).serialize(),
+        ],
+        http2=True,
+    )
+
+    with HTTPConnection(
+        origin=origin, network_backend=network_backend, keepalive_expiry=5.0
+    ) as conn:
+        content = b"x" * 10_000_000
+        with pytest.raises(LocalProtocolError) as exc_info:
+            conn.request("POST", "https://example.com/", content=content)
+        assert str(exc_info.value) == "1"
 
 
 


### PR DESCRIPTION
Closes #775 

TODO:

- [x] Add failing tests
- [x] Suppress exceptions while sending the request
- [x] Add changelog 