### PR TITLE
Optimize connection pool implementation

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -238,6 +238,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         those connections to be handled seperately.
         """
         closing_connections = []
+        idling_count = 0
 
         # First we handle cleaning up any connections that are closed,
         # have expired their keep-alive, or surplus idle connections.
@@ -249,26 +250,24 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 # log: "closing expired connection"
                 self._connections.remove(connection)
                 closing_connections.append(connection)
-            elif (
-                connection.is_idle()
-                and len([connection.is_idle() for connection in self._connections])
-                > self._max_keepalive_connections
-            ):
+            elif connection.is_idle():
+                if idling_count < self._max_keepalive_connections:
+                    idling_count += 1
+                    continue
                 # log: "closing idle connection"
                 self._connections.remove(connection)
                 closing_connections.append(connection)
 
         # Assign queued requests to connections.
-        queued_requests = [request for request in self._requests if request.is_queued()]
-        for pool_request in queued_requests:
+        for pool_request in list(self._requests):
+            if not pool_request.is_queued():
+                continue
+
             origin = pool_request.request.url.origin
             available_connections = [
                 connection
                 for connection in self._connections
                 if connection.can_handle_request(origin) and connection.is_available()
-            ]
-            idle_connections = [
-                connection for connection in self._connections if connection.is_idle()
             ]
 
             # There are three cases for how we may be able to handle the request:
@@ -286,15 +285,18 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 connection = self.create_connection(origin)
                 self._connections.append(connection)
                 pool_request.assign_to_connection(connection)
-            elif idle_connections:
-                # log: "closing idle connection"
-                connection = idle_connections[0]
-                self._connections.remove(connection)
-                closing_connections.append(connection)
-                # log: "creating new connection"
-                connection = self.create_connection(origin)
-                self._connections.append(connection)
-                pool_request.assign_to_connection(connection)
+            else:
+                idling_connection = next(
+                    (c for c in self._connections if c.is_idle()), None
+                )
+                if idling_connection is not None:
+                    # log: "closing idle connection"
+                    self._connections.remove(idling_connection)
+                    closing_connections.append(idling_connection)
+                    # log: "creating new connection"
+                    new_connection = self.create_connection(origin)
+                    self._connections.append(new_connection)
+                    pool_request.assign_to_connection(new_connection)
 
         return closing_connections
 

--- a/httpcore/_sync/http11.py
+++ b/httpcore/_sync/http11.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+import random
 import ssl
 import time
 from types import TracebackType
@@ -56,10 +57,12 @@ class HTTP11Connection(ConnectionInterface):
         origin: Origin,
         stream: NetworkStream,
         keepalive_expiry: Optional[float] = None,
+        socket_poll_interval_between: Tuple[float, float] = (1, 3),
     ) -> None:
         self._origin = origin
         self._network_stream = stream
-        self._keepalive_expiry: Optional[float] = keepalive_expiry
+        self._keepalive_expiry = keepalive_expiry
+        self._socket_poll_interval_between = socket_poll_interval_between
         self._expire_at: Optional[float] = None
         self._state = HTTPConnectionState.NEW
         self._state_lock = Lock()
@@ -68,6 +71,8 @@ class HTTP11Connection(ConnectionInterface):
             our_role=h11.CLIENT,
             max_incomplete_event_size=self.MAX_INCOMPLETE_EVENT_SIZE,
         )
+        # Assuming we were just connected
+        self._network_stream_used_at = time.monotonic()
 
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
@@ -173,6 +178,7 @@ class HTTP11Connection(ConnectionInterface):
         bytes_to_send = self._h11_state.send(event)
         if bytes_to_send is not None:
             self._network_stream.write(bytes_to_send, timeout=timeout)
+            self._network_stream_used_at = time.monotonic()
 
     # Receiving the response...
 
@@ -224,6 +230,7 @@ class HTTP11Connection(ConnectionInterface):
                 data = self._network_stream.read(
                     self.READ_NUM_BYTES, timeout=timeout
                 )
+                self._network_stream_used_at = time.monotonic()
 
                 # If we feed this case through h11 we'll raise an exception like:
                 #
@@ -281,16 +288,28 @@ class HTTP11Connection(ConnectionInterface):
     def has_expired(self) -> bool:
         now = time.monotonic()
         keepalive_expired = self._expire_at is not None and now > self._expire_at
+        if keepalive_expired:
+            return True
 
         # If the HTTP connection is idle but the socket is readable, then the
         # only valid state is that the socket is about to return b"", indicating
         # a server-initiated disconnect.
-        server_disconnected = (
-            self._state == HTTPConnectionState.IDLE
-            and self._network_stream.get_extra_info("is_readable")
-        )
+        # Checking the readable status is relatively expensive so check it at a lower frequency.
+        if (now - self._network_stream_used_at) > self._socket_poll_interval():
+            self._network_stream_used_at = now
+            server_disconnected = (
+                self._state == HTTPConnectionState.IDLE
+                and self._network_stream.get_extra_info("is_readable")
+            )
+            if server_disconnected:
+                return True
 
-        return keepalive_expired or server_disconnected
+        return False
+
+    def _socket_poll_interval(self) -> float:
+        # Randomize to avoid polling for all the connections at once
+        low, high = self._socket_poll_interval_between
+        return random.uniform(low, high)
 
     def is_idle(self) -> bool:
         return self._state == HTTPConnectionState.IDLE

--- a/tests/_async/test_http11.py
+++ b/tests/_async/test_http11.py
@@ -1,3 +1,5 @@
+from typing import Any, List
+
 import pytest
 
 import httpcore
@@ -16,7 +18,10 @@ async def test_http11_connection():
         ]
     )
     async with httpcore.AsyncHTTP11Connection(
-        origin=origin, stream=stream, keepalive_expiry=5.0
+        origin=origin,
+        stream=stream,
+        keepalive_expiry=5.0,
+        socket_poll_interval_between=(0, 0),
     ) as conn:
         response = await conn.request("GET", "https://example.com/")
         assert response.status == 200
@@ -48,7 +53,9 @@ async def test_http11_connection_unread_response():
             b"Hello, world!",
         ]
     )
-    async with httpcore.AsyncHTTP11Connection(origin=origin, stream=stream) as conn:
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         async with conn.stream("GET", "https://example.com/") as response:
             assert response.status == 200
 
@@ -70,7 +77,9 @@ async def test_http11_connection_with_remote_protocol_error():
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
     stream = httpcore.AsyncMockStream([b"Wait, this isn't valid HTTP!", b""])
-    async with httpcore.AsyncHTTP11Connection(origin=origin, stream=stream) as conn:
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.RemoteProtocolError):
             await conn.request("GET", "https://example.com/")
 
@@ -99,7 +108,9 @@ async def test_http11_connection_with_incomplete_response():
             b"Hello, wor",
         ]
     )
-    async with httpcore.AsyncHTTP11Connection(origin=origin, stream=stream) as conn:
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.RemoteProtocolError):
             await conn.request("GET", "https://example.com/")
 
@@ -129,7 +140,9 @@ async def test_http11_connection_with_local_protocol_error():
             b"Hello, world!",
         ]
     )
-    async with httpcore.AsyncHTTP11Connection(origin=origin, stream=stream) as conn:
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.LocalProtocolError) as exc_info:
             await conn.request("GET", "https://example.com/", headers={"Host": "\0"})
 
@@ -142,6 +155,85 @@ async def test_http11_connection_with_local_protocol_error():
         assert (
             repr(conn)
             == "<AsyncHTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
+        )
+
+
+@pytest.mark.anyio
+async def test_http11_has_expired_checks_readable_status():
+    class AsyncMockStreamReadable(httpcore.AsyncMockStream):
+        def __init__(self, buffer: List[bytes]) -> None:
+            super().__init__(buffer)
+            self.is_readable = False
+            self.checks = 0
+
+        def get_extra_info(self, info: str) -> Any:
+            if info == "is_readable":
+                self.checks += 1
+                return self.is_readable
+            return super().get_extra_info(info)  # pragma: nocover
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = AsyncMockStreamReadable(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
+        response = await conn.request("GET", "https://example.com/")
+        assert response.status == 200
+
+        assert stream.checks == 0
+        assert not conn.has_expired()
+        stream.is_readable = True
+        assert conn.has_expired()
+        assert stream.checks == 2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("should_check", [True, False])
+async def test_http11_has_expired_checks_readable_status_by_interval(
+    monkeypatch, should_check
+):
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+    async with httpcore.AsyncHTTP11Connection(
+        origin=origin,
+        stream=stream,
+        keepalive_expiry=5.0,
+        socket_poll_interval_between=(0, 0) if should_check else (999, 999),
+    ) as conn:
+        orig = conn._network_stream.get_extra_info
+        calls = []
+
+        def patch_get_extra_info(attr_name: str) -> Any:
+            calls.append(attr_name)
+            return orig(attr_name)
+
+        monkeypatch.setattr(
+            conn._network_stream, "get_extra_info", patch_get_extra_info
+        )
+
+        response = await conn.request("GET", "https://example.com/")
+        assert response.status == 200
+
+        assert "is_readable" not in calls
+        assert not conn.has_expired()
+        assert (
+            ("is_readable" in calls) if should_check else ("is_readable" not in calls)
         )
 
 

--- a/tests/_sync/test_http11.py
+++ b/tests/_sync/test_http11.py
@@ -1,3 +1,5 @@
+from typing import Any, List
+
 import pytest
 
 import httpcore
@@ -16,7 +18,10 @@ def test_http11_connection():
         ]
     )
     with httpcore.HTTP11Connection(
-        origin=origin, stream=stream, keepalive_expiry=5.0
+        origin=origin,
+        stream=stream,
+        keepalive_expiry=5.0,
+        socket_poll_interval_between=(0, 0),
     ) as conn:
         response = conn.request("GET", "https://example.com/")
         assert response.status == 200
@@ -48,7 +53,9 @@ def test_http11_connection_unread_response():
             b"Hello, world!",
         ]
     )
-    with httpcore.HTTP11Connection(origin=origin, stream=stream) as conn:
+    with httpcore.HTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with conn.stream("GET", "https://example.com/") as response:
             assert response.status == 200
 
@@ -70,7 +77,9 @@ def test_http11_connection_with_remote_protocol_error():
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
     stream = httpcore.MockStream([b"Wait, this isn't valid HTTP!", b""])
-    with httpcore.HTTP11Connection(origin=origin, stream=stream) as conn:
+    with httpcore.HTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.RemoteProtocolError):
             conn.request("GET", "https://example.com/")
 
@@ -99,7 +108,9 @@ def test_http11_connection_with_incomplete_response():
             b"Hello, wor",
         ]
     )
-    with httpcore.HTTP11Connection(origin=origin, stream=stream) as conn:
+    with httpcore.HTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.RemoteProtocolError):
             conn.request("GET", "https://example.com/")
 
@@ -129,7 +140,9 @@ def test_http11_connection_with_local_protocol_error():
             b"Hello, world!",
         ]
     )
-    with httpcore.HTTP11Connection(origin=origin, stream=stream) as conn:
+    with httpcore.HTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
         with pytest.raises(httpcore.LocalProtocolError) as exc_info:
             conn.request("GET", "https://example.com/", headers={"Host": "\0"})
 
@@ -142,6 +155,85 @@ def test_http11_connection_with_local_protocol_error():
         assert (
             repr(conn)
             == "<HTTP11Connection ['https://example.com:443', CLOSED, Request Count: 1]>"
+        )
+
+
+
+def test_http11_has_expired_checks_readable_status():
+    class MockStreamReadable(httpcore.MockStream):
+        def __init__(self, buffer: List[bytes]) -> None:
+            super().__init__(buffer)
+            self.is_readable = False
+            self.checks = 0
+
+        def get_extra_info(self, info: str) -> Any:
+            if info == "is_readable":
+                self.checks += 1
+                return self.is_readable
+            return super().get_extra_info(info)  # pragma: nocover
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = MockStreamReadable(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+    with httpcore.HTTP11Connection(
+        origin=origin, stream=stream, socket_poll_interval_between=(0, 0)
+    ) as conn:
+        response = conn.request("GET", "https://example.com/")
+        assert response.status == 200
+
+        assert stream.checks == 0
+        assert not conn.has_expired()
+        stream.is_readable = True
+        assert conn.has_expired()
+        assert stream.checks == 2
+
+
+
+@pytest.mark.parametrize("should_check", [True, False])
+def test_http11_has_expired_checks_readable_status_by_interval(
+    monkeypatch, should_check
+):
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.MockStream(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+    with httpcore.HTTP11Connection(
+        origin=origin,
+        stream=stream,
+        keepalive_expiry=5.0,
+        socket_poll_interval_between=(0, 0) if should_check else (999, 999),
+    ) as conn:
+        orig = conn._network_stream.get_extra_info
+        calls = []
+
+        def patch_get_extra_info(attr_name: str) -> Any:
+            calls.append(attr_name)
+            return orig(attr_name)
+
+        monkeypatch.setattr(
+            conn._network_stream, "get_extra_info", patch_get_extra_info
+        )
+
+        response = conn.request("GET", "https://example.com/")
+        assert response.status == 200
+
+        assert "is_readable" not in calls
+        assert not conn.has_expired()
+        assert (
+            ("is_readable" in calls) if should_check else ("is_readable" not in calls)
         )
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Second PR in series of optimizations to improve performance of `httpcore` and even reach performance levels of `aiohttp` (and `urllib3` library).
Related discussion https://github.com/encode/httpx/issues/3215#issuecomment-2157885121

Optimizes the connection pool by reducing the time complexity of the idling connections checks. Also it no longer checks the sockets readable status on every pool operation. Pools `has_expired` check uses socket polling via `is_readable` check which is relatively expensive. So now the polling is done using smudged intervals (smudging to avoid all polls being done at the exactly same time). This still should have relatively low chance of encountering broken keep alive connections when connection is picked up from the pool.

**Async** previously:
![old1](https://github.com/encode/httpcore/assets/12939780/11f433c1-3ee9-46ac-ae9a-2888f62f251f)

**Async** with PR:
![new2](https://github.com/encode/httpcore/assets/12939780/e811fcb1-626d-4463-bba7-2d1926e64e96)

Async request latency is not so stable yet (as this doesn't include https://github.com/encode/httpcore/pull/922) but the overall duration of the [benchmark](https://github.com/encode/httpcore/pull/923) improves by 7.5x. (The difference diminishes when server latency increases over 100ms or so.)

**Sync** previously:
![sync_old](https://github.com/encode/httpcore/assets/12939780/312c801e-81bc-40ac-b062-9d76347babbf)

**Sync** with PR:
![sync_new](https://github.com/encode/httpcore/assets/12939780/11bb0ed7-675c-40d1-af0d-c12a1ec5b542)

Sync request latency improves by x2.5. With this `httpcore` has same performance as `urllib3` library.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
