### PR TITLE
Version 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 1.0.9 (April 24th, 2025)
+
+- Resolve https://github.com/advisories/GHSA-vqfr-h8mv-ghfj with h11 dependency update. (#1008)
+
 ## Version 1.0.8 (April 11th, 2025)
 
 - Fix `AttributeError` when importing on Python 3.14. (#1005)

--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -131,7 +131,7 @@ __all__ = [
     "WriteError",
 ]
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 
 __locals = locals()


### PR DESCRIPTION
## Version 1.0.9 (April 24th, 2025)

- Resolving https://github.com/advisories/GHSA-vqfr-h8mv-ghfj with h11 dependency update. (#1008)