### PR TITLE
Handle asynchronous cancellations for HTTPConnection instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Handle asynchronous cancellations for the HTTPConnection instances. (#802)
 - Fix pool timeout to account for the total time spent retrying. (#823)
 
 ## 1.0.0 (October 6th, 2023)

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -181,7 +181,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
             # If HTTP/2 support is enabled, and the resulting connection could
             # end up as HTTP/2 then we should indicate the connection as being
             # available to service multiple requests.
-            return (
+            return (  # pragma: no cover
                 self._http2
                 and (self._origin.scheme == b"https" or not self._http1)
                 and not self._connect_failed
@@ -207,7 +207,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
+            return (
+                "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
+            )  # pragma: no cover
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -189,8 +189,6 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         return self._connection.is_available()
 
     def has_expired(self) -> bool:
-        if self._connect_failed:
-            return True
         if self._connection is None:
             return self._connect_failed
         return self._connection.has_expired()
@@ -210,9 +208,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
             if self._is_new:
                 return "NEW CONNECTION"
             return (
-                "CONNECTING"
-                if not (self._is_new or self._connect_failed)
-                else "CONNECTINION FAILED"
+                "CONNECTINION FAILED" if self._connect_failed else "CONNECTINION FAILED"
             )
         return self._connection.info()
 

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -207,9 +207,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return (
-                "CONNECTINION FAILED" if self._connect_failed else "CONNECTINION FAILED"
-            )
+            return "CONNECTINION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -207,7 +207,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return "CONNECTINION FAILED" if self._connect_failed else "CONNECTING"
+            return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -189,8 +189,6 @@ class HTTPConnection(ConnectionInterface):
         return self._connection.is_available()
 
     def has_expired(self) -> bool:
-        if self._connect_failed:
-            return True
         if self._connection is None:
             return self._connect_failed
         return self._connection.has_expired()
@@ -210,9 +208,7 @@ class HTTPConnection(ConnectionInterface):
             if self._is_new:
                 return "NEW CONNECTION"
             return (
-                "CONNECTING"
-                if not (self._is_new or self._connect_failed)
-                else "CONNECTINION FAILED"
+                "CONNECTINION FAILED" if self._connect_failed else "CONNECTINION FAILED"
             )
         return self._connection.info()
 

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -207,9 +207,7 @@ class HTTPConnection(ConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return (
-                "CONNECTINION FAILED" if self._connect_failed else "CONNECTINION FAILED"
-            )
+            return "CONNECTINION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -181,7 +181,7 @@ class HTTPConnection(ConnectionInterface):
             # If HTTP/2 support is enabled, and the resulting connection could
             # end up as HTTP/2 then we should indicate the connection as being
             # available to service multiple requests.
-            return (
+            return (  # pragma: no cover
                 self._http2
                 and (self._origin.scheme == b"https" or not self._http1)
                 and not self._connect_failed
@@ -207,7 +207,9 @@ class HTTPConnection(ConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
+            return (
+                "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
+            )  # pragma: no cover
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -207,7 +207,7 @@ class HTTPConnection(ConnectionInterface):
         if self._connection is None:
             if self._is_new:
                 return "NEW CONNECTION"
-            return "CONNECTINION FAILED" if self._connect_failed else "CONNECTING"
+            return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -63,6 +63,7 @@ class HTTPConnection(ConnectionInterface):
         self._connect_failed: bool = False
         self._request_lock = Lock()
         self._socket_options = socket_options
+        self._is_new = True
 
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
@@ -73,6 +74,7 @@ class HTTPConnection(ConnectionInterface):
         with self._request_lock:
             if self._connection is None:
                 try:
+                    self._is_new = False
                     stream = self._connect(request)
 
                     ssl_object = stream.get_extra_info("ssl_object")
@@ -94,7 +96,7 @@ class HTTPConnection(ConnectionInterface):
                             stream=stream,
                             keepalive_expiry=self._keepalive_expiry,
                         )
-                except Exception as exc:
+                except BaseException as exc:
                     self._connect_failed = True
                     raise exc
             elif not self._connection.is_available():
@@ -174,6 +176,8 @@ class HTTPConnection(ConnectionInterface):
 
     def is_available(self) -> bool:
         if self._connection is None:
+            if self._is_new:
+                return True
             # If HTTP/2 support is enabled, and the resulting connection could
             # end up as HTTP/2 then we should indicate the connection as being
             # available to service multiple requests.
@@ -185,6 +189,8 @@ class HTTPConnection(ConnectionInterface):
         return self._connection.is_available()
 
     def has_expired(self) -> bool:
+        if self._connect_failed:
+            return True
         if self._connection is None:
             return self._connect_failed
         return self._connection.has_expired()
@@ -201,7 +207,13 @@ class HTTPConnection(ConnectionInterface):
 
     def info(self) -> str:
         if self._connection is None:
-            return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
+            if self._is_new:
+                return "NEW CONNECTION"
+            return (
+                "CONNECTING"
+                if not (self._is_new or self._connect_failed)
+                else "CONNECTINION FAILED"
+            )
         return self._connection.info()
 
     def __repr__(self) -> str:

--- a/tests/_async/test_connection.py
+++ b/tests/_async/test_connection.py
@@ -37,9 +37,9 @@ async def test_http_connection():
     ) as conn:
         assert not conn.is_idle()
         assert not conn.is_closed()
-        assert not conn.is_available()
+        assert conn.is_available()
         assert not conn.has_expired()
-        assert repr(conn) == "<AsyncHTTPConnection [CONNECTING]>"
+        assert repr(conn) == "<AsyncHTTPConnection [NEW CONNECTION]>"
 
         async with conn.stream("GET", "https://example.com/") as response:
             assert (

--- a/tests/_sync/test_connection.py
+++ b/tests/_sync/test_connection.py
@@ -37,9 +37,9 @@ def test_http_connection():
     ) as conn:
         assert not conn.is_idle()
         assert not conn.is_closed()
-        assert not conn.is_available()
+        assert conn.is_available()
         assert not conn.has_expired()
-        assert repr(conn) == "<HTTPConnection [CONNECTING]>"
+        assert repr(conn) == "<HTTPConnection [NEW CONNECTION]>"
 
         with conn.stream("GET", "https://example.com/") as response:
             assert (


### PR DESCRIPTION
Motivated by https://github.com/encode/httpx/issues/947 🔥

Closes #785

This pull request just adds some logic to check if the connection was previously used or if it's just been created.
Now the example from #785 works fine(?).

It's very hard to explain where the problem actually is, but I think you can find the answer to that question in #785.

In simple words, the **client always thinks that there cannot be a connection that has not failed and is also not in the connecting process**. This is because every connection is attached to some request when it's created, and there are no cases when it can just hang in our connection pool except for asynchronous cancellations.

Now the `HTTPConnection` instances can be new if "._is_new" is set to true and failed if "._connect_failed" is set to true. Otherwise, if both of them are false, that means it's in the connecting process.