### PR TITLE
Remove useless patterns from unasync.py

### DIFF
--- a/unasync.py
+++ b/unasync.py
@@ -6,9 +6,7 @@ import sys
 SUBS = [
     ('from .._backends.auto import AutoBackend', 'from .._backends.sync import SyncBackend'),
     ('import trio as concurrency', 'from tests import concurrency'),
-    ('AsyncByteStream', 'SyncByteStream'),
     ('AsyncIterator', 'Iterator'),
-    ('AutoBackend', 'SyncBackend'),
     ('Async([A-Z][A-Za-z0-9_]*)', r'\2'),
     ('async def', 'def'),
     ('async with', 'with'),
@@ -16,8 +14,6 @@ SUBS = [
     ('await ', ''),
     ('handle_async_request', 'handle_request'),
     ('aclose', 'close'),
-    ('aclose_func', 'close_func'),
-    ('aiterator', 'iterator'),
     ('aiter_stream', 'iter_stream'),
     ('aread', 'read'),
     ('asynccontextmanager', 'contextmanager'),

--- a/unasync.py
+++ b/unasync.py
@@ -33,10 +33,14 @@ COMPILED_SUBS = [
     for regex, repl in SUBS
 ]
 
+USED_SUBS = set()
 
 def unasync_line(line):
-    for regex, repl in COMPILED_SUBS:
+    for index, (regex, repl) in enumerate(COMPILED_SUBS):
+        old_line = line
         line = re.sub(regex, repl, line)
+        if old_line != line:
+            USED_SUBS.add(index)
     return line
 
 
@@ -81,6 +85,18 @@ def main():
     unasync_dir("httpcore/_async", "httpcore/_sync", check_only=check_only)
     unasync_dir("tests/_async", "tests/_sync", check_only=check_only)
 
+    if len(USED_SUBS) != len(SUBS):
+        unused_subs = []
+
+        for i in range(len(SUBS)):
+            if i not in USED_SUBS:
+                unused_subs.append(SUBS[i])
+        
+        from pprint import pprint
+        print("These patterns were not used:")
+        pprint(unused_subs)
+        exit(1)   
+        
 
 if __name__ == '__main__':
     main()

--- a/unasync.py
+++ b/unasync.py
@@ -2,6 +2,7 @@
 import os
 import re
 import sys
+from pprint import pprint
 
 SUBS = [
     ('from .._backends.auto import AutoBackend', 'from .._backends.sync import SyncBackend'),
@@ -82,13 +83,8 @@ def main():
     unasync_dir("tests/_async", "tests/_sync", check_only=check_only)
 
     if len(USED_SUBS) != len(SUBS):
-        unused_subs = []
+        unused_subs = [SUBS[i] for i in range(len(SUBS)) if i not in USED_SUBS]
 
-        for i in range(len(SUBS)):
-            if i not in USED_SUBS:
-                unused_subs.append(SUBS[i])
-        
-        from pprint import pprint
         print("These patterns were not used:")
         pprint(unused_subs)
         exit(1)   


### PR DESCRIPTION
Some patterns became obsolete, but they were not deleted.

I also included a check for unused patterns.