### PR TITLE
Fixed typo in `Request` class docstring.

### DIFF
--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -339,7 +339,7 @@ class Request:
             url: The request URL, either as a `URL` instance, or as a string or bytes.
                 For example: `"https://www.example.com".`
             headers: The HTTP request headers.
-            content: The content of the response body.
+            content: The content of the request body.
             extensions: A dictionary of optional extra information included on
                 the request. Possible keys include `"timeout"`, and `"trace"`.
         """


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Just a small typo in the docstring for the `Request` class. The `content` parameter is described as the content of the *response body*, rather than the *request body*.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
