### PR TITLE
Added httpcore.SSLError and redirect TLS handshake errors to it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Added httpcore.SSLError and redirect TLS handshake errors to it. (#960)
+
 ## Version 1.0.6 (October 1st, 2024)
 
 - Relax `trio` dependency pinning. (#956)

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -9,6 +9,7 @@ The following exceptions may be raised when sending a request:
     * `httpcore.WriteTimeout`
 * `httpcore.NetworkError`
     * `httpcore.ConnectError`
+        * `httpcore.SSLError`
     * `httpcore.ReadError`
     * `httpcore.WriteError`
 * `httpcore.ProtocolError`

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -29,6 +29,7 @@ from ._exceptions import (
     ReadError,
     ReadTimeout,
     RemoteProtocolError,
+    SSLError,
     TimeoutException,
     UnsupportedProtocol,
     WriteError,
@@ -128,6 +129,7 @@ __all__ = [
     "ConnectError",
     "ReadError",
     "WriteError",
+    "SSLError",
 ]
 
 __version__ = "1.0.6"

--- a/httpcore/_backends/anyio.py
+++ b/httpcore/_backends/anyio.py
@@ -8,6 +8,7 @@ from .._exceptions import (
     ConnectTimeout,
     ReadError,
     ReadTimeout,
+    SSLError,
     WriteError,
     WriteTimeout,
     map_exceptions,
@@ -64,7 +65,7 @@ class AnyIOStream(AsyncNetworkStream):
             TimeoutError: ConnectTimeout,
             anyio.BrokenResourceError: ConnectError,
             anyio.EndOfStream: ConnectError,
-            ssl.SSLError: ConnectError,
+            ssl.SSLError: SSLError,
         }
         with map_exceptions(exc_map):
             try:

--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -1,4 +1,5 @@
 import contextlib
+import ssl
 from typing import Iterator, Mapping, Type
 
 ExceptionMapping = Mapping[Type[Exception], Type[Exception]]
@@ -78,4 +79,8 @@ class ReadError(NetworkError):
 
 
 class WriteError(NetworkError):
+    pass
+
+
+class SSLError(ssl.SSLError, ConnectError):
     pass


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Discussed at https://github.com/encode/httpx/discussions/3214.
`httpcore.SSLError` is subclass of `httpcore.ConnectError`, so it's backward compatible.
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
