### PR TITLE
Safe async cancellations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix support for async cancellations. (#880)
 - Fix trace extension when used with socks proxy. (#849)
 - Fix SSL context for connections using the "wss" scheme (#869)
 

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -6,7 +6,7 @@ from typing import Iterable, Iterator, Optional, Type
 
 from .._backends.auto import AutoBackend
 from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
-from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout
+from .._exceptions import ConnectError, ConnectTimeout
 from .._models import Origin, Request, Response
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
@@ -70,9 +70,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                 f"Attempted to send request to {request.url.origin} on connection to {self._origin}"
             )
 
-        async with self._request_lock:
-            if self._connection is None:
-                try:
+        try:
+            async with self._request_lock:
+                if self._connection is None:
                     stream = await self._connect(request)
 
                     ssl_object = stream.get_extra_info("ssl_object")
@@ -94,11 +94,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                             stream=stream,
                             keepalive_expiry=self._keepalive_expiry,
                         )
-                except Exception as exc:
-                    self._connect_failed = True
-                    raise exc
-            elif not self._connection.is_available():
-                raise ConnectionNotAvailable()
+        except BaseException as exc:
+            self._connect_failed = True
+            raise exc
 
         return await self._connection.handle_async_request(request)
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -7,7 +7,7 @@ from .._backends.auto import AutoBackend
 from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Request, Response
-from .._synchronization import AsyncEvent, AsyncLock
+from .._synchronization import AsyncEvent, AsyncLock, AsyncShieldCancellation
 from .connection import AsyncHTTPConnection
 from .interfaces import AsyncConnectionInterface, AsyncRequestInterface
 
@@ -193,9 +193,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
         pool_request = AsyncPoolRequest(request)
         try:
             while True:
-                async with self._pool_lock:
-                    self._requests.append(pool_request)
-                    closing = self._assign_requests_to_connections()
+                with AsyncShieldCancellation():
+                    async with self._pool_lock:
+                        self._requests.append(pool_request)
+                        closing = self._assign_requests_to_connections()
                 await self._close_connections(closing)
                 connection = await pool_request.wait_for_connection(timeout=timeout)
 
@@ -209,9 +210,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     break
 
         except BaseException as exc:
-            async with self._pool_lock:
-                self._requests.remove(pool_request)
-                closing = self._assign_requests_to_connections()
+            with AsyncShieldCancellation():
+                async with self._pool_lock:
+                    self._requests.remove(pool_request)
+                    closing = self._assign_requests_to_connections()
             await self._close_connections(closing)
             raise exc from None
 
@@ -225,17 +227,6 @@ class AsyncConnectionPool(AsyncRequestInterface):
             extensions=response.extensions,
         )
 
-    async def _request_closed(self, request: AsyncPoolRequest) -> None:
-        """
-        Once a request completes we remove it from the pool,
-        and determine if we can now assign any queued requests
-        to a connection.
-        """
-        async with self._pool_lock:
-            self._requests.remove(request)
-            closing = self._assign_requests_to_connections()
-        await self._close_connections(closing)
-
     def _assign_requests_to_connections(self) -> List[AsyncConnectionInterface]:
         """
         Manage the state of the connection pool, assigning incoming
@@ -248,10 +239,18 @@ class AsyncConnectionPool(AsyncRequestInterface):
         """
         closing_connections = []
 
-        # Close any expired connections.
         for connection in list(self._connections):
-            if connection.has_expired():
+            if connection.is_closed():
+                # log: "removing closed connection"
+                self._connections.remove(connection)
+            elif connection.has_expired():
                 # log: "closing expired connection"
+                self._connections.remove(connection)
+                closing_connections.append(connection)
+            elif (
+                connection.is_idle() and len(self._connections) > self._max_connections
+            ):
+                # log: "closing idle connection"
                 self._connections.remove(connection)
                 closing_connections.append(connection)
 
@@ -266,6 +265,9 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 for connection in self._connections
                 if connection.can_handle_request(origin) and connection.is_available()
             ]
+            idle_connections = [
+                connection for connection in self._connections if connection.is_idle()
+            ]
             if avilable_connections:
                 # log: "reusing existing connection"
                 connection = avilable_connections[0]
@@ -275,12 +277,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 connection = self.create_connection(origin)
                 self._connections.append(connection)
                 pool_request.assign_to_connection(connection)
-            else:
-                idle_connections = [
-                    connection
-                    for connection in self._connections
-                    if connection.is_idle()
-                ]
+            elif idle_connections:
                 # log: "closing idle connection"
                 connection = idle_connections[0]
                 self._connections.remove(connection)
@@ -300,10 +297,9 @@ class AsyncConnectionPool(AsyncRequestInterface):
             await connection.aclose()
 
     async def aclose(self) -> None:
-        closing = list(self._connections)
-        self._requests = []
+        closing_connections = list(self._connections)
         self._connections = []
