### PR TITLE
Bump mkdocs-material-extensions from 1.1.1 to 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ trio==0.21.0
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
 mkdocs-material==9.1.15
-mkdocs-material-extensions==1.1.1
+mkdocs-material-extensions==1.2
 mkdocstrings[python-legacy]==0.22.0
 jinja2==3.1.2
 


### PR DESCRIPTION
Required for #815 