### PR TITLE
GitHub Actions: Add Python 3.14t to the testing

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,18 +13,20 @@ jobs:
     runs-on: "ubuntu-latest"
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/checkout@v5"
+      - uses: "actions/setup-python@v6"
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Run linting checks"
+        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
         run: "scripts/check"
       - name: "Build package & docs"
         run: "scripts/build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,9 @@ coverage[toml]==7.5.4
 ruff==0.5.0
 mypy==1.10.1
 trio-typing==0.10.0
+pycparser==2.23 ; python_version >= "3.14"
 pytest==8.2.2
-pytest-httpbin==2.0.0
+pytest-httpbin==2.1.0
 pytest-trio==0.8.0
 werkzeug<3.1  # See: https://github.com/psf/httpbin/issues/35
 
@@ -26,5 +27,7 @@ werkzeug<3.1  # See: https://github.com/psf/httpbin/issues/35
 uvicorn==0.30.1
 aiohttp==3.10.2
 urllib3==2.2.2
-matplotlib==3.7.5
+matplotlib==3.7.5 ; python_version < "3.10"
+matplotlib==3.10.7 ; python_version >= "3.10"
 pyinstrument==4.6.2
+

--- a/tests/benchmark/client.py
+++ b/tests/benchmark/client.py
@@ -7,10 +7,10 @@ from contextlib import contextmanager
 from typing import Any, Callable, Coroutine, Iterator, List
 
 import aiohttp
-import matplotlib.pyplot as plt  # type: ignore[import-untyped]
+import matplotlib.pyplot as plt
 import pyinstrument
 import urllib3
-from matplotlib.axes import Axes  # type: ignore[import-untyped]
+from matplotlib.axes import Axes
 
 import httpcore
 


### PR DESCRIPTION
Python 3.14 (the π version) was released today.
* https://www.python.org/downloads/release/python-3140/
* https://github.com/actions/python-versions/releases

Installing numpy v1 (1.26.4) fails on Python 3.14t. -- https://pypi.org/project/numpy
% `uvx --python=3.14 numpy=="1.*" --version ` # Fails.
--> Upgrade `matpotlib`

Free-threaded Python 3.14t is blocked by:
* [x] ~python-hyper/brotlicffi#205~
* [ ] python-hyper/brotlicffi#206 ___REVERTED___
* [ ] A release of https://pypi.org/project/brotlicffi > ~`1.1.0.0`~ `1.2.0.0`

<!-- Thanks for contributing to HTTP Core! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
