### PR TITLE
Keep sock original timeout, If read,write timeout not set

### DIFF
--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -77,7 +77,8 @@ class TLSinTLSStream(NetworkStream):  # pragma: no cover
     def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
         exc_map: ExceptionMapping = {socket.timeout: ReadTimeout, OSError: ReadError}
         with map_exceptions(exc_map):
-            self._sock.settimeout(timeout)
+            if timeout:
+                self._sock.settimeout(timeout)
             return typing.cast(
                 bytes, self._perform_io(partial(self.ssl_obj.read, max_bytes))
             )
@@ -85,7 +86,8 @@ class TLSinTLSStream(NetworkStream):  # pragma: no cover
     def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
         exc_map: ExceptionMapping = {socket.timeout: WriteTimeout, OSError: WriteError}
         with map_exceptions(exc_map):
-            self._sock.settimeout(timeout)
+            if timeout:
+                self._sock.settimeout(timeout)
             while buffer:
                 nsent = self._perform_io(partial(self.ssl_obj.write, buffer))
                 buffer = buffer[nsent:]
@@ -122,7 +124,8 @@ class SyncStream(NetworkStream):
     def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
         exc_map: ExceptionMapping = {socket.timeout: ReadTimeout, OSError: ReadError}
         with map_exceptions(exc_map):
-            self._sock.settimeout(timeout)
+            if timeout:
+                self._sock.settimeout(timeout)
             return self._sock.recv(max_bytes)
 
     def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
@@ -132,7 +135,8 @@ class SyncStream(NetworkStream):
         exc_map: ExceptionMapping = {socket.timeout: WriteTimeout, OSError: WriteError}
         with map_exceptions(exc_map):
             while buffer:
-                self._sock.settimeout(timeout)
+                if timeout:
+                    self._sock.settimeout(timeout)
                 n = self._sock.send(buffer)
                 buffer = buffer[n:]
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In httpcore/_backends/sync.py, when not set timeout. It will override original sock timeout setting,this patch fixed it.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