-        await self._close_connections(closing)
+        await self._close_connections(closing_connections)
 
     async def __aenter__(self) -> "AsyncConnectionPool":
         # Acquiring the pool lock here ensures that we have the
@@ -331,19 +327,23 @@ class PoolByteStream:
         self._stream = stream
         self._pool_request = pool_request
         self._pool = pool
+        self._closed = False
+        assert self._pool_request in self._pool._requests
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         try:
             async for part in self._stream:
                 yield part
         except BaseException:
-            async with self._pool._pool_lock:
-                self._pool._requests.remove(self._pool_request)
-                closing = self._pool._assign_requests_to_connections()
-            await self._pool._close_connections(closing)
+            await self.aclose()
 
     async def aclose(self) -> None:
-        async with self._pool._pool_lock:
-            self._pool._requests.remove(self._pool_request)
-            closing = self._pool._assign_requests_to_connections()
-        await self._pool._close_connections(closing)
+        if not self._closed:
+            self._closed = True
+            with AsyncShieldCancellation():
+                if hasattr(self._stream, "aclose"):
+                    await self._stream.aclose()
+                async with self._pool._pool_lock:
+                    self._pool._requests.remove(self._pool_request)
+                    closing = self._pool._assign_requests_to_connections()
+            await self._pool._close_connections(closing)

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -239,6 +239,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
         """
         closing_connections = []
 
+        # First we handle cleaning up any connections that are closed,
+        # have expired their keep-alive, or surplus idle connections.
         for connection in list(self._connections):
             if connection.is_closed():
                 # log: "removing closed connection"
@@ -270,6 +272,13 @@ class AsyncConnectionPool(AsyncRequestInterface):
             idle_connections = [
                 connection for connection in self._connections if connection.is_idle()
             ]
+
+            # There are three cases for how we may be able to handle the request:
+            #
+            # 1. There is an existing connection that can handle the request.
+            # 2. We can create a new connection to handle the request.
+            # 3. We can close an idle connection and then create a new connection
+            #    to handle the request.
             if avilable_connections:
                 # log: "reusing existing connection"
                 connection = avilable_connections[0]

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -12,7 +12,7 @@ from .connection import AsyncHTTPConnection
 from .interfaces import AsyncConnectionInterface, AsyncRequestInterface
 
 
-class AsyncPoolRequest(Request):
+class AsyncPoolRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self.connection: Optional[AsyncConnectionInterface] = None
@@ -35,6 +35,9 @@ class AsyncPoolRequest(Request):
             await self._connection_acquired.wait(timeout=timeout)
         assert self.connection is not None
         return self.connection
+
+    def is_queued(self) -> bool:
+        return self.connection is None
 
 
 class AsyncConnectionPool(AsyncRequestInterface):
@@ -256,9 +259,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 closing_connections.append(connection)
 
         # Assign queued requests to connections.
-        queued_requests = [
-            request for request in self._requests if request.connection is None
-        ]
+        queued_requests = [request for request in self._requests if request.is_queued()]
         for pool_request in queued_requests:
             origin = pool_request.request.url.origin
             avilable_connections = [
@@ -321,6 +322,28 @@ class AsyncConnectionPool(AsyncRequestInterface):
         traceback: Optional[TracebackType] = None,
     ) -> None:
         await self.aclose()
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        with self._optional_thread_lock:
+            request_is_queued = [request.is_queued() for request in self._requests]
+            connection_is_idle = [
+                connection.is_idle() for connection in self._connections
+            ]
+
+            num_active_requests = request_is_queued.count(False)
+            num_queued_requests = request_is_queued.count(True)
+            num_active_connections = connection_is_idle.count(False)
+            num_idle_connections = connection_is_idle.count(True)
+
+        requests_info = (
+            f"Requests: {num_active_requests} active, {num_queued_requests} queued"
+        )
+        connection_info = (
+            f"Connections: {num_active_connections} active, {num_idle_connections} idle"
+        )
+
+        return f"<{class_name} [{requests_info} | {connection_info}]>"
 
 
 class PoolByteStream:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -240,7 +240,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         closing_connections = []
 
         # First we handle cleaning up any connections that are closed,
-        # have expired their keep-alive, or surplus idle connections.
+        # have expired their keep-alive, or surplus idle connections.
         for connection in list(self._connections):
             if connection.is_closed():
                 # log: "removing closed connection"

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -12,31 +12,6 @@ from .connection import AsyncHTTPConnection
 from .interfaces import AsyncConnectionInterface, AsyncRequestInterface
 
 
-class RequestStatus:
-    def __init__(self, request: Request):
-        self.request = request
-        self.connection: Optional[AsyncConnectionInterface] = None
-        self._connection_acquired = AsyncEvent()
-
-    def set_connection(self, connection: AsyncConnectionInterface) -> None:
-        assert self.connection is None
-        self.connection = connection
-        self._connection_acquired.set()
-
-    def unset_connection(self) -> None:
-        assert self.connection is not None
-        self.connection = None
-        self._connection_acquired = AsyncEvent()
-
-    async def wait_for_connection(
-        self, timeout: Optional[float] = None
-    ) -> AsyncConnectionInterface:
-        if self.connection is None:
-            await self._connection_acquired.wait(timeout=timeout)
-        assert self.connection is not None
-        return self.connection
-
-
 class AsyncPoolRequest(Request):
     def __init__(self, request: Request) -> None:
         self.request = request
@@ -337,22 +312,22 @@ class PoolByteStream:
         self._pool_request = pool_request
         self._pool = pool
         self._closed = False
-        assert self._pool_request in self._pool._requests
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         try:
             async for part in self._stream:
                 yield part
-        except BaseException:
+        except BaseException as exc:
             await self.aclose()
+            raise exc from None
 
     async def aclose(self) -> None:
         if not self._closed:
             self._closed = True
-            if hasattr(self._stream, "aclose"):
-                await self._stream.aclose()
-
             with AsyncShieldCancellation():
+                if hasattr(self._stream, "aclose"):
+                    await self._stream.aclose()
+
                 self._pool._requests.remove(self._pool_request)
                 closing = self._pool._assign_requests_to_connections()
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -200,7 +200,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
                 else:
-                    break
+                    break  # pragma: nocover
 
         except BaseException as exc:
             with self._optional_thread_lock:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -6,7 +6,7 @@ from typing import Iterable, Iterator, Optional, Type
 
 from .._backends.sync import SyncBackend
 from .._backends.base import SOCKET_OPTION, NetworkBackend, NetworkStream
-from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout
+from .._exceptions import ConnectError, ConnectTimeout
 from .._models import Origin, Request, Response
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
@@ -70,9 +70,9 @@ class HTTPConnection(ConnectionInterface):
                 f"Attempted to send request to {request.url.origin} on connection to {self._origin}"
             )
 
-        with self._request_lock:
-            if self._connection is None:
-                try:
+        try:
+            with self._request_lock:
+                if self._connection is None:
                     stream = self._connect(request)
 
                     ssl_object = stream.get_extra_info("ssl_object")
@@ -94,11 +94,9 @@ class HTTPConnection(ConnectionInterface):
                             stream=stream,
                             keepalive_expiry=self._keepalive_expiry,
                         )
-                except Exception as exc:
-                    self._connect_failed = True
-                    raise exc
-            elif not self._connection.is_available():
-                raise ConnectionNotAvailable()
+        except BaseException as exc:
+            self._connect_failed = True
+            raise exc
 
         return self._connection.handle_request(request)
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -191,11 +191,11 @@ class ConnectionPool(RequestInterface):
         timeout = timeouts.get("pool", None)
 
         pool_request = PoolRequest(request)
+        self._requests.append(pool_request)
         try:
             while True:
                 with ShieldCancellation():
                     with self._pool_lock:
-                        self._requests.append(pool_request)
                         closing = self._assign_requests_to_connections()
                 self._close_connections(closing)
                 connection = pool_request.wait_for_connection(timeout=timeout)
@@ -248,7 +248,9 @@ class ConnectionPool(RequestInterface):
                 self._connections.remove(connection)
                 closing_connections.append(connection)
             elif (
-                connection.is_idle() and len(self._connections) > self._max_connections
+                connection.is_idle()
+                and len([connection.is_idle() for connection in self._connections])
+                > self._max_keepalive_connections
             ):
                 # log: "closing idle connection"
                 self._connections.remove(connection)

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -200,7 +200,7 @@ class ConnectionPool(RequestInterface):
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
                 else:
-                    break
+                    break  # pragma: nocover
 
         except BaseException as exc:
             with self._optional_thread_lock:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -208,11 +208,12 @@ class ConnectionPool(RequestInterface):
                 else:
                     break
 
-        except BaseException:
+        except BaseException as exc:
             with self._pool_lock:
                 self._requests.remove(pool_request)
                 closing = self._assign_requests_to_connections()
             self._close_connections(closing)
+            raise exc from None
 
         assert isinstance(response.stream, Iterable)
         return Response(
@@ -258,8 +259,8 @@ class ConnectionPool(RequestInterface):
         queued_requests = [
             request for request in self._requests if request.connection is None
         ]
-        for request in queued_requests:
-            origin = request.url.origin
+        for pool_request in queued_requests:
+            origin = pool_request.request.url.origin
             avilable_connections = [
                 connection
                 for connection in self._connections
@@ -268,12 +269,12 @@ class ConnectionPool(RequestInterface):
             if avilable_connections:
                 # log: "reusing existing connection"
                 connection = avilable_connections[0]
-                request.assign_to_connection(connection)
+                pool_request.assign_to_connection(connection)
             elif len(self._connections) < self._max_connections:
                 # log: "creating new connection"
                 connection = self.create_connection(origin)
                 self._connections.append(connection)
-                request.assign_to_connection(connection)
+                pool_request.assign_to_connection(connection)
             else:
                 idle_connections = [
                     connection
@@ -287,7 +288,7 @@ class ConnectionPool(RequestInterface):
                 # log: "creating new connection"
                 connection = self.create_connection(origin)
                 self._connections.append(connection)
-                request.assign_to_connection(connection)
+                pool_request.assign_to_connection(connection)
 
         return closing_connections
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -240,7 +240,7 @@ class ConnectionPool(RequestInterface):
         closing_connections = []
 
         # First we handle cleaning up any connections that are closed,
-        # have expired their keep-alive, or surplus idle connections.
+        # have expired their keep-alive, or surplus idle connections.
         for connection in list(self._connections):
             if connection.is_closed():
                 # log: "removing closed connection"

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -239,6 +239,8 @@ class ConnectionPool(RequestInterface):
         """
         closing_connections = []
 
