### PR TITLE
Version 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## Version 1.0.7 (November 15th, 2024)
 
-- Support `proxy=…` configuration on `ConnectionPool()`.
+- Support `proxy=…` configuration on `ConnectionPool()`. (#974)
 
 ## Version 1.0.6 (October 1st, 2024)
 

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -131,7 +131,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 __locals = locals()


### PR DESCRIPTION
## Version 1.0.7 (November 15th, 2024)

- Support `proxy=…` configuration on `ConnectionPool()`. (#974)

---

Docs... https://github.com/encode/httpcore/blob/master/docs/proxies.md