### PR TITLE
Fix bug with async socks proxy and tracing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 1.0.2 (November 10th, 2023) 
+## 1.0.3 (November 22th, 2023)
+
+- Fix copy paste bug with socks proxy and tracing. (#849)
+
+## 1.0.2 (November 10th, 2023)
 
 - Fix `float("inf")` timeouts in `Event.wait` function. (#846)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix copy paste bug with socks proxy and tracing. (#849)
+- Fix trace extension when used with socks proxy. (#849)
 
 ## 1.0.2 (November 10th, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 1.0.3 (November 22th, 2023)
+## Unreleased
 
 - Fix copy paste bug with socks proxy and tracing. (#849)
 

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -130,7 +130,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 __locals = locals()

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -130,7 +130,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "1.0.3"
+__version__ = "1.0.2"
 
 
 __locals = locals()

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -228,7 +228,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         "port": self._proxy_origin.port,
                         "timeout": timeout,
                     }
-                    with Trace("connect_tcp", logger, request, kwargs) as trace:
+                    async with Trace("connect_tcp", logger, request, kwargs) as trace:
                         stream = await self._network_backend.connect_tcp(**kwargs)
                         trace.return_value = stream
 
@@ -239,7 +239,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         "port": self._remote_origin.port,
                         "auth": self._proxy_auth,
                     }
-                    with Trace(
+                    async with Trace(
                         "setup_socks5_connection", logger, request, kwargs
                     ) as trace:
                         await _init_socks5_connection(**kwargs)


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

If you are using socks proxy, asynchronous client and tracing, it fails with the following error:

```
  File "/opt/.../3rdparty_python_httpcore/site-packages/httpcore/_async/socks_proxy.py", line 231, in handle_async_request
    with Trace("connect_tcp", logger, request, kwargs) as trace:
  File "/opt/.../3rdparty_python_httpcore/site-packages/httpcore/_trace.py", line 50, in __enter__
    self.trace(f"{self.name}.started", info)
  File "/opt/.../3rdparty_python_httpcore/site-packages/httpcore/_trace.py", line 33, in trace
    raise TypeError(
TypeError: If you are using a synchronous interface, the callback of the `trace` extension should be a normal function instead of an asynchronous function.
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
