### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 1.0.1 (November 3rd, 2023)
 
 - Fix pool timeout to account for the total time spent retrying. (#823)
 - Raise a neater RuntimeError when the correct async deps are not installed. (#826)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -130,7 +130,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 __locals = locals()


### PR DESCRIPTION
Provisionally marked up for a release tomorrow...

## 1.0.1 (November 3rd, 2023)

- Fix pool timeout to account for the total time spent retrying. (#823)
- Raise a neater RuntimeError when the correct async deps are not installed. (#826)
- Add support for synchronous TLS-in-TLS streams. (#840)