+        # First we handle cleaning up any connections that are closed,
+        # have expired their keep-alive, or surplus idle connections.
         for connection in list(self._connections):
             if connection.is_closed():
                 # log: "removing closed connection"
@@ -270,6 +272,13 @@ class ConnectionPool(RequestInterface):
             idle_connections = [
                 connection for connection in self._connections if connection.is_idle()
             ]
+
+            # There are three cases for how we may be able to handle the request:
+            #
+            # 1. There is an existing connection that can handle the request.
+            # 2. We can create a new connection to handle the request.
+            # 3. We can close an idle connection and then create a new connection
+            #    to handle the request.
             if avilable_connections:
                 # log: "reusing existing connection"
                 connection = avilable_connections[0]

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -1,14 +1,13 @@
 import ssl
 import sys
-import time
 from types import TracebackType
 from typing import Iterable, Iterator, Iterable, List, Optional, Type
 
 from .._backends.sync import SyncBackend
 from .._backends.base import SOCKET_OPTION, NetworkBackend
-from .._exceptions import ConnectionNotAvailable, PoolTimeout, UnsupportedProtocol
+from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Request, Response
-from .._synchronization import Event, Lock, ShieldCancellation
+from .._synchronization import Event, Lock
 from .connection import HTTPConnection
 from .interfaces import ConnectionInterface, RequestInterface
 
