### PR TITLE
Bump mkdocs-material-extensions from 1.2 to 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
 mkdocs-material==9.4.2
-mkdocs-material-extensions==1.2
+mkdocs-material-extensions==1.3
 mkdocstrings[python-legacy]==0.22.0
 jinja2==3.1.2
 


### PR DESCRIPTION
Required for #837