### PR TITLE
Handle `trio` raising `NotImplementedError` on unsupported platforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Handle `SSLError` exception. (#918)
+- Handle `trio` raising `NotImplementedError` on unsupported platforms. (#955)
+- Handle mapping `ssl.SSLError` to `httpcore.ConnectError`. (#918)
 
 ## 1.0.5 (March 27th, 2024)
 

--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -104,9 +104,9 @@ class AnyIOBackend(AsyncNetworkBackend):
         timeout: typing.Optional[float] = None,
         local_address: typing.Optional[str] = None,
         socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
-    ) -> AsyncNetworkStream:
+    ) -> AsyncNetworkStream:  # pragma: nocover
         if socket_options is None:
-            socket_options = []  # pragma: no cover
+            socket_options = []
         exc_map = {
             TimeoutError: ConnectTimeout,
             OSError: ConnectError,
@@ -120,7 +120,7 @@ class AnyIOBackend(AsyncNetworkBackend):
                     local_host=local_address,
                 )
                 # By default TCP sockets opened in `asyncio` include TCP_NODELAY.
-                for option in socket_options:  # pragma: nocover
+                for option in socket_options:
                     stream._raw_socket.setsockopt(*option)  # type: ignore[attr-defined] # pragma: no cover
         return AnyIOStream(stream)
 

--- a/httpcore/_synchronization.py
+++ b/httpcore/_synchronization.py
@@ -9,7 +9,7 @@ from ._exceptions import ExceptionMapping, PoolTimeout, map_exceptions
 
 try:
     import trio
-except ImportError:  # pragma: nocover
+except (ImportError, NotImplementedError):  # pragma: nocover
     trio = None  # type: ignore
 
 try:


### PR DESCRIPTION
Closes #946
