### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -39,7 +39,7 @@ def merge_headers(
     """
     default_headers = [] if default_headers is None else list(default_headers)
     override_headers = [] if override_headers is None else list(override_headers)
-    has_override = set(key.lower() for key, value in override_headers)
+    has_override = {key.lower() for key, value in override_headers}
     default_headers = [
         (key, value)
         for key, value in default_headers

--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -118,7 +118,7 @@ def include_request_headers(
     url: "URL",
     content: Union[None, bytes, Iterable[bytes], AsyncIterable[bytes]],
 ) -> List[Tuple[bytes, bytes]]:
-    headers_set = set(k.lower() for k, v in headers)
+    headers_set = {k.lower() for k, v in headers}
 
     if b"host" not in headers_set:
         default_port = DEFAULT_PORTS.get(url.scheme)
@@ -440,8 +440,7 @@ class Response:
                 "Attempted to call 'for ... in response.iter_stream()' more than once."
             )
         self._stream_consumed = True
-        for chunk in self.stream:
-            yield chunk
+        yield from self.stream
 
     def close(self) -> None:
         if not isinstance(self.stream, Iterable):  # pragma: nocover

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -360,8 +360,7 @@ class PoolByteStream:
 
     def __iter__(self) -> Iterator[bytes]:
         try:
-            for part in self._stream:
-                yield part
+            yield from self._stream
         except BaseException as exc:
             self.close()
             raise exc from None

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -338,8 +338,7 @@ class HTTP11ConnectionByteStream:
         kwargs = {"request": self._request}
         try:
             with Trace("receive_response_body", logger, self._request, kwargs):
-                for chunk in self._connection._receive_response_body(**kwargs):
-                    yield chunk
+                yield from self._connection._receive_response_body(**kwargs)
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -569,10 +569,9 @@ class HTTP2ConnectionByteStream:
         kwargs = {"request": self._request, "stream_id": self._stream_id}
         try:
             with Trace("receive_response_body", logger, self._request, kwargs):
-                for chunk in self._connection._receive_response_body(
+                yield from self._connection._receive_response_body(
                     request=self._request, stream_id=self._stream_id
-                ):
-                    yield chunk
+                )
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -39,7 +39,7 @@ def merge_headers(
     """
     default_headers = [] if default_headers is None else list(default_headers)
     override_headers = [] if override_headers is None else list(override_headers)
-    has_override = set(key.lower() for key, value in override_headers)
+    has_override = {key.lower() for key, value in override_headers}
     default_headers = [
         (key, value)
         for key, value in default_headers

--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -42,7 +42,7 @@ def unasync_line(line):
 
 
 def unasync_file(in_path, out_path):
-    with open(in_path, "r") as in_file:
+    with open(in_path) as in_file:
         with open(out_path, "w", newline="") as out_file:
             for line in in_file.readlines():
                 line = unasync_line(line)
@@ -50,8 +50,8 @@ def unasync_file(in_path, out_path):
 
 
 def unasync_file_check(in_path, out_path):
-    with open(in_path, "r") as in_file:
-        with open(out_path, "r") as out_file:
+    with open(in_path) as in_file:
+        with open(out_path) as out_file:
             for in_line, out_line in zip(in_file.readlines(), out_file.readlines()):
                 expected = unasync_line(in_line)
                 if out_line != expected:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,7 @@ def test_url_cannot_include_unicode_strings():
         httpcore.URL("https://www.example.com/☺")
     assert str(exc_info.value) == "url strings may not include unicode characters."
 
-    httpcore.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode("utf-8"))
+    httpcore.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode())
 
 
 # Request
@@ -113,8 +113,7 @@ class ByteIterator:
         self._chunks = chunks
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for chunk in self._chunks:
-            yield chunk
+        yield from self._chunks
 
 
 def test_response_sync_read():


### PR DESCRIPTION
# Summary
Filter all code over `pyupgrade --py38`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
