### PR TITLE
Don't check all statuses when asquire connection

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -154,9 +154,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
-        waiting = [s for s in self._requests if s.connection is None]
-        if waiting and waiting[0] is not status:
-            return False
+        for s in self._requests:
+            if s.connection is None:
+                if s is not status:
+                    return False
+                break
 
         # Reuse an existing connection if one is currently available.
         for idx, connection in enumerate(self._pool):

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -154,11 +154,9 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
-        for s in self._requests:
-            if s.connection is None:
-                if s is not status:
-                    return False
-                break
+        waiting = (s for s in self._requests if s.connection is None)
+        if next(waiting, default=status) is not status:
+            return False
 
         # Reuse an existing connection if one is currently available.
         for idx, connection in enumerate(self._pool):

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -155,7 +155,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
         waiting = (s for s in self._requests if s.connection is None)
-        if next(waiting, default=status) is not status:
+        if next(waiting, status) is not status:
             return False
 
         # Reuse an existing connection if one is currently available.

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -155,7 +155,7 @@ class ConnectionPool(RequestInterface):
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
         waiting = (s for s in self._requests if s.connection is None)
-        if next(waiting, default=status) is not status:
+        if next(waiting, status) is not status:
             return False
 
         # Reuse an existing connection if one is currently available.

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -154,11 +154,9 @@ class ConnectionPool(RequestInterface):
 
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
-        for s in self._requests:
-            if s.connection is None:
-                if s is not status:
-                    return False
-                break
+        waiting = (s for s in self._requests if s.connection is None)
+        if next(waiting, default=status) is not status:
+            return False
 
         # Reuse an existing connection if one is currently available.
         for idx, connection in enumerate(self._pool):

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -154,9 +154,11 @@ class ConnectionPool(RequestInterface):
 
         # If there are queued requests in front of us, then don't acquire a
         # connection. We handle requests strictly in order.
-        waiting = [s for s in self._requests if s.connection is None]
-        if waiting and waiting[0] is not status:
-            return False
+        for s in self._requests:
+            if s.connection is None:
+                if s is not status:
+                    return False
+                break
 
         # Reuse an existing connection if one is currently available.
         for idx, connection in enumerate(self._pool):


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This improves performance by avoiding iterate over all members of `ConnectionPool._requests` when huge requests available in the pool.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
