### PR TITLE
Fix synchronous TLS-in-TLS streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Fix pool timeout to account for the total time spent retrying. (#823)
+- Fix synchronous TLS-in-TLS streams. (#840)
 
 ## 1.0.0 (October 6th, 2023)
 

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -145,12 +145,6 @@ class SyncStream(NetworkStream):
         server_hostname: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
     ) -> NetworkStream:
-        if isinstance(self._sock, ssl.SSLSocket):  # pragma: no cover
-            raise RuntimeError(
-                "Attempted to add a TLS layer on top of the existing "
-                "TLS stream, which is not supported by httpcore package"
-            )
-
         exc_map: ExceptionMapping = {
             socket.timeout: ConnectTimeout,
             OSError: ConnectError,


### PR DESCRIPTION
Closes #841

I'm not sure how we missed that, but it appears we have an if statement that prevents `TLS-in-TLS` streams for synchronous backends.

@tomchristie included a basic example of how to test this feature in sync and async code in the [pull request that adds HTTPS proxy support](https://github.com/encode/httpcore/pull/786).

This pull request simply corrects `TLS-in-TLS` sync by removing unnecessary if. To test locally, follow the steps outlined in the [PR that adds HTTPS proxy support](https://github.com/encode/httpcore/pull/786).
