### PR TITLE
default port for the socks5h scheme

### DIFF
--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -284,6 +284,7 @@ class URL:
             b"ws": 80,
             b"wss": 443,
             b"socks5": 1080,
+            b"socks5h": 1080,
         }[self.scheme]
         return Origin(
             scheme=self.scheme, host=self.host, port=self.port or default_port

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -43,11 +43,15 @@ def test_url_cannot_include_unicode_strings():
 
 def test_url_origin_socks5():
     url = httpcore.URL("socks5://127.0.0.1")
-    assert url.origin == httpcore.Origin(scheme=b"socks5", host=b"127.0.0.1", port=1080)
+    assert url.origin == httpcore.Origin(
+        scheme=b"socks5", host=b"127.0.0.1", port=1080
+    )
     assert str(url.origin) == "socks5://127.0.0.1:1080"
 
     url = httpcore.URL("socks5h://127.0.0.1")
-    assert url.origin == httpcore.Origin(scheme=b"socks5h", host=b"127.0.0.1", port=1080)
+    assert url.origin == httpcore.Origin(
+        scheme=b"socks5h", host=b"127.0.0.1", port=1080
+    )
     assert str(url.origin) == "socks5h://127.0.0.1:1080"
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,6 +41,16 @@ def test_url_cannot_include_unicode_strings():
     httpcore.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode("utf-8"))
 
 
+def test_url_origin_socks5():
+    url = httpcore.URL("socks5://127.0.0.1")
+    assert url.origin == httpcore.Origin(scheme=b"socks5", host=b"127.0.0.1", port=1080)
+    assert str(url.origin) == "socks5://127.0.0.1:1080"
+
+    url = httpcore.URL("socks5h://127.0.0.1")
+    assert url.origin == httpcore.Origin(scheme=b"socks5h", host=b"127.0.0.1", port=1080)
+    assert str(url.origin) == "socks5h://127.0.0.1:1080"
+
+
 # Request
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -43,16 +43,14 @@ def test_url_cannot_include_unicode_strings():
 
 def test_url_origin_socks5():
     url = httpcore.URL("socks5://127.0.0.1")
-    assert url.origin == httpcore.Origin(
-        scheme=b"socks5", host=b"127.0.0.1", port=1080
-    )
-    assert str(url.origin) == "socks5://127.0.0.1:1080"
+    origin = url.origin
+    assert origin == httpcore.Origin(scheme=b"socks5", host=b"127.0.0.1", port=1080)
+    assert str(origin) == "socks5://127.0.0.1:1080"
 
     url = httpcore.URL("socks5h://127.0.0.1")
-    assert url.origin == httpcore.Origin(
-        scheme=b"socks5h", host=b"127.0.0.1", port=1080
-    )
-    assert str(url.origin) == "socks5h://127.0.0.1:1080"
+    origin = url.origin
+    assert origin == httpcore.Origin(scheme=b"socks5h", host=b"127.0.0.1", port=1080)
+    assert str(origin) == "socks5h://127.0.0.1:1080"
 
 
 # Request


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
This change is needed to unblock https://github.com/encode/httpx/pull/3178 and support `socks5h` scheme (server-side hostname resolution socks5 proxy). Support for the `socks5h` is needed to ensure global environment variables like `all_proxy="socks5h://..."` can be used reliably with different programs (some of which are httpx based).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
