### PR TITLE
Raise a neater RuntimeError when the correct async deps are not installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Fix pool timeout to account for the total time spent retrying. (#823)
+- Raise a neater RuntimeError when the correct async deps are not installed. (#826)
 
 ## 1.0.0 (November 6th, 2023)
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -326,6 +326,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
             self._requests = []
 
     async def __aenter__(self) -> "AsyncConnectionPool":
+        # Acquiring the pool lock here ensures that we have the
+        # correct dependencies installed as early as possible.
+        async with self._pool_lock:
+            pass
         return self
 
     async def __aexit__(

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -326,6 +326,8 @@ class ConnectionPool(RequestInterface):
             self._requests = []
 
     def __enter__(self) -> "ConnectionPool":
+        # Acquiring the pool lock here ensures that we have the
+        # correct dependencies installed as early as possible.
         with self._pool_lock:
             pass
         return self

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -326,6 +326,8 @@ class ConnectionPool(RequestInterface):
             self._requests = []
 
     def __enter__(self) -> "ConnectionPool":
+        with self._pool_lock:
+            pass
         return self
 
     def __exit__(


### PR DESCRIPTION
Closes #825.

**example.py**

```python
import httpcore
import asyncio


async def main():
    async with httpcore.AsyncConnectionPool() as pool:
        response = await pool.request("GET", "https://www.example.com")
    print(response)


asyncio.run(main())
```

**output:**

```shell
$ venv/bin/python ./example.py 
Traceback (most recent call last):
  File "/Users/tomchristie/Temp/./example.py", line 11, in <module>
    asyncio.run(main())
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/tomchristie/Temp/./example.py", line 6, in main
    async with httpcore.AsyncConnectionPool() as pool:
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_async/connection_pool.py", line 331, in __aenter__
    async with self._pool_lock:
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_synchronization.py", line 64, in __aenter__
    self.setup()
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_synchronization.py", line 56, in setup
    self._backend = current_async_library()
  File "/Users/tomchristie/GitHub/encode/httpcore/httpcore/_synchronization.py", line 35, in current_async_library
    raise RuntimeError(
RuntimeError: Running with asyncio requires installation of 'httpcore[asyncio]'.
```

Compare this against... https://github.com/encode/httpcore/issues/825#issuecomment-1761296515