### PR TITLE
Fix `AttributeError` when importing on Python 3.14

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -136,5 +136,6 @@ __version__ = "1.0.7"
 
 __locals = locals()
 for __name in __all__:
+    # Exclude SOCKET_OPTION, it causes AttributeError on Python 3.14
     if not __name.startswith(("__", "SOCKET_OPTION")):
         setattr(__locals[__name], "__module__", "httpcore")  # noqa

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -136,5 +136,5 @@ __version__ = "1.0.7"
 
 __locals = locals()
 for __name in __all__:
-    if not __name.startswith("__"):
+    if not __name.startswith(("__", "SOCKET_OPTION")):
         setattr(__locals[__name], "__module__", "httpcore")  # noqa


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Fixes https://github.com/encode/httpcore/discussions/995.

On Python 3.14, we get an `AttributeError` on import:

```pytb
❯ python3.14
Python 3.14.0a7 (v3.14.0a7:29af6cee02f, Apr  8 2025, 07:53:42) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import httpcore
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import httpcore
  File "/private/tmp/httpcore/httpcore/httpcore/__init__.py", line 140, in <module>
    setattr(__locals[__name], "__module__", "httpcore")  # noqa
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting new attributes. Did you mean: '__reduce__'?
```

This is caused by `SOCKET_OPTION`, let's exclude it:

```pycon
❯ python3.14
Python 3.14.0a7 (v3.14.0a7:29af6cee02f, Apr  8 2025, 07:53:42) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import httpcore
>>>
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
