### PR TITLE
prioritize h2

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -143,7 +143,7 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                         if self._ssl_context is None
                         else self._ssl_context
                     )
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                    alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                     ssl_context.set_alpn_protocols(alpn_protocols)
 
                     kwargs = {

--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -143,7 +143,11 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
                         if self._ssl_context is None
                         else self._ssl_context
                     )
-                    alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
+                    alpn_protocols = []
+                    if self._http2:
+                        alpn_protocols.append("h2")
+                    if self._http1:
+                        alpn_protocols.append("http/1.1")
                     ssl_context.set_alpn_protocols(alpn_protocols)
 
                     kwargs = {

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -304,7 +304,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     if self._ssl_context is None
                     else self._ssl_context
                 )
-                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
                 kwargs = {

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -304,7 +304,11 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     if self._ssl_context is None
                     else self._ssl_context
                 )
-                alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
+                alpn_protocols = []
+                if self._http2:
+                    alpn_protocols.append("h2")
+                if self._http1:
+                    alpn_protocols.append("http/1.1")
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
                 kwargs = {

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -251,9 +251,11 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                             if self._ssl_context is None
                             else self._ssl_context
                         )
-                        alpn_protocols = (
-                            ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
-                        )
+                        alpn_protocols = []
+                        if self._http2:
+                            alpn_protocols.append("h2")
+                        if self._http1:
+                            alpn_protocols.append("http/1.1")
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
                         kwargs = {

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -252,7 +252,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                             else self._ssl_context
                         )
                         alpn_protocols = (
-                            ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                            ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                         )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -143,7 +143,7 @@ class HTTPConnection(ConnectionInterface):
                         if self._ssl_context is None
                         else self._ssl_context
                     )
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                    alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                     ssl_context.set_alpn_protocols(alpn_protocols)
 
                     kwargs = {

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -143,7 +143,11 @@ class HTTPConnection(ConnectionInterface):
                         if self._ssl_context is None
                         else self._ssl_context
                     )
-                    alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
+                    alpn_protocols = []
+                    if self._http2:
+                        alpn_protocols.append("h2")
+                    if self._http1:
+                        alpn_protocols.append("http/1.1")
                     ssl_context.set_alpn_protocols(alpn_protocols)
 
                     kwargs = {

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -304,7 +304,7 @@ class TunnelHTTPConnection(ConnectionInterface):
                     if self._ssl_context is None
                     else self._ssl_context
                 )
-                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
                 kwargs = {

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -304,7 +304,11 @@ class TunnelHTTPConnection(ConnectionInterface):
                     if self._ssl_context is None
                     else self._ssl_context
                 )
-                alpn_protocols = ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
+                alpn_protocols = []
+                if self._http2:
+                    alpn_protocols.append("h2")
+                if self._http1:
+                    alpn_protocols.append("http/1.1")
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
                 kwargs = {

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -251,9 +251,11 @@ class Socks5Connection(ConnectionInterface):
                             if self._ssl_context is None
                             else self._ssl_context
                         )
-                        alpn_protocols = (
-                            ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
-                        )
+                        alpn_protocols = []
+                        if self._http2:
+                            alpn_protocols.append("h2")
+                        if self._http1:
+                            alpn_protocols.append("http/1.1")
                         ssl_context.set_alpn_protocols(alpn_protocols)
 
                         kwargs = {

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -252,7 +252,7 @@ class Socks5Connection(ConnectionInterface):
                             else self._ssl_context
                         )
                         alpn_protocols = (
-                            ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
+                            ["h2", "http/1.1"] if self._http2 else ["http/1.1"]
                         )
                         ssl_context.set_alpn_protocols(alpn_protocols)
 

--- a/tests/_async/test_socks_proxy.py
+++ b/tests/_async/test_socks_proxy.py
@@ -27,6 +27,8 @@ async def test_socks5_request():
     async with httpcore.AsyncConnectionPool(
         proxy=httpcore.Proxy("socks5://localhost:8080/"),
         network_backend=network_backend,
+        # We also enable h2, but will negotiated http1.1
+        http2=True,
     ) as proxy:
         # Sending an intial request, which once complete will return to the pool, IDLE.
         async with proxy.stream("GET", "https://example.com/") as response:

--- a/tests/_sync/test_socks_proxy.py
+++ b/tests/_sync/test_socks_proxy.py
@@ -27,6 +27,8 @@ def test_socks5_request():
     with httpcore.ConnectionPool(
         proxy=httpcore.Proxy("socks5://localhost:8080/"),
         network_backend=network_backend,
+        # We also enable h2, but will negotiated http1.1
+        http2=True,
     ) as proxy:
         # Sending an intial request, which once complete will return to the pool, IDLE.
         with proxy.stream("GET", "https://example.com/") as response:


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

When using h2 give it priority in tls alpn. In general order of tls alpn is important and servers mostly choose the first version that they support, by setting http1.1 first most server will actually negotiate http1.1

Also don't specify http1.1 if only h2 is enabled. This could otherwise lead to negotiating something that is not supported, which was especially bad when the wrong order was used.

Found this actually when forcing httpcore to use h2 only and then wireshark failing to decode traffic because tls negotiated http1.1 but we were actually using h2

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