@@ -26,6 +25,31 @@ class RequestStatus:
 
     def unset_connection(self) -> None:
         assert self.connection is not None
+        self.connection = None
+        self._connection_acquired = Event()
+
+    def wait_for_connection(
+        self, timeout: Optional[float] = None
+    ) -> ConnectionInterface:
+        if self.connection is None:
+            self._connection_acquired.wait(timeout=timeout)
+        assert self.connection is not None
+        return self.connection
+
+
+class PoolRequest(Request):
+    def __init__(self, request: Request) -> None:
+        self.request = request
+        self.connection: Optional[ConnectionInterface] = None
+        self._connection_acquired = Event()
+
+    def assign_to_connection(
+        self, connection: Optional[ConnectionInterface]
+    ) -> None:
+        self.connection = connection
+        self._connection_acquired.set()
+
+    def clear_connection(self) -> None:
         self.connection = None
         self._connection_acquired = Event()
 
@@ -107,8 +131,8 @@ class ConnectionPool(RequestInterface):
         self._local_address = local_address
         self._uds = uds
 
-        self._pool: List[ConnectionInterface] = []
-        self._requests: List[RequestStatus] = []
+        self._connections: List[ConnectionInterface] = []
+        self._requests: List[PoolRequest] = []
         self._pool_lock = Lock()
         self._network_backend = (
             SyncBackend() if network_backend is None else network_backend
@@ -145,64 +169,7 @@ class ConnectionPool(RequestInterface):
         ]
         ```
         """
-        return list(self._pool)
-
-    def _attempt_to_acquire_connection(self, status: RequestStatus) -> bool:
-        """
-        Attempt to provide a connection that can handle the given origin.
-        """
-        origin = status.request.url.origin
-
-        # If there are queued requests in front of us, then don't acquire a
-        # connection. We handle requests strictly in order.
-        waiting = [s for s in self._requests if s.connection is None]
-        if waiting and waiting[0] is not status:
-            return False
-
-        # Reuse an existing connection if one is currently available.
-        for idx, connection in enumerate(self._pool):
-            if connection.can_handle_request(origin) and connection.is_available():
-                self._pool.pop(idx)
-                self._pool.insert(0, connection)
-                status.set_connection(connection)
-                return True
-
-        # If the pool is currently full, attempt to close one idle connection.
-        if len(self._pool) >= self._max_connections:
-            for idx, connection in reversed(list(enumerate(self._pool))):
-                if connection.is_idle():
-                    connection.close()
-                    self._pool.pop(idx)
-                    break
-
-        # If the pool is still full, then we cannot acquire a connection.
-        if len(self._pool) >= self._max_connections:
-            return False
-
-        # Otherwise create a new connection.
-        connection = self.create_connection(origin)
-        self._pool.insert(0, connection)
-        status.set_connection(connection)
-        return True
-
-    def _close_expired_connections(self) -> None:
-        """
-        Clean up the connection pool by closing off any connections that have expired.
-        """
-        # Close any connections that have expired their keep-alive time.
-        for idx, connection in reversed(list(enumerate(self._pool))):
-            if connection.has_expired():
-                connection.close()
-                self._pool.pop(idx)
-
-        # If the pool size exceeds the maximum number of allowed keep-alive connections,
-        # then close off idle connections as required.
-        pool_size = len(self._pool)
-        for idx, connection in reversed(list(enumerate(self._pool))):
-            if connection.is_idle() and pool_size > self._max_keepalive_connections:
-                connection.close()
-                self._pool.pop(idx)
-                pool_size -= 1
+        return list(self._connections)
 
     def handle_request(self, request: Request) -> Response:
         """
@@ -220,110 +187,122 @@ class ConnectionPool(RequestInterface):
                 f"Request URL has an unsupported protocol '{scheme}://'."
             )
 
-        status = RequestStatus(request)
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("pool", None)
 
-        if timeout is not None:
-            deadline = time.monotonic() + timeout
-        else:
-            deadline = float("inf")
-
-        with self._pool_lock:
-            self._requests.append(status)
-            self._close_expired_connections()
-            self._attempt_to_acquire_connection(status)
-
-        while True:
-            try:
-                connection = status.wait_for_connection(timeout=timeout)
-            except BaseException as exc:
-                # If we timeout here, or if the task is cancelled, then make
-                # sure to remove the request from the queue before bubbling
-                # up the exception.
+        pool_request = PoolRequest(request)
+        try:
+            while True:
                 with self._pool_lock:
-                    # Ensure only remove when task exists.
-                    if status in self._requests:
-                        self._requests.remove(status)
-                    raise exc
+                    self._requests.append(pool_request)
+                    closing = self._assign_requests_to_connections()
+                self._close_connections(closing)
+                connection = pool_request.wait_for_connection(timeout=timeout)
 
-            try:
-                response = connection.handle_request(request)
-            except ConnectionNotAvailable:
-                # The ConnectionNotAvailable exception is a special case, that
-                # indicates we need to retry the request on a new connection.
-                #
-                # The most common case where this can occur is when multiple
-                # requests are queued waiting for a single connection, which
-                # might end up as an HTTP/2 connection, but which actually ends
-                # up as HTTP/1.1.
-                with self._pool_lock:
-                    # Maintain our position in the request queue, but reset the
-                    # status so that the request becomes queued again.
-                    status.unset_connection()
-                    self._attempt_to_acquire_connection(status)
-            except BaseException as exc:
-                with ShieldCancellation():
-                    self.response_closed(status)
-                raise exc
-            else:
-                break
+                try:
+                    response = connection.handle_request(
+                        pool_request.request
+                    )
+                except ConnectionNotAvailable:
+                    pool_request.clear_connection()
+                else:
+                    break
 
-            timeout = deadline - time.monotonic()
-            if timeout < 0:
-                raise PoolTimeout  # pragma: nocover
+        except BaseException:
+            with self._pool_lock:
+                self._requests.remove(pool_request)
+                closing = self._assign_requests_to_connections()
+            self._close_connections(closing)
 
-        # When we return the response, we wrap the stream in a special class
-        # that handles notifying the connection pool once the response
-        # has been released.
         assert isinstance(response.stream, Iterable)
         return Response(
             status=response.status,
             headers=response.headers,
-            content=ConnectionPoolByteStream(response.stream, self, status),
+            content=PoolByteStream(
+                stream=response.stream, pool_request=pool_request, pool=self
+            ),
             extensions=response.extensions,
         )
 
-    def response_closed(self, status: RequestStatus) -> None:
+    def _request_closed(self, request: PoolRequest) -> None:
         """
-        This method acts as a callback once the request/response cycle is complete.
-
-        It is called into from the `ConnectionPoolByteStream.close()` method.
+        Once a request completes we remove it from the pool,
+        and determine if we can now assign any queued requests
+        to a connection.
         """
-        assert status.connection is not None
-        connection = status.connection
-
         with self._pool_lock:
-            # Update the state of the connection pool.
-            if status in self._requests:
-                self._requests.remove(status)
+            self._requests.remove(request)
+            closing = self._assign_requests_to_connections()
+        self._close_connections(closing)
 
-            if connection.is_closed() and connection in self._pool:
-                self._pool.remove(connection)
+    def _assign_requests_to_connections(self) -> List[ConnectionInterface]:
+        """
+        Manage the state of the connection pool, assigning incoming
+        requests to connections as available.
 
-            # Since we've had a response closed, it's possible we'll now be able
-            # to service one or more requests that are currently pending.
-            for status in self._requests:
-                if status.connection is None:
-                    acquired = self._attempt_to_acquire_connection(status)
-                    # If we could not acquire a connection for a queued request
-                    # then we don't need to check anymore requests that are
-                    # queued later behind it.
-                    if not acquired:
-                        break
+        Called whenever a new request is added or removed from the pool.
 
-            # Housekeeping.
-            self._close_expired_connections()
+        Any closing connections are returned, allowing the I/O for closing
+        those connections to be handled seperately.
+        """
+        closing_connections = []
+
+        # Close any expired connections.
+        for connection in list(self._connections):
+            if connection.has_expired():
+                # log: "closing expired connection"
+                self._connections.remove(connection)
+                closing_connections.append(connection)
+
+        # Assign queued requests to connections.
+        queued_requests = [
+            request for request in self._requests if request.connection is None
+        ]
+        for request in queued_requests:
+            origin = request.url.origin
+            avilable_connections = [
+                connection
+                for connection in self._connections
+                if connection.can_handle_request(origin) and connection.is_available()
+            ]
+            if avilable_connections:
+                # log: "reusing existing connection"
+                connection = avilable_connections[0]
+                request.assign_to_connection(connection)
+            elif len(self._connections) < self._max_connections:
+                # log: "creating new connection"
+                connection = self.create_connection(origin)
+                self._connections.append(connection)
+                request.assign_to_connection(connection)
+            else:
+                idle_connections = [
+                    connection
+                    for connection in self._connections
+                    if connection.is_idle()
+                ]
+                # log: "closing idle connection"
+                connection = idle_connections[0]
+                self._connections.remove(connection)
+                closing_connections.append(connection)
+                # log: "creating new connection"
+                connection = self.create_connection(origin)
+                self._connections.append(connection)
+                request.assign_to_connection(connection)
+
+        return closing_connections
+
+    def _close_connections(self, closing: List[ConnectionInterface]) -> None:
+        """
+        Close connections which have been removed from the pool.
+        """
+        for connection in closing:
+            connection.close()
 
     def close(self) -> None:
-        """
-        Close any connections in the pool.
-        """
-        with self._pool_lock:
-            for connection in self._pool:
-                connection.close()
-            self._pool = []
-            self._requests = []
+        closing = list(self._connections)
+        self._requests = []
+        self._connections = []
+        self._close_connections(closing)
 
     def __enter__(self) -> "ConnectionPool":
         # Acquiring the pool lock here ensures that we have the
@@ -341,30 +320,29 @@ class ConnectionPool(RequestInterface):
         self.close()
 
 
-class ConnectionPoolByteStream:
-    """
-    A wrapper around the response byte stream, that additionally handles
-    notifying the connection pool when the response has been closed.
-    """
-
+class PoolByteStream:
     def __init__(
         self,
         stream: Iterable[bytes],
+        pool_request: PoolRequest,
         pool: ConnectionPool,
-        status: RequestStatus,
     ) -> None:
         self._stream = stream
+        self._pool_request = pool_request
         self._pool = pool
-        self._status = status
 
     def __iter__(self) -> Iterator[bytes]:
-        for part in self._stream:
-            yield part
+        try:
+            for part in self._stream:
+                yield part
+        except BaseException:
+            with self._pool._pool_lock:
+                self._pool._requests.remove(self._pool_request)
+                closing = self._pool._assign_requests_to_connections()
+            self._pool._close_connections(closing)
 
     def close(self) -> None:
-        try:
-            if hasattr(self._stream, "close"):
-                self._stream.close()
-        finally:
-            with ShieldCancellation():
-                self._pool.response_closed(self._status)
+        with self._pool._pool_lock:
+            self._pool._requests.remove(self._pool_request)
+            closing = self._pool._assign_requests_to_connections()
+        self._pool._close_connections(closing)

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -45,6 +45,13 @@ def current_async_library() -> str:
 
 
 class AsyncLock:
+    """
+    This is a standard lock.
+
+    In the sync case `Lock` provides thread locking.
+    In the async case `AsyncLock` provides async locking.
+    """
+
     def __init__(self) -> None:
         self._backend = ""
 
@@ -80,6 +87,26 @@ class AsyncLock:
             self._trio_lock.release()
         elif self._backend == "asyncio":
             self._anyio_lock.release()
+
+
+class AsyncThreadLock:
+    """
+    This is a threading-only lock for no-I/O contexts.
+
+    In the sync case `ThreadLock` provides thread locking.
+    In the async case `AsyncThreadLock` is a no-op.
+    """
+
+    def __enter__(self) -> "AsyncThreadLock":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        pass
 
 
 class AsyncEvent:
@@ -202,10 +229,41 @@ class AsyncShieldCancellation:
 
 
 class Lock:
+    """
+    This is a standard lock.
+
+    In the sync case `Lock` provides thread locking.
+    In the async case `AsyncLock` provides async locking.
+    """
+
     def __init__(self) -> None:
         self._lock = threading.Lock()
 
     def __enter__(self) -> "Lock":
+        self._lock.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        self._lock.release()
+
+
+class ThreadLock:
+    """
+    This is a threading-only lock for no-I/O contexts.
+
+    In the sync case `ThreadLock` provides thread locking.
+    In the async case `AsyncThreadLock` is a no-op.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> "ThreadLock":
         self._lock.acquire()
         return self
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ trio-typing==0.10.0
 types-certifi==2021.10.8.3
 pytest==8.0.0
 pytest-httpbin==2.0.0
-pytest-trio==0.7.0
+pytest-trio==0.8.0
 werkzeug<2.1  # See: https://github.com/postmanlabs/httpbin/issues/673

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -38,6 +38,10 @@ async def test_connection_pool_with_keepalive():
             assert info == [
                 "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
             ]
+            assert (
+                repr(pool)
+                == "<AsyncConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 0 idle]>"
+            )
             await response.aread()
 
         assert response.status == 200
@@ -46,6 +50,10 @@ async def test_connection_pool_with_keepalive():
         assert info == [
             "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
         ]
+        assert (
+            repr(pool)
+            == "<AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 1 idle]>"
+        )
 
         # Sending a second request to the same origin will reuse the existing IDLE connection.
         async with pool.stream("GET", "https://example.com/") as response:
@@ -53,6 +61,10 @@ async def test_connection_pool_with_keepalive():
             assert info == [
                 "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>"
             ]
+            assert (
+                repr(pool)
+                == "<AsyncConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 0 idle]>"
+            )
             await response.aread()
 
         assert response.status == 200
@@ -61,6 +73,10 @@ async def test_connection_pool_with_keepalive():
         assert info == [
             "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"
         ]
+        assert (
+            repr(pool)
+            == "<AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 1 idle]>"
+        )
 
         # Sending a request to a different origin will not reuse the existing IDLE connection.
         async with pool.stream("GET", "http://example.com/") as response:
@@ -69,6 +85,10 @@ async def test_connection_pool_with_keepalive():
                 "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
                 "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
             ]
+            assert (
+                repr(pool)
+                == "<AsyncConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 1 idle]>"
+            )
             await response.aread()
 
         assert response.status == 200
@@ -78,6 +98,10 @@ async def test_connection_pool_with_keepalive():
             "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
             "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, IDLE, Request Count: 1]>",
         ]
+        assert (
+            repr(pool)
+            == "<AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 2 idle]>"
+        )
 
 
 @pytest.mark.anyio
@@ -619,6 +643,11 @@ async def test_connection_pool_concurrency_same_domain_keepalive():
                 "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 4]>",
                 "<AsyncHTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 5]>",
             ]
+
+    assert (
+        repr(pool)
+        == "<AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 0 idle]>"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -66,8 +66,8 @@ async def test_connection_pool_with_keepalive():
         async with pool.stream("GET", "http://example.com/") as response:
             info = [repr(c) for c in pool.connections]
             assert info == [
-                "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
                 "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
+                "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
             ]
             await response.aread()
 
@@ -75,8 +75,8 @@ async def test_connection_pool_with_keepalive():
         assert response.content == b"Hello, world!"
         info = [repr(c) for c in pool.connections]
         assert info == [
-            "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, IDLE, Request Count: 1]>",
             "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
+            "<AsyncHTTPConnection ['http://example.com:80', HTTP/1.1, IDLE, Request Count: 1]>",
         ]
 
 
@@ -205,11 +205,16 @@ async def test_connection_pool_with_http2_goaway():
         http2=True,
     )
 
+    def debug(*args, **kwargs):
+        print(*args, **kwargs)
+
     async with httpcore.AsyncConnectionPool(
         network_backend=network_backend,
     ) as pool:
         # Sending an intial request, which once complete will return to the pool, IDLE.
-        response = await pool.request("GET", "https://example.com/")
+        response = await pool.request(
+            "GET", "https://example.com/", exensions={"trace": debug}
+        )
         assert response.status == 200
         assert response.content == b"Hello, world!"
 
@@ -225,8 +230,8 @@ async def test_connection_pool_with_http2_goaway():
 
         info = [repr(c) for c in pool.connections]
         assert info == [
-            "<AsyncHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>",
             "<AsyncHTTPConnection ['https://example.com:443', HTTP/2, CLOSED, Request Count: 1]>",
+            "<AsyncHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>",
         ]
 
 

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -205,16 +205,11 @@ def test_connection_pool_with_http2_goaway():
         http2=True,
     )
 
-    def debug(*args, **kwargs):
-        print(*args, **kwargs)
-
     with httpcore.ConnectionPool(
         network_backend=network_backend,
     ) as pool:
         # Sending an intial request, which once complete will return to the pool, IDLE.
-        response = pool.request(
-            "GET", "https://example.com/", exensions={"trace": debug}
-        )
+        response = pool.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"
 
@@ -224,13 +219,13 @@ def test_connection_pool_with_http2_goaway():
         ]
 
         # Sending a second request to the same origin will require a new connection.
+        # The original connection has now been closed.
         response = pool.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"
 
         info = [repr(c) for c in pool.connections]
         assert info == [
-            "<HTTPConnection ['https://example.com:443', HTTP/2, CLOSED, Request Count: 1]>",
             "<HTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>",
         ]
 

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -38,6 +38,10 @@ def test_connection_pool_with_keepalive():
             assert info == [
                 "<HTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 1]>"
             ]
+            assert (
+                repr(pool)
+                == "<ConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 0 idle]>"
+            )
             response.read()
 
         assert response.status == 200
@@ -46,6 +50,10 @@ def test_connection_pool_with_keepalive():
         assert info == [
             "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
         ]
+        assert (
+            repr(pool)
+            == "<ConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 1 idle]>"
+        )
 
         # Sending a second request to the same origin will reuse the existing IDLE connection.
         with pool.stream("GET", "https://example.com/") as response:
@@ -53,6 +61,10 @@ def test_connection_pool_with_keepalive():
             assert info == [
                 "<HTTPConnection ['https://example.com:443', HTTP/1.1, ACTIVE, Request Count: 2]>"
             ]
+            assert (
+                repr(pool)
+                == "<ConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 0 idle]>"
+            )
             response.read()
 
         assert response.status == 200
@@ -61,6 +73,10 @@ def test_connection_pool_with_keepalive():
         assert info == [
             "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"
         ]
+        assert (
+            repr(pool)
+            == "<ConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 1 idle]>"
+        )
 
         # Sending a request to a different origin will not reuse the existing IDLE connection.
         with pool.stream("GET", "http://example.com/") as response:
@@ -69,6 +85,10 @@ def test_connection_pool_with_keepalive():
                 "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
                 "<HTTPConnection ['http://example.com:80', HTTP/1.1, ACTIVE, Request Count: 1]>",
             ]
+            assert (
+                repr(pool)
+                == "<ConnectionPool [Requests: 1 active, 0 queued | Connections: 1 active, 1 idle]>"
+            )
             response.read()
 
         assert response.status == 200
@@ -78,6 +98,10 @@ def test_connection_pool_with_keepalive():
             "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>",
             "<HTTPConnection ['http://example.com:80', HTTP/1.1, IDLE, Request Count: 1]>",
         ]
+        assert (
+            repr(pool)
+            == "<ConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 2 idle]>"
+        )
 
 
 
@@ -619,6 +643,11 @@ def test_connection_pool_concurrency_same_domain_keepalive():
                 "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 4]>",
                 "<HTTPConnection ['https://a.com:443', HTTP/1.1, ACTIVE, Request Count: 5]>",
             ]
+
+    assert (
+        repr(pool)
+        == "<ConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 0 idle]>"
+    )
 
 
 


### PR DESCRIPTION
Closes https://github.com/encode/httpcore/issues/830
Closes #785
Closes #861
Closes https://github.com/encode/httpx/issues/1171

Let's talk about what's going on here.

We've got an issue with handling async cancellations correctly, which needs some re-working in order to comprehensively resolve it. We're somewhat in contrast to either `urllib3` (sync) or `aiohttp` (async) here, because we're having to get both the thread-safe and the task-safe-plus-also-support-cancellations cases correct.

Currently we're at thread-safe plus task-safe, but missing correct handling of also allowing external cancellations at any point.

So then...

---

This pull request reworks the handling of the connection pool state. The state is a list of connections, a list of requests, and an association between each request and the connection that has been selected to handle it.

The fundamental change in this pull request is that the management of the pool state has been re-worked so that it does not include I/O.

https://github.com/encode/httpcore/blob/cda040d4f6f01b73c97fbf8cd767cff21e820b83/httpcore/_async/connection_pool.py#L228-L299

This ensures that updating the state of the connection pool is always atomic.

---

As part of resolving this, also adds connection pool `__repr__` to demonstate the state more clearly.

The look like so...

```python
<httpcore.ConnectionPool [Requests: 10 active, 3 queued | Connections: 2 active, idle]>
```