### PR TITLE
Dependabot: Monthly upgrades to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
           - "*"
         exclude-patterns:
           - "werkzeug"
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Dependabot: Monthly upgrades to GitHub Actions

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

GitHub Actions are only used at CI test-time, while most other dependencies are also used at runtime.  This means that if the CI tests pass, maintainers have more confidence that the proposed changes will not break runtime.  

GitHub Actions have very infrequent major version changes .  `setup-python`, the most frequent, has only had five major upgrades in its lifetime.

When GitHub Actions are upgraded, it often happens in batches.  The `pattern: *` proposed in this PR will consolidate all GHA updates into a single pull request to further reduce chattiness.  Please see the example output provided above.

There is a tradeoff between supply chain security and chattiness.  Given that we have a few GHAs that are updated rarely and usually in batches, and we are using `pattern: *` to ensure that ___there will only ever be a single GHA upgrade PR at a time___.