### PR TITLE
Fix float("inf") timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Fix `float("inf")` timeouts in `Event.wait` function. (#846)
+
 ## 1.0.1 (November 3rd, 2023)
 
 - Fix pool timeout to account for the total time spent retrying. (#823)

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -226,6 +226,8 @@ class Event:
         self._event.set()
 
     def wait(self, timeout: Optional[float] = None) -> None:
+        if timeout == float("inf"):  # pragma: no cover
+            timeout = None
         if not self._event.wait(timeout=timeout):
             raise PoolTimeout()  # pragma: nocover
 


### PR DESCRIPTION
Resolves #845

The issue is that our `AsyncEvent.wait` supports `float('inf')` timeout but `Event.wait` doesn't.

Simple demonstration:

Works
```python
import asyncio
from httpcore._synchronization import AsyncEvent

async def background(event: AsyncEvent):
    await asyncio.sleep(2)
    event.set()

async def main():
    event = AsyncEvent()
    asyncio.create_task(background(event))
    await event.wait(timeout=float("inf"))
    print('done')

asyncio.run(main())
```

Doesn't work
```python
import threading
import time
from httpcore._synchronization import Event

def background(event: Event):
    time.sleep(2) 
    event.set()

def main():
    event = Event()
    threading.Thread(target=background, args=[event]).start()
    event.wait(timeout=float("inf"))
    print('done')

main()  
```

Error:

```
Traceback (most recent call last):
  File "/home/test/programs/gitprojects/httpcore/tust.py", line 15, in <module>
    main()
  File "/home/test/programs/gitprojects/httpcore/tust.py", line 12, in main
    event.wait(timeout=float("inf"))
  File "/home/test/programs/gitprojects/httpcore/httpcore/_synchronization.py", line 229, in wait
    if not self._event.wait(timeout=timeout):
  File "/usr/lib/python3.10/threading.py", line 607, in wait
    signaled = self._cond.wait(timeout)
  File "/usr/lib/python3.10/threading.py", line 324, in wait
    gotit = waiter.acquire(True, timeout)
OverflowError: timestamp too large to convert to C _PyTime_t
```