### PR TITLE
Raise exception with cause exception

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -205,7 +205,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 else:
                     break  # pragma: nocover
 
-        except BaseException as exc:
+        except BaseException:
             with self._optional_thread_lock:
                 # For any exception or cancellation we remove the request from
                 # the queue, and then re-assign requests to connections.
@@ -362,7 +362,7 @@ class PoolByteStream:
         try:
             async for part in self._stream:
                 yield part
-        except BaseException as exc:
+        except BaseException:
             await self.aclose()
             raise
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -213,7 +213,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 closing = self._assign_requests_to_connections()
 
             await self._close_connections(closing)
-            raise exc from None
+            raise
 
         # Return the response. Note that in this case we still have to manage
         # the point at which the response is closed.
@@ -364,7 +364,7 @@ class PoolByteStream:
                 yield part
         except BaseException as exc:
             await self.aclose()
-            raise exc from None
+            raise
 
     async def aclose(self) -> None:
         if not self._closed:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -205,7 +205,7 @@ class ConnectionPool(RequestInterface):
                 else:
                     break  # pragma: nocover
 
-        except BaseException as exc:
+        except BaseException:
             with self._optional_thread_lock:
                 # For any exception or cancellation we remove the request from
                 # the queue, and then re-assign requests to connections.
@@ -362,7 +362,7 @@ class PoolByteStream:
         try:
             for part in self._stream:
                 yield part
-        except BaseException as exc:
+        except BaseException:
             self.close()
             raise
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -213,7 +213,7 @@ class ConnectionPool(RequestInterface):
                 closing = self._assign_requests_to_connections()
 
             self._close_connections(closing)
-            raise exc from None
+            raise
 
         # Return the response. Note that in this case we still have to manage
         # the point at which the response is closed.
@@ -364,7 +364,7 @@ class PoolByteStream:
                 yield part
         except BaseException as exc:
             self.close()
-            raise exc from None
+            raise
 
     def close(self) -> None:
         if not self._closed:

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -410,6 +410,8 @@ def test_connection_pool_with_connect_exception():
     be returned to the connection pool.
     """
 
+    cause_exception = Exception("cause")
+
     class FailedConnectBackend(httpcore.MockBackend):
         def connect_tcp(
             self,
@@ -421,7 +423,7 @@ def test_connection_pool_with_connect_exception():
                 typing.Iterable[httpcore.SOCKET_OPTION]
             ] = None,
         ) -> httpcore.NetworkStream:
-            raise httpcore.ConnectError("Could not connect")
+            raise httpcore.ConnectError("Could not connect") from cause_exception
 
     network_backend = FailedConnectBackend([])
 
@@ -432,10 +434,12 @@ def test_connection_pool_with_connect_exception():
 
     with httpcore.ConnectionPool(network_backend=network_backend) as pool:
         # Sending an initial request, which once complete will not return to the pool.
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as exc_info:
             pool.request(
                 "GET", "https://example.com/", extensions={"trace": trace}
             )
+
+        assert exc_info.value.__cause__ is cause_exception
 
         info = [repr(c) for c in pool.connections]
         assert info == []


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In the current logic, the original exception is discarded, which makes it hard to determine the thrown exception more precisely.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

# Use case

```python
try:
  resp = pool.request('GET', 'https://example.com')
except ConnectError as error:
  # before
  assert error.__cause__ is None
  # after
  assert isinstance(error.__cause__, ssl.SSLError)
```
