### PR TITLE
fix(h2_connection_reset): add stream reset when client cancel the req…

### DIFF
--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -401,6 +401,9 @@ class HTTP2Connection(ConnectionInterface):
                     self._max_streams_semaphore.acquire()
                     self._max_streams -= 1
 
+    def _reset_steam(self, stream_id: int, error_code: int) -> None:
+        self._h2_state.reset_stream(stream_id=stream_id, error_code=error_code)
+
     def _response_closed(self, stream_id: int) -> None:
         self._max_streams_semaphore.release()
         del self._events[stream_id]
@@ -578,6 +581,12 @@ class HTTP2ConnectionByteStream:
             # we want to close the response (and possibly the connection)
             # before raising that exception.
             with ShieldCancellation():
+                # need send cancel frame when the exception is not from remote peer.
+                if not isinstance(exc, RemoteProtocolError):
+                    self._connection._reset_steam(
+                        stream_id=self._stream_id,
+                        error_code=h2.settings.ErrorCodes.CANCEL,
+                    )
                 self.close()
             raise exc
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

add the missing connection reset of h2 connection when client cancel the request.

fix #943

in discussion with #941 
