### PR TITLE
Update trio dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ socks = [
     "socksio==1.*",
 ]
 trio = [
-    "trio>=0.22.0,<0.26.0",
+    "trio>=0.22.0,<1.0",
 ]
 asyncio = [
     "anyio>=4.0,<5.0",


### PR DESCRIPTION
Relax `trio` dependency pinning upper bound to `<1.0`.

Trio's versioning has been extremely careful.
I think we can feel confident enough with this.

Prompted by https://github.com/encode/httpcore/pull/922#issuecomment-2361111584 - thanks @agronholm.