### PR TITLE
Add context to trace functions

### DIFF
--- a/httpcore/_trace.py
+++ b/httpcore/_trace.py
@@ -24,11 +24,12 @@ class Trace:
         self.return_value: Any = None
         self.should_trace = self.debug or self.trace_extension is not None
         self.prefix = self.logger.name.split(".")[-1]
+        self.context: Dict[str, Any] = {}
 
     def trace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
             prefix_and_name = f"{self.prefix}.{name}"
-            ret = self.trace_extension(prefix_and_name, info)
+            ret = self.trace_extension(prefix_and_name, info, self.context)
             if inspect.iscoroutine(ret):  # pragma: no cover
                 raise TypeError(
                     "If you are using a synchronous interface, "
@@ -67,7 +68,7 @@ class Trace:
     async def atrace(self, name: str, info: Dict[str, Any]) -> None:
         if self.trace_extension is not None:
             prefix_and_name = f"{self.prefix}.{name}"
-            coro = self.trace_extension(prefix_and_name, info)
+            coro = self.trace_extension(prefix_and_name, info, self.context)
             if not inspect.iscoroutine(coro):  # pragma: no cover
                 raise TypeError(
                     "If you're using an asynchronous interface, "


### PR DESCRIPTION
This PR adds context to the traces, giving us more control over them and providing context for particular events. It allows us to store variables specifically for that event and access them through the started, complete, or failed stages.

Originally, I tried to add metrics for the httpx client to measure how much time the SSL handshake took. I thought it would be amazing to have some context for the trace functions.

Here is the example of usecase, from the documentation:

```python
import httpcore
import time


def log(event_name, info, context):
    _, event_name, stage = event_name.split(".")
    if event_name == "start_tls":
        if stage == "started":
            context["start_time"] = time.monotonic()
        elif stage == "complete":
            elapsed = time.monotonic() - context["start_time"]
            print(f"TLS handshake took {elapsed:.2f} seconds")


r = httpcore.request("GET", "https://www.encode.io/", extensions={"trace": log})
```