### PR TITLE
fix: handle http2 goaway race conditions

### DIFF
--- a/httpcore/__init__.py
+++ b/httpcore/__init__.py
@@ -19,6 +19,7 @@ from ._backends.mock import AsyncMockBackend, AsyncMockStream, MockBackend, Mock
 from ._backends.sync import SyncBackend
 from ._exceptions import (
     ConnectError,
+    ConnectionGoingAway,
     ConnectionNotAvailable,
     ConnectTimeout,
     LocalProtocolError,
@@ -114,6 +115,7 @@ __all__ = [
     "default_ssl_context",
     "SOCKET_OPTION",
     # exceptions
+    "ConnectionGoingAway",
     "ConnectionNotAvailable",
     "ProxyError",
     "ProtocolError",

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -261,7 +261,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
                         # Likely safe to retry.
                         continue
                     else:
-                        # Request may have been processed. Propagate error with context so application can decide whether to retry.
+                        # Request may have been processed. Propagate error with context so application can decide
+                        # whether to retry.
                         msg = "GOAWAY recieved: request may have been processed"
                         # QUESTION: What is the best way to propagate the context for the applications?
                         raise RemoteProtocolError(msg) from exc

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -7,7 +7,12 @@ import typing
 
 from .._backends.auto import AutoBackend
 from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend
-from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
+from .._exceptions import (
+    ConnectionGoingAway,
+    ConnectionNotAvailable,
+    RemoteProtocolError,
+    UnsupportedProtocol,
+)
 from .._models import Origin, Proxy, Request, Response
 from .._synchronization import AsyncEvent, AsyncShieldCancellation, AsyncThreadLock
 from .connection import AsyncHTTPConnection
@@ -242,6 +247,26 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     #
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
+                except ConnectionGoingAway as exc:
+                    # GOAWAY frame recieved during request processing.
+                    # Determine if we can safely retry based on RFC 7540 semantics.
+                    pool_request.clear_connection()
+
+                    if exc.is_safe_to_retry:
+                        # stream_id > last_stream_id: guaranteed unprocessed per RFC 7540
+                        # Safe to retry on a new connection
+                        continue
+                    elif exc.is_graceful_shutdown and not exc.may_have_side_effects:
+                        # Graceful shutdown and headers weren't sent yet.
+                        # Likely safe to retry.
+                        continue
+                    else:
+                        # Request may have been processed. Propagate error with context so application can decide whether to retry.
+                        msg = (
+                            "GOAWAY recieved: request may have been processed"
+                        )
+                        # QUESTION: What is the best way to propagate the context for the applications?
+                        raise RemoteProtocolError(msg) from exc
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -262,9 +262,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                         continue
                     else:
                         # Request may have been processed. Propagate error with context so application can decide whether to retry.
-                        msg = (
-                            "GOAWAY recieved: request may have been processed"
-                        )
+                        msg = "GOAWAY recieved: request may have been processed"
                         # QUESTION: What is the best way to propagate the context for the applications?
                         raise RemoteProtocolError(msg) from exc
                 else:

--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -241,15 +241,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     response = await connection.handle_async_request(
                         pool_request.request
                     )
-                except ConnectionNotAvailable:
-                    # In some cases a connection may initially be available to
-                    # handle a request, but then become unavailable.
-                    #
-                    # In this case we clear the connection and try again.
-                    pool_request.clear_connection()
                 except ConnectionGoingAway as exc:
                     # GOAWAY frame recieved during request processing.
                     # Determine if we can safely retry based on RFC 7540 semantics.
+                    # NOTE: This must be caught before ConnectionNotAvailable since
+                    # ConnectionGoingAway is a subclass of ConnectionNotAvailable.
                     pool_request.clear_connection()
 
                     if exc.is_safe_to_retry:
@@ -266,6 +262,12 @@ class AsyncConnectionPool(AsyncRequestInterface):
                         msg = "GOAWAY recieved: request may have been processed"
                         # QUESTION: What is the best way to propagate the context for the applications?
                         raise RemoteProtocolError(msg) from exc
+                except ConnectionNotAvailable:
+                    # In some cases a connection may initially be available to
+                    # handle a request, but then become unavailable.
+                    #
+                    # In this case we clear the connection and try again.
+                    pool_request.clear_connection()
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -141,7 +141,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
             # Initialize phase tracking for this stream
-            self._stream_requests[stream_id] = {"headers_sent": False, "body_sent": False}
+            self._stream_requests[stream_id] = {
+                "headers_sent": False,
+                "body_sent": False,
+            }
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
             self._used_all_stream_ids = True
             self._request_count -= 1
@@ -191,7 +194,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 # it as a ConnectionGoingAway if applicable, or RemoteProtocolError.
                 if self._connection_terminated:  # pragma: nocover
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False},
+                        stream_id,
+                        {"headers_sent": False, "body_sent": False},
                     )
                     raise ConnectionGoingAway(
                         self._connection_terminated,
@@ -203,15 +207,19 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                     )
                 # Check if h2 is in CLOSED state due to GOAWAY. This can happen when
                 # GOAWAY was recieved but we haven't processed the event yet (race condition).
-                if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                if (
+                    self._h2_state.state_machine.state
+                    == h2.connection.ConnectionState.CLOSED
+                ):
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False},
+                        stream_id,
+                        {"headers_sent": False, "body_sent": False},
                     )
                     msg = f"Connection closed: {exc}"
                     raise ConnectionGoingAway(
                         msg,
-                        last_stream_id=stream_id, # Conservative: assume this stream may have been processed
-                        error_code=0, # Assume graceful shutdown
+                        last_stream_id=stream_id,  # Conservative: assume this stream may have been processed
+                        error_code=0,  # Assume graceful shutdown
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -405,7 +413,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         # stream_id <= last_stream_id: may have been processed
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
-                            last_stream_id=last_stream_id if last_stream_id is not None else 0,
+                            last_stream_id=last_stream_id
+                            if last_stream_id is not None
+                            else 0,
                             error_code=self._connection_terminated.error_code,
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
@@ -527,7 +537,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                             body_sent=phase["body_sent"],
                         )
                     # Check if h2 is in CLOSED state (GOAWAY received but not processed)
-                    if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                    if (
+                        self._h2_state.state_machine.state
+                        == h2.connection.ConnectionState.CLOSED
+                    ):
                         raise ConnectionGoingAway(
                             "Server disconnected (connection closed)",
                             last_stream_id=stream_id,  # Conservative
@@ -605,7 +618,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     def is_available(self) -> bool:
         return (
-            self._state not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
+            self._state
+            not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -198,9 +198,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         {"headers_sent": False, "body_sent": False},
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated, # type: ignore[arg-type]
-                        last_stream_id=self._connection_terminated.last_stream_id, # type: ignore[arg-type]
-                        error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                        self._connection_terminated,  # type: ignore[arg-type]
+                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type]
+                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -404,7 +404,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -416,7 +416,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                             last_stream_id=last_stream_id
                             if last_stream_id is not None
                             else 0,
-                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -531,7 +531,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -195,7 +195,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 if self._connection_terminated:  # pragma: nocover
                     phase = self._stream_requests.get(
                         stream_id,
-                        {"headers_sent": False, "body_sent": False},
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     raise ConnectionGoingAway(
                         self._connection_terminated,  # type: ignore[arg-type]
@@ -213,7 +216,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 ):
                     phase = self._stream_requests.get(
                         stream_id,
-                        {"headers_sent": False, "body_sent": False},
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     msg = f"Connection closed: {exc}"
                     raise ConnectionGoingAway(
@@ -396,7 +402,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 last_stream_id = self._connection_terminated.last_stream_id
                 if stream_id is not None:
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False}
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     if last_stream_id is not None and stream_id > last_stream_id:
                         # stream_id > last_stream_id: guaranteed unprocessed, safe to retry
@@ -523,7 +533,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 # Server disconnected. Check if this is related to GOAWAY.
                 if stream_id is not None:
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False}
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     # If we have a GOAWAY recorded, this disconnect is GOAWAY-related
                     if self._connection_terminated is not None:

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -549,6 +549,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
                         )
+                raise RemoteProtocolError("Server disconnected")
         except Exception as exc:
             # If we get a network error we should:
             #

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -198,9 +198,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         {"headers_sent": False, "body_sent": False},
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated,
-                        last_stream_id=self._connection_terminated.last_stream_id,
-                        error_code=self._connection_terminated.error_code,
+                        self._connection_terminated, # type: ignore[arg-type]
+                        last_stream_id=self._connection_terminated.last_stream_id, # type: ignore[arg-type]
+                        error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -404,7 +404,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -416,7 +416,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                             last_stream_id=last_stream_id
                             if last_stream_id is not None
                             else 0,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -531,7 +531,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -14,6 +14,7 @@ import h2.settings
 
 from .._backends.base import AsyncNetworkStream
 from .._exceptions import (
+    ConnectionGoingAway,
     ConnectionNotAvailable,
     LocalProtocolError,
     RemoteProtocolError,
@@ -36,7 +37,8 @@ def has_body_headers(request: Request) -> bool:
 class HTTPConnectionState(enum.IntEnum):
     ACTIVE = 1
     IDLE = 2
-    CLOSED = 3
+    DRAINING = 3
+    CLOSED = 4
 
 
 class AsyncHTTP2Connection(AsyncConnectionInterface):
@@ -81,6 +83,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         self._read_exception: Exception | None = None
         self._write_exception: Exception | None = None
+
+        # Track request phases for GOAWAY retry safety determination.
+        # Maps stream_id -> {"headers_sent": bool, "body_sent": bool}
+        # TODO: Consider shifting this to a dataclass or typeddict
+        self._stream_requests: dict[int, dict[str, bool]] = {}
 
     async def handle_async_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
@@ -133,6 +140,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
+            # Initialize phase tracking for this stream
+            self._stream_requests[stream_id] = {"headers_sent": False, "body_sent": False}
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
             self._used_all_stream_ids = True
             self._request_count -= 1
@@ -142,8 +151,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             kwargs = {"request": request, "stream_id": stream_id}
             async with Trace("send_request_headers", logger, request, kwargs):
                 await self._send_request_headers(request=request, stream_id=stream_id)
+            self._stream_requests[stream_id]["headers_sent"] = True
             async with Trace("send_request_body", logger, request, kwargs):
                 await self._send_request_body(request=request, stream_id=stream_id)
+            self._stream_requests[stream_id]["body_sent"] = True
             async with Trace(
                 "receive_response_headers", logger, request, kwargs
             ) as trace:
@@ -177,9 +188,35 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 # a protocol error at any point they interact with the 'h2_state'.
                 #
                 # In this case we'll have stored the event, and should raise
-                # it as a RemoteProtocolError.
+                # it as a ConnectionGoingAway if applicable, or RemoteProtocolError.
                 if self._connection_terminated:  # pragma: nocover
-                    raise RemoteProtocolError(self._connection_terminated)
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False},
+                    )
+                    raise ConnectionGoingAway(
+                        self._connection_terminated,
+                        last_stream_id=self._connection_terminated.last_stream_id,
+                        error_code=self._connection_terminated.error_code,
+                        request_stream_id=stream_id,
+                        headers_sent=phase["headers_sent"],
+                        body_sent=phase["body_sent"],
+                    )
+                # Check if h2 is in CLOSED state due to GOAWAY. This can happen when
+                # GOAWAY was recieved but we haven't processed the event yet (race condition).
+                if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False},
+                    )
+                    msg = f"Connection closed: {exc}"
+                    raise ConnectionGoingAway(
+                        msg,
+                        last_stream_id=stream_id, # Conservative: assume this stream may have been processed
+                        error_code=0, # Assume graceful shutdown
+                        request_stream_id=stream_id,
+                        headers_sent=phase["headers_sent"],
+                        body_sent=phase["body_sent"],
+                    )
+
                 # If h2 raises a protocol error in some other state then we
                 # must somehow have made a protocol violation.
                 raise LocalProtocolError(exc)  # pragma: nocover
@@ -349,10 +386,33 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         async with self._read_lock:
             if self._connection_terminated is not None:
                 last_stream_id = self._connection_terminated.last_stream_id
-                if stream_id and last_stream_id and stream_id > last_stream_id:
-                    self._request_count -= 1
-                    raise ConnectionNotAvailable()
-                raise RemoteProtocolError(self._connection_terminated)
+                if stream_id is not None:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False}
+                    )
+                    if last_stream_id is not None and stream_id > last_stream_id:
+                        # stream_id > last_stream_id: guaranteed unprocessed, safe to retry
+                        self._request_count -= 1
+                        raise ConnectionGoingAway(
+                            f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
+                            last_stream_id=last_stream_id,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                    if self._state != HTTPConnectionState.DRAINING:
+                        # stream_id <= last_stream_id: may have been processed
+                        raise ConnectionGoingAway(
+                            f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
+                            last_stream_id=last_stream_id if last_stream_id is not None else 0,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                else:
+                    raise RemoteProtocolError(self._connection_terminated)
 
             # This conditional is a bit icky. We don't want to block reading if we've
             # actually got an event to return for a given stream. We need to do that
@@ -361,7 +421,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             # block until we've available flow control, event when we have events
             # pending for the stream ID we're attempting to send on.
             if stream_id is None or not self._events.get(stream_id):
-                events = await self._read_incoming_data(request)
+                events = await self._read_incoming_data(request, stream_id)
                 for event in events:
                     if isinstance(event, h2.events.RemoteSettingsChanged):
                         async with Trace(
@@ -384,6 +444,13 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
                     elif isinstance(event, h2.events.ConnectionTerminated):
                         self._connection_terminated = event
+                        # Transition to DRAINING on graceful shutdown (NO_ERROR),
+                        # allowing in-flight streams to complete.
+                        # Non-graceful shutdown closes immediately.
+                        if event.error_code == 0:
+                            self._state = HTTPConnectionState.DRAINING
+                        else:
+                            self._state = HTTPConnectionState.CLOSED
 
         await self._write_outgoing_data(request)
 
@@ -409,6 +476,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _response_closed(self, stream_id: int) -> None:
         await self._max_streams_semaphore.release()
         del self._events[stream_id]
+        self._stream_requests.pop(stream_id, None)  # Clean up phase tracking
         async with self._state_lock:
             if self._connection_terminated and not self._events:
                 await self.aclose()
@@ -430,7 +498,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     # Wrappers around network read/write operations...
 
-    async def _read_incoming_data(self, request: Request) -> list[h2.events.Event]:
+    async def _read_incoming_data(
+        self, request: Request, stream_id: int | None = None
+    ) -> list[h2.events.Event]:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -440,7 +510,32 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         try:
             data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
             if data == b"":
-                raise RemoteProtocolError("Server disconnected")
+                # Server disconnected. Check if this is related to GOAWAY.
+                if stream_id is not None:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False}
+                    )
+                    # If we have a GOAWAY recorded, this disconnect is GOAWAY-related
+                    if self._connection_terminated is not None:
+                        last_stream_id = self._connection_terminated.last_stream_id
+                        raise ConnectionGoingAway(
+                            "Server disconnected after GOAWAY",
+                            last_stream_id=last_stream_id if last_stream_id else 0,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                    # Check if h2 is in CLOSED state (GOAWAY received but not processed)
+                    if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                        raise ConnectionGoingAway(
+                            "Server disconnected (connection closed)",
+                            last_stream_id=stream_id,  # Conservative
+                            error_code=0,  # Assume graceful
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
         except Exception as exc:
             # If we get a network error we should:
             #
@@ -510,7 +605,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     def is_available(self) -> bool:
         return (
-            self._state != HTTPConnectionState.CLOSED
+            self._state not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (
@@ -521,7 +616,12 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        return self._expire_at is not None and now > self._expire_at
+        keepalive_expired = self._expire_at is not None and now > self._expire_at
+        # Draining connections with no active streams are considered expired
+        draining_complete = (
+            self._state == HTTPConnectionState.DRAINING and not self._events
+        )
+        return keepalive_expired or draining_complete
 
     def is_idle(self) -> bool:
         return self._state == HTTPConnectionState.IDLE

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -201,9 +201,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         },
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated,  # type: ignore[arg-type]
-                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type]
-                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                        self._connection_terminated,  # type: ignore[arg-type,unused-ignore]
+                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type,unused-ignore]
+                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -414,7 +414,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -426,7 +426,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                             last_stream_id=last_stream_id
                             if last_stream_id is not None
                             else 0,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -545,7 +545,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_exceptions.py
+++ b/httpcore/_exceptions.py
@@ -19,6 +19,84 @@ class ConnectionNotAvailable(Exception):
     pass
 
 
+class ConnectionGoingAway(ConnectionNotAvailable):
+    """
+    Raised when a GOAWAY frame is received during HTTP/2 request processing.
+
+    This exception provides context for determining whether a request is safe
+    to retry, based on RFC 7540 Section 6.8 semantics.
+
+    Per RFC 7540: streams with IDs > last_stream_id are guaranteed unprocessed
+    and safe to retry. Streams with IDs <= last_stream_id may have been processed.
+
+    Attributes:
+        last_stream_id: The highest stream ID the server may have processed.
+        error_code: The GOAWAY error code (0 = NO_ERROR for graceful shutdown).
+        request_stream_id: The stream ID assigned to this specific request.
+        headers_sent: Whether request headers were transmitted before GOAWAY.
+        body_sent: Whether request body was transmitted before GOAWAY.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        last_stream_id: int,
+        error_code: int,
+        request_stream_id: int,
+        headers_sent: bool = False,
+        body_sent: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.last_stream_id = last_stream_id
+        self.error_code = error_code
+        self.request_stream_id = request_stream_id
+        self.headers_sent = headers_sent
+        self.body_sent = body_sent
+
+    @property
+    def is_safe_to_retry(self) -> bool:
+        """
+        Returns True if the request is guaranteed unprocessed and safe to retry.
+
+        Per RFC 7540 Section 6.8: any stream with ID > last_stream_id was never
+        seen by the server and can be safely retried.
+        """
+        return self.request_stream_id > self.last_stream_id
+
+    @property
+    def is_graceful_shutdown(self) -> bool:
+        """
+        Returns True if this is a graceful shutdown (NO_ERROR).
+
+        NO_ERROR (0x0) indicates administrative shutdown such as server restart,
+        connection limit reached, or idle timeout.
+        """
+        return self.error_code == 0
+
+    @property
+    def may_have_side_effects(self) -> bool:
+        """
+        Returns True if the request may have been processed by the server.
+
+        If stream_id > last_stream_id: guaranteed no side effects (unprocessed).
+        If stream_id <= last_stream_id AND (headers or body sent): possibly processed.
+        """
+        if self.request_stream_id > self.last_stream_id:
+            return False  # Guaranteed unprocessed per RFC 7540
+        return self.headers_sent or self.body_sent
+
+    def __repr__(self) -> str:
+        return (
+            f"ConnectionGoingAway("
+            f"last_stream_id={self.last_stream_id}, "
+            f"error_code={self.error_code}, "
+            f"request_stream_id={self.request_stream_id}, "
+            f"is_safe_to_retry={self.is_safe_to_retry}, "
+            f"is_graceful_shutdown={self.is_graceful_shutdown})"
+        )
+
+
 class ProxyError(Exception):
     pass
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -261,7 +261,8 @@ class ConnectionPool(RequestInterface):
                         # Likely safe to retry.
                         continue
                     else:
-                        # Request may have been processed. Propagate error with context so application can decide whether to retry.
+                        # Request may have been processed. Propagate error with context so application can decide
+                        # whether to retry.
                         msg = (
                             "GOAWAY recieved: request may have been processed"
                         )

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -7,7 +7,12 @@ import typing
 
 from .._backends.sync import SyncBackend
 from .._backends.base import SOCKET_OPTION, NetworkBackend
-from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
+from .._exceptions import (
+    ConnectionGoingAway,
+    ConnectionNotAvailable,
+    RemoteProtocolError,
+    UnsupportedProtocol,
+)
 from .._models import Origin, Proxy, Request, Response
 from .._synchronization import Event, ShieldCancellation, ThreadLock
 from .connection import HTTPConnection
@@ -242,6 +247,26 @@ class ConnectionPool(RequestInterface):
                     #
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
+                except ConnectionGoingAway as exc:
+                    # GOAWAY frame recieved during request processing.
+                    # Determine if we can safely retry based on RFC 7540 semantics.
+                    pool_request.clear_connection()
+
+                    if exc.is_safe_to_retry:
+                        # stream_id > last_stream_id: guaranteed unprocessed per RFC 7540
+                        # Safe to retry on a new connection
+                        continue
+                    elif exc.is_graceful_shutdown and not exc.may_have_side_effects:
+                        # Graceful shutdown and headers weren't sent yet.
+                        # Likely safe to retry.
+                        continue
+                    else:
+                        # Request may have been processed. Propagate error with context so application can decide whether to retry.
+                        msg = (
+                            "GOAWAY recieved: request may have been processed"
+                        )
+                        # QUESTION: What is the best way to propagate the context for the applications?
+                        raise RemoteProtocolError(msg) from exc
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -242,11 +242,10 @@ class ConnectionPool(RequestInterface):
                         pool_request.request
                     )
                 except ConnectionGoingAway as exc:
-                    # NOTE: This must be caught before ConnectionNotAvailable since
-                    # ConnectionGoingAway is a subclass of ConnectionNotAvailable.
-                    #
                     # GOAWAY frame recieved during request processing.
                     # Determine if we can safely retry based on RFC 7540 semantics.
+                    # NOTE: This must be caught before ConnectionNotAvailable since
+                    # ConnectionGoingAway is a subclass of ConnectionNotAvailable.
                     pool_request.clear_connection()
 
                     if exc.is_safe_to_retry:

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -241,13 +241,10 @@ class ConnectionPool(RequestInterface):
                     response = connection.handle_request(
                         pool_request.request
                     )
-                except ConnectionNotAvailable:
-                    # In some cases a connection may initially be available to
-                    # handle a request, but then become unavailable.
-                    #
-                    # In this case we clear the connection and try again.
-                    pool_request.clear_connection()
                 except ConnectionGoingAway as exc:
+                    # NOTE: This must be caught before ConnectionNotAvailable since
+                    # ConnectionGoingAway is a subclass of ConnectionNotAvailable.
+                    #
                     # GOAWAY frame recieved during request processing.
                     # Determine if we can safely retry based on RFC 7540 semantics.
                     pool_request.clear_connection()
@@ -266,6 +263,12 @@ class ConnectionPool(RequestInterface):
                         msg = "GOAWAY recieved: request may have been processed"
                         # QUESTION: What is the best way to propagate the context for the applications?
                         raise RemoteProtocolError(msg) from exc
+                except ConnectionNotAvailable:
+                    # In some cases a connection may initially be available to
+                    # handle a request, but then become unavailable.
+                    #
+                    # In this case we clear the connection and try again.
+                    pool_request.clear_connection()
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -263,9 +263,7 @@ class ConnectionPool(RequestInterface):
                     else:
                         # Request may have been processed. Propagate error with context so application can decide
                         # whether to retry.
-                        msg = (
-                            "GOAWAY recieved: request may have been processed"
-                        )
+                        msg = "GOAWAY recieved: request may have been processed"
                         # QUESTION: What is the best way to propagate the context for the applications?
                         raise RemoteProtocolError(msg) from exc
                 else:

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -522,7 +522,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code,   # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -201,9 +201,9 @@ class HTTP2Connection(ConnectionInterface):
                         },
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated,  # type: ignore[arg-type]
-                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type]
-                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                        self._connection_terminated,  # type: ignore[arg-type,unused-ignore]
+                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type,unused-ignore]
+                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -414,7 +414,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -426,7 +426,7 @@ class HTTP2Connection(ConnectionInterface):
                             last_stream_id=last_stream_id
                             if last_stream_id is not None
                             else 0,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -545,7 +545,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type,unused-ignore]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -89,7 +89,6 @@ class HTTP2Connection(ConnectionInterface):
         # TODO: Consider shifting this to a dataclass or typeddict
         self._stream_requests: dict[int, dict[str, bool]] = {}
 
-
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
             # This cannot occur in normal operation, since the connection pool
@@ -142,7 +141,10 @@ class HTTP2Connection(ConnectionInterface):
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
             # Initialize phase tracking for this stream
-            self._stream_requests[stream_id] = {"headers_sent": False, "body_sent": False}
+            self._stream_requests[stream_id] = {
+                "headers_sent": False,
+                "body_sent": False,
+            }
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
             self._used_all_stream_ids = True
             self._request_count -= 1
@@ -192,7 +194,11 @@ class HTTP2Connection(ConnectionInterface):
                 # it as a ConnectionGoingAway if applicable, or RemoteProtocolError.
                 if self._connection_terminated:  # pragma: nocover
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False},
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     raise ConnectionGoingAway(
                         self._connection_terminated,  # type: ignore[arg-type]
@@ -204,15 +210,22 @@ class HTTP2Connection(ConnectionInterface):
                     )
                 # Check if h2 is in CLOSED state due to GOAWAY. This can happen when
                 # GOAWAY was recieved but we haven't processed the event yet (race condition).
-                if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                if (
+                    self._h2_state.state_machine.state
+                    == h2.connection.ConnectionState.CLOSED
+                ):
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False},
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     msg = f"Connection closed: {exc}"
                     raise ConnectionGoingAway(
                         msg,
-                        last_stream_id=stream_id, # Conservative: assume this stream may have been processed
-                        error_code=0, # Assume graceful shutdown
+                        last_stream_id=stream_id,  # Conservative: assume this stream may have been processed
+                        error_code=0,  # Assume graceful shutdown
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -389,7 +402,11 @@ class HTTP2Connection(ConnectionInterface):
                 last_stream_id = self._connection_terminated.last_stream_id
                 if stream_id is not None:
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False}
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     if last_stream_id is not None and stream_id > last_stream_id:
                         # stream_id > last_stream_id: guaranteed unprocessed, safe to retry
@@ -402,11 +419,13 @@ class HTTP2Connection(ConnectionInterface):
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
                         )
-                    # stream_id <= last_stream_id: may have been processed
                     if self._state != HTTPConnectionState.DRAINING:
+                        # stream_id <= last_stream_id: may have been processed
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
-                            last_stream_id=last_stream_id if last_stream_id is not None else 0,
+                            last_stream_id=last_stream_id
+                            if last_stream_id is not None
+                            else 0,
                             error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
@@ -477,7 +496,7 @@ class HTTP2Connection(ConnectionInterface):
     def _response_closed(self, stream_id: int) -> None:
         self._max_streams_semaphore.release()
         del self._events[stream_id]
-        self._stream_requests.pop(stream_id, None)  # Clean up phase tracking        
+        self._stream_requests.pop(stream_id, None)  # Clean up phase tracking
         with self._state_lock:
             if self._connection_terminated and not self._events:
                 self.close()
@@ -514,7 +533,11 @@ class HTTP2Connection(ConnectionInterface):
                 # Server disconnected. Check if this is related to GOAWAY.
                 if stream_id is not None:
                     phase = self._stream_requests.get(
-                        stream_id, {"headers_sent": False, "body_sent": False}
+                        stream_id,
+                        {
+                            "headers_sent": False,
+                            "body_sent": False,
+                        },
                     )
                     # If we have a GOAWAY recorded, this disconnect is GOAWAY-related
                     if self._connection_terminated is not None:
@@ -522,13 +545,16 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             "Server disconnected after GOAWAY",
                             last_stream_id=last_stream_id if last_stream_id else 0,
-                            error_code=self._connection_terminated.error_code,   # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
                         )
                     # Check if h2 is in CLOSED state (GOAWAY received but not processed)
-                    if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                    if (
+                        self._h2_state.state_machine.state
+                        == h2.connection.ConnectionState.CLOSED
+                    ):
                         raise ConnectionGoingAway(
                             "Server disconnected (connection closed)",
                             last_stream_id=stream_id,  # Conservative
@@ -607,7 +633,8 @@ class HTTP2Connection(ConnectionInterface):
 
     def is_available(self) -> bool:
         return (
-            self._state not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
+            self._state
+            not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -537,6 +537,7 @@ class HTTP2Connection(ConnectionInterface):
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
                         )
+                raise RemoteProtocolError("Server disconnected")
         except Exception as exc:
             # If we get a network error we should:
             #

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -14,6 +14,7 @@ import h2.settings
 
 from .._backends.base import NetworkStream
 from .._exceptions import (
+    ConnectionGoingAway,
     ConnectionNotAvailable,
     LocalProtocolError,
     RemoteProtocolError,
@@ -36,7 +37,8 @@ def has_body_headers(request: Request) -> bool:
 class HTTPConnectionState(enum.IntEnum):
     ACTIVE = 1
     IDLE = 2
-    CLOSED = 3
+    DRAINING = 3
+    CLOSED = 4
 
 
 class HTTP2Connection(ConnectionInterface):
@@ -81,6 +83,12 @@ class HTTP2Connection(ConnectionInterface):
 
         self._read_exception: Exception | None = None
         self._write_exception: Exception | None = None
+
+        # Track request phases for GOAWAY retry safety determination.
+        # Maps stream_id -> {"headers_sent": bool, "body_sent": bool}
+        # TODO: Consider shifting this to a dataclass or typeddict
+        self._stream_requests: dict[int, dict[str, bool]] = {}
+
 
     def handle_request(self, request: Request) -> Response:
         if not self.can_handle_request(request.url.origin):
@@ -133,6 +141,8 @@ class HTTP2Connection(ConnectionInterface):
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
+            # Initialize phase tracking for this stream
+            self._stream_requests[stream_id] = {"headers_sent": False, "body_sent": False}
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
             self._used_all_stream_ids = True
             self._request_count -= 1
@@ -142,8 +152,10 @@ class HTTP2Connection(ConnectionInterface):
             kwargs = {"request": request, "stream_id": stream_id}
             with Trace("send_request_headers", logger, request, kwargs):
                 self._send_request_headers(request=request, stream_id=stream_id)
+            self._stream_requests[stream_id]["headers_sent"] = True
             with Trace("send_request_body", logger, request, kwargs):
                 self._send_request_body(request=request, stream_id=stream_id)
+            self._stream_requests[stream_id]["body_sent"] = True
             with Trace(
                 "receive_response_headers", logger, request, kwargs
             ) as trace:
@@ -177,9 +189,35 @@ class HTTP2Connection(ConnectionInterface):
                 # a protocol error at any point they interact with the 'h2_state'.
                 #
                 # In this case we'll have stored the event, and should raise
-                # it as a RemoteProtocolError.
+                # it as a ConnectionGoingAway if applicable, or RemoteProtocolError.
                 if self._connection_terminated:  # pragma: nocover
-                    raise RemoteProtocolError(self._connection_terminated)
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False},
+                    )
+                    raise ConnectionGoingAway(
+                        self._connection_terminated,
+                        last_stream_id=self._connection_terminated.last_stream_id,
+                        error_code=self._connection_terminated.error_code,
+                        request_stream_id=stream_id,
+                        headers_sent=phase["headers_sent"],
+                        body_sent=phase["body_sent"],
+                    )
+                # Check if h2 is in CLOSED state due to GOAWAY. This can happen when
+                # GOAWAY was recieved but we haven't processed the event yet (race condition).
+                if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False},
+                    )
+                    msg = f"Connection closed: {exc}"
+                    raise ConnectionGoingAway(
+                        msg,
+                        last_stream_id=stream_id, # Conservative: assume this stream may have been processed
+                        error_code=0, # Assume graceful shutdown
+                        request_stream_id=stream_id,
+                        headers_sent=phase["headers_sent"],
+                        body_sent=phase["body_sent"],
+                    )
+
                 # If h2 raises a protocol error in some other state then we
                 # must somehow have made a protocol violation.
                 raise LocalProtocolError(exc)  # pragma: nocover
@@ -349,10 +387,33 @@ class HTTP2Connection(ConnectionInterface):
         with self._read_lock:
             if self._connection_terminated is not None:
                 last_stream_id = self._connection_terminated.last_stream_id
-                if stream_id and last_stream_id and stream_id > last_stream_id:
-                    self._request_count -= 1
-                    raise ConnectionNotAvailable()
-                raise RemoteProtocolError(self._connection_terminated)
+                if stream_id is not None:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False}
+                    )
+                    if last_stream_id is not None and stream_id > last_stream_id:
+                        # stream_id > last_stream_id: guaranteed unprocessed, safe to retry
+                        self._request_count -= 1
+                        raise ConnectionGoingAway(
+                            f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
+                            last_stream_id=last_stream_id,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                    # stream_id <= last_stream_id: may have been processed
+                    if self._state != HTTPConnectionState.DRAINING:
+                        raise ConnectionGoingAway(
+                            f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
+                            last_stream_id=last_stream_id if last_stream_id is not None else 0,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                else:
+                    raise RemoteProtocolError(self._connection_terminated)
 
             # This conditional is a bit icky. We don't want to block reading if we've
             # actually got an event to return for a given stream. We need to do that
@@ -361,7 +422,7 @@ class HTTP2Connection(ConnectionInterface):
             # block until we've available flow control, event when we have events
             # pending for the stream ID we're attempting to send on.
             if stream_id is None or not self._events.get(stream_id):
-                events = self._read_incoming_data(request)
+                events = self._read_incoming_data(request, stream_id)
                 for event in events:
                     if isinstance(event, h2.events.RemoteSettingsChanged):
                         with Trace(
@@ -384,6 +445,13 @@ class HTTP2Connection(ConnectionInterface):
 
                     elif isinstance(event, h2.events.ConnectionTerminated):
                         self._connection_terminated = event
+                        # Transition to DRAINING on graceful shutdown (NO_ERROR),
+                        # allowing in-flight streams to complete.
+                        # Non-graceful shutdown closes immediately.
+                        if event.error_code == 0:
+                            self._state = HTTPConnectionState.DRAINING
+                        else:
+                            self._state = HTTPConnectionState.CLOSED
 
         self._write_outgoing_data(request)
 
@@ -409,6 +477,7 @@ class HTTP2Connection(ConnectionInterface):
     def _response_closed(self, stream_id: int) -> None:
         self._max_streams_semaphore.release()
         del self._events[stream_id]
+        self._stream_requests.pop(stream_id, None)  # Clean up phase tracking        
         with self._state_lock:
             if self._connection_terminated and not self._events:
                 self.close()
@@ -430,7 +499,9 @@ class HTTP2Connection(ConnectionInterface):
 
     # Wrappers around network read/write operations...
 
-    def _read_incoming_data(self, request: Request) -> list[h2.events.Event]:
+    def _read_incoming_data(
+        self, request: Request, stream_id: int | None = None
+    ) -> list[h2.events.Event]:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -440,7 +511,32 @@ class HTTP2Connection(ConnectionInterface):
         try:
             data = self._network_stream.read(self.READ_NUM_BYTES, timeout)
             if data == b"":
-                raise RemoteProtocolError("Server disconnected")
+                # Server disconnected. Check if this is related to GOAWAY.
+                if stream_id is not None:
+                    phase = self._stream_requests.get(
+                        stream_id, {"headers_sent": False, "body_sent": False}
+                    )
+                    # If we have a GOAWAY recorded, this disconnect is GOAWAY-related
+                    if self._connection_terminated is not None:
+                        last_stream_id = self._connection_terminated.last_stream_id
+                        raise ConnectionGoingAway(
+                            "Server disconnected after GOAWAY",
+                            last_stream_id=last_stream_id if last_stream_id else 0,
+                            error_code=self._connection_terminated.error_code,
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
+                    # Check if h2 is in CLOSED state (GOAWAY received but not processed)
+                    if self._h2_state.state_machine.state == h2.connection.ConnectionState.CLOSED:
+                        raise ConnectionGoingAway(
+                            "Server disconnected (connection closed)",
+                            last_stream_id=stream_id,  # Conservative
+                            error_code=0,  # Assume graceful
+                            request_stream_id=stream_id,
+                            headers_sent=phase["headers_sent"],
+                            body_sent=phase["body_sent"],
+                        )
         except Exception as exc:
             # If we get a network error we should:
             #
@@ -510,7 +606,7 @@ class HTTP2Connection(ConnectionInterface):
 
     def is_available(self) -> bool:
         return (
-            self._state != HTTPConnectionState.CLOSED
+            self._state not in (HTTPConnectionState.DRAINING, HTTPConnectionState.CLOSED)
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (
@@ -521,7 +617,12 @@ class HTTP2Connection(ConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        return self._expire_at is not None and now > self._expire_at
+        keepalive_expired = self._expire_at is not None and now > self._expire_at
+        # Draining connections with no active streams are considered expired
+        draining_complete = (
+            self._state == HTTPConnectionState.DRAINING and not self._events
+        )
+        return keepalive_expired or draining_complete
 
     def is_idle(self) -> bool:
         return self._state == HTTPConnectionState.IDLE

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -195,9 +195,9 @@ class HTTP2Connection(ConnectionInterface):
                         stream_id, {"headers_sent": False, "body_sent": False},
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated,
-                        last_stream_id=self._connection_terminated.last_stream_id,
-                        error_code=self._connection_terminated.error_code,
+                        self._connection_terminated, # type: ignore[arg-type]
+                        last_stream_id=self._connection_terminated.last_stream_id, # type: ignore[arg-type]
+                        error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -397,7 +397,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -407,7 +407,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id if last_stream_id is not None else 0,
-                            error_code=self._connection_terminated.error_code,
+                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -195,9 +195,9 @@ class HTTP2Connection(ConnectionInterface):
                         stream_id, {"headers_sent": False, "body_sent": False},
                     )
                     raise ConnectionGoingAway(
-                        self._connection_terminated, # type: ignore[arg-type]
-                        last_stream_id=self._connection_terminated.last_stream_id, # type: ignore[arg-type]
-                        error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                        self._connection_terminated,  # type: ignore[arg-type]
+                        last_stream_id=self._connection_terminated.last_stream_id,  # type: ignore[arg-type]
+                        error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                         request_stream_id=stream_id,
                         headers_sent=phase["headers_sent"],
                         body_sent=phase["body_sent"],
@@ -397,7 +397,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} > last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id,
-                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],
@@ -407,7 +407,7 @@ class HTTP2Connection(ConnectionInterface):
                         raise ConnectionGoingAway(
                             f"GOAWAY received: stream {stream_id} <= last_stream_id {last_stream_id}",
                             last_stream_id=last_stream_id if last_stream_id is not None else 0,
-                            error_code=self._connection_terminated.error_code, # type: ignore[arg-type]
+                            error_code=self._connection_terminated.error_code,  # type: ignore[arg-type]
                             request_stream_id=stream_id,
                             headers_sent=phase["headers_sent"],
                             body_sent=phase["body_sent"],

--- a/tests/_async/test_http2.py
+++ b/tests/_async/test_http2.py
@@ -214,7 +214,7 @@ async def test_http2_connection_with_goaway():
     )
     async with httpcore.AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
         # The initial request has been closed midway, with an unrecoverable error.
-        with pytest.raises(httpcore.RemoteProtocolError):
+        with pytest.raises(httpcore.ConnectionGoingAway):
             await conn.request("GET", "https://example.com/")
 
         # The second request can receive a graceful `ConnectionNotAvailable`,

--- a/tests/_async/test_http2_goaway.py
+++ b/tests/_async/test_http2_goaway.py
@@ -994,3 +994,45 @@ async def test_http2_protocol_error_with_h2_closed_state():
 
         # Verify the exception properties
         assert exc_info.value.error_code == 0  # Assumed graceful
+
+
+@pytest.mark.anyio
+async def test_mock_backend_with_retry_exhausted_buffers():
+    """
+    Test the AsyncMockBackendWithRetry when more connections are made
+    than buffers provided. This covers the else branch at line 497.
+    """
+    network_backend = AsyncMockBackendWithRetry(
+        buffers_by_connection=[
+            # Only one buffer set provided
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=0, last_stream_id=0
+                ).serialize(),
+                b"",
+            ],
+        ],
+        http2=True,
+    )
+
+    # First connection uses the buffer
+    stream1 = await network_backend.connect_tcp("example.com", 443)
+    assert stream1 is not None
+
+    # Second connection should hit the else branch (empty buffer)
+    stream2 = await network_backend.connect_tcp("example.com", 443)
+    assert stream2 is not None
+
+
+@pytest.mark.anyio
+async def test_mock_connection_graceful_goaway_info():
+    """
+    Test the info() method of MockConnectionGracefulGoaway.
+    This covers line 795.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    mock_conn = MockConnectionGracefulGoaway(origin)
+
+    # Verify the info method returns the expected string
+    assert mock_conn.info() == "MockConnectionGracefulGoaway"

--- a/tests/_async/test_http2_goaway.py
+++ b/tests/_async/test_http2_goaway.py
@@ -826,3 +826,171 @@ async def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
 
         # Verify the first connection was called twice (retry happened)
         assert pool._mock_connections[0]._calls == 2  # type: ignore[attr-defined]
+
+
+# =============================================================================
+# Tests for edge cases in HTTP/2 GOAWAY handling
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_http2_receive_events_with_terminated_connection_no_stream_id():
+    """
+    Test _receive_events when connection is terminated and stream_id is None.
+    This covers line 435 in http2.py - the RemoteProtocolError path.
+
+    This scenario occurs when _receive_events is called without a stream_id
+    (e.g., from _wait_for_outgoing_flow) after the connection has terminated.
+    We test this by directly manipulating the connection state.
+    """
+    import h2.events
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # We'll manipulate the connection state after initialization
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        # Directly set _connection_terminated to simulate a terminated connection
+        # This mimics the state after receiving a GOAWAY but before cleanup
+        terminated = h2.events.ConnectionTerminated()
+        terminated.error_code = 0
+        terminated.last_stream_id = 0
+        terminated.additional_data = b""
+        conn._connection_terminated = terminated
+
+        # Create a mock request for the _receive_events call
+        request = httpcore.Request(
+            method=b"GET",
+            url=httpcore.URL("https://example.com/"),
+            headers=[(b"host", b"example.com")],
+        )
+
+        # Call _receive_events with stream_id=None to trigger line 435
+        with pytest.raises(httpcore.RemoteProtocolError):
+            await conn._receive_events(request, stream_id=None)
+
+
+@pytest.mark.anyio
+async def test_http2_server_disconnect_with_h2_closed_state():
+    """
+    Test server disconnect when h2 state machine is CLOSED but _connection_terminated
+    is not yet set. This covers line 558 in http2.py.
+
+    This simulates a race condition where h2 has processed GOAWAY internally
+    (transitioning to CLOSED state) but we haven't processed the event yet.
+    """
+    import h2.connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+
+    # Create a mock stream that sets state to CLOSED BEFORE returning empty data
+    # This simulates the race condition accurately
+    class MockStreamWithClosedStateOnDisconnect(httpcore.AsyncMockStream):
+        def __init__(self, conn_ref: list) -> None:
+            self._conn_ref = conn_ref
+            self._read_count = 0
+            super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
+
+        async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+            self._read_count += 1
+            if self._read_count == 1:
+                # First read returns settings
+                return hyperframe.frame.SettingsFrame().serialize()
+            # Before returning empty (disconnect), set h2 state to CLOSED
+            # This simulates h2 having processed GOAWAY internally
+            if self._conn_ref and self._conn_ref[0]:
+                self._conn_ref[
+                    0
+                ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
+                self._conn_ref[0]._connection_terminated = None
+            return b""  # Server disconnect
+
+    conn_ref: list = []
+    stream = MockStreamWithClosedStateOnDisconnect(conn_ref)
+
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        conn_ref.append(conn)
+
+        # Set up stream tracking for the request
+        conn._stream_requests[1] = {"headers_sent": True, "body_sent": False}
+
+        # Create a mock request
+        request = httpcore.Request(
+            method=b"GET",
+            url=httpcore.URL("https://example.com/"),
+            headers=[(b"host", b"example.com")],
+        )
+
+        # First call consumes the initial settings frame
+        await conn._read_incoming_data(request, stream_id=1)
+
+        # Second call should hit line 558 when mock returns empty data
+        # and sets h2 state to CLOSED
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn._read_incoming_data(request, stream_id=1)
+
+        # Verify the exception has the expected properties
+        assert exc_info.value.request_stream_id == 1
+        assert exc_info.value.error_code == 0  # Assumed graceful
+
+
+@pytest.mark.anyio
+async def test_http2_protocol_error_with_h2_closed_state():
+    """
+    Test h2 ProtocolError when state machine is CLOSED.
+    This covers lines 213-225 in http2.py.
+
+    This simulates the race condition where h2 raises a ProtocolError
+    and the state machine is in CLOSED state, but _connection_terminated
+    is not yet set.
+    """
+    import h2.connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+
+    # Create a mock stream that sets state to CLOSED during write
+    # This causes h2 to raise ProtocolError when trying to read the next frame
+    class MockStreamWithClosedOnWrite(httpcore.AsyncMockStream):
+        def __init__(self, conn_ref: list) -> None:
+            self._conn_ref = conn_ref
+            self._write_count = 0
+            super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
+
+        async def write(self, data: bytes, timeout: float | None = None) -> None:
+            self._write_count += 1
+            # After first write (settings ACK), set state to CLOSED
+            # to simulate race condition during request sending
+            if self._write_count > 1 and self._conn_ref and self._conn_ref[0]:
+                self._conn_ref[
+                    0
+                ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
+                self._conn_ref[0]._connection_terminated = None
+
+    conn_ref: list = []
+    stream = MockStreamWithClosedOnWrite(conn_ref)
+
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        conn_ref.append(conn)
+
+        # Use handle_async_request which has the try-except block
+        # The request will fail when h2 raises ProtocolError in CLOSED state
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.handle_async_request(
+                httpcore.Request(
+                    method=b"GET",
+                    url=httpcore.URL("https://example.com/"),
+                    headers=[(b"host", b"example.com")],
+                )
+            )
+
+        # Verify the exception properties
+        assert exc_info.value.error_code == 0  # Assumed graceful

--- a/tests/_async/test_http2_goaway.py
+++ b/tests/_async/test_http2_goaway.py
@@ -1,0 +1,848 @@
+"""
+Comprehensive tests for HTTP/2 GOAWAY handling.
+
+These tests cover the new GOAWAY functionality introduced to handle race conditions
+when servers send GOAWAY frames during HTTP/2 connections. Key features tested:
+
+1. ConnectionGoingAway exception properties (is_safe_to_retry, is_graceful_shutdown, may_have_side_effects)
+2. DRAINING connection state for graceful shutdowns
+3. Request phase tracking (headers_sent, body_sent)
+4. Pool-level retry logic based on GOAWAY context
+5. Various race conditions between GOAWAY and request processing
+"""
+from __future__ import annotations
+
+import hpack
+import hyperframe.frame
+import pytest
+
+import httpcore
+
+
+# =============================================================================
+# Tests for ConnectionGoingAway Exception Properties
+# =============================================================================
+
+
+class TestConnectionGoingAwayException:
+    """Tests for the ConnectionGoingAway exception class and its properties."""
+
+    def test_is_safe_to_retry_when_stream_id_greater_than_last_stream_id(self):
+        """
+        Per RFC 7540 Section 6.8: streams with IDs > last_stream_id are guaranteed
+        unprocessed and safe to retry.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=3,  # > last_stream_id
+            headers_sent=True,
+            body_sent=True,
+        )
+        assert exc.is_safe_to_retry is True
+
+    def test_is_not_safe_to_retry_when_stream_id_equals_last_stream_id(self):
+        """
+        Streams with IDs <= last_stream_id may have been processed by the server.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=1,  # == last_stream_id
+            headers_sent=True,
+            body_sent=True,
+        )
+        assert exc.is_safe_to_retry is False
+
+    def test_is_not_safe_to_retry_when_stream_id_less_than_last_stream_id(self):
+        """
+        Streams with IDs <= last_stream_id may have been processed by the server.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=5,
+            error_code=0,
+            request_stream_id=1,  # < last_stream_id
+            headers_sent=True,
+            body_sent=True,
+        )
+        assert exc.is_safe_to_retry is False
+
+    def test_is_graceful_shutdown_when_error_code_is_zero(self):
+        """
+        NO_ERROR (0x0) indicates administrative shutdown such as server restart,
+        connection limit reached, or idle timeout.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,  # NO_ERROR
+            request_stream_id=1,
+        )
+        assert exc.is_graceful_shutdown is True
+
+    def test_is_not_graceful_shutdown_when_error_code_is_nonzero(self):
+        """
+        Non-zero error codes indicate an error condition.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=1,  # PROTOCOL_ERROR
+            request_stream_id=1,
+        )
+        assert exc.is_graceful_shutdown is False
+
+    def test_may_have_side_effects_when_stream_id_greater_than_last_stream_id(self):
+        """
+        If stream_id > last_stream_id, the request was guaranteed unprocessed,
+        so no side effects are possible.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=3,  # > last_stream_id
+            headers_sent=True,  # Even with headers sent, no side effects possible
+            body_sent=True,
+        )
+        assert exc.may_have_side_effects is False
+
+    def test_may_have_side_effects_when_headers_sent(self):
+        """
+        If stream_id <= last_stream_id AND headers were sent, side effects are possible.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=1,  # <= last_stream_id
+            headers_sent=True,
+            body_sent=False,
+        )
+        assert exc.may_have_side_effects is True
+
+    def test_may_have_side_effects_when_body_sent(self):
+        """
+        If stream_id <= last_stream_id AND body was sent, side effects are possible.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=1,  # <= last_stream_id
+            headers_sent=False,
+            body_sent=True,
+        )
+        assert exc.may_have_side_effects is True
+
+    def test_no_side_effects_when_nothing_sent(self):
+        """
+        If stream_id <= last_stream_id but nothing was sent, no side effects.
+        """
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=1,  # <= last_stream_id
+            headers_sent=False,
+            body_sent=False,
+        )
+        assert exc.may_have_side_effects is False
+
+    def test_repr(self):
+        """Test the __repr__ method provides useful debugging info."""
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=3,
+            headers_sent=True,
+            body_sent=True,
+        )
+        repr_str = repr(exc)
+        assert "ConnectionGoingAway" in repr_str
+        assert "last_stream_id=1" in repr_str
+        assert "error_code=0" in repr_str
+        assert "request_stream_id=3" in repr_str
+        assert "is_safe_to_retry=True" in repr_str
+        assert "is_graceful_shutdown=True" in repr_str
+
+    def test_inheritance_from_connection_not_available(self):
+        """ConnectionGoingAway should be a subclass of ConnectionNotAvailable."""
+        exc = httpcore.ConnectionGoingAway(
+            "GOAWAY received",
+            last_stream_id=1,
+            error_code=0,
+            request_stream_id=1,
+        )
+        assert isinstance(exc, httpcore.ConnectionNotAvailable)
+
+
+# =============================================================================
+# Tests for HTTP/2 Connection GOAWAY Handling
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_non_graceful_shutdown():
+    """
+    Non-graceful shutdown (error_code != 0) should raise ConnectionGoingAway
+    with is_graceful_shutdown=False.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            # Non-graceful GOAWAY with PROTOCOL_ERROR (error_code=1)
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=1, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        # First request should fail with ConnectionGoingAway due to non-graceful GOAWAY
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Verify it's not a graceful shutdown
+        assert exc_info.value.is_graceful_shutdown is False
+        assert exc_info.value.error_code == 1
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_graceful_shutdown_properties():
+    """
+    When GOAWAY with NO_ERROR is received, the exception should have
+    is_graceful_shutdown=True.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            # Graceful GOAWAY with NO_ERROR
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        # Request should raise ConnectionGoingAway since GOAWAY is received
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Should be a graceful shutdown
+        assert exc_info.value.is_graceful_shutdown is True
+        assert exc_info.value.error_code == 0
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_stream_id_greater_than_last_stream_id():
+    """
+    When stream_id > last_stream_id, the request is guaranteed unprocessed
+    and should raise ConnectionGoingAway with is_safe_to_retry=True.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # GOAWAY with last_stream_id=0 before any streams were processed
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=0
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Stream 1 > last_stream_id (0), so safe to retry
+        assert exc_info.value.request_stream_id == 1
+        assert exc_info.value.last_stream_id == 0
+        assert exc_info.value.is_safe_to_retry is True
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_stream_id_less_than_or_equal_to_last_stream_id():
+    """
+    When stream_id <= last_stream_id and connection is not DRAINING,
+    the request may have been processed and should raise ConnectionGoingAway.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            # GOAWAY with last_stream_id=1, so stream 1 may have been processed
+            # Using error_code=1 to trigger non-DRAINING state
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=1, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Stream 1 <= last_stream_id (1), NOT safe to retry
+        assert exc_info.value.request_stream_id == 1
+        assert exc_info.value.last_stream_id == 1
+        assert exc_info.value.is_safe_to_retry is False
+
+
+@pytest.mark.anyio
+async def test_http2_server_disconnect_after_goaway():
+    """
+    When server disconnects after sending GOAWAY, the exception should
+    include GOAWAY context.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # GOAWAY followed immediately by disconnect
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=0
+            ).serialize(),
+            b"",  # Server disconnect
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Should include GOAWAY context
+        assert exc_info.value.last_stream_id == 0
+        assert exc_info.value.is_graceful_shutdown is True
+
+
+@pytest.mark.anyio
+async def test_http2_tracks_request_phase_headers_sent():
+    """
+    The connection should track when headers have been sent for GOAWAY context.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # GOAWAY after headers would be sent but before response
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Headers should have been sent
+        assert exc_info.value.headers_sent is True
+
+
+@pytest.mark.anyio
+async def test_http2_tracks_request_phase_body_sent():
+    """
+    The connection should track when body has been sent for GOAWAY context.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # GOAWAY after body would be sent but before response
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request(
+                "POST",
+                "https://example.com/",
+                headers={b"content-length": b"11"},
+                content=b"Hello World",
+            )
+
+        # Body should have been sent
+        assert exc_info.value.body_sent is True
+
+
+@pytest.mark.anyio
+async def test_http2_draining_connection_goaway_after_complete_response():
+    """
+    When GOAWAY is sent after a complete response, the first request succeeds.
+    The GOAWAY is only discovered on the next request attempt, which then fails.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.DataFrame(
+                stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
+            ).serialize(),
+            # GOAWAY after the first response completes - discovered on next request
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=1
+            ).serialize(),
+            b"",  # Disconnect after GOAWAY
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        # First request should complete successfully
+        response = await conn.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+        # Connection appears available because GOAWAY hasn't been read yet
+        # (it comes after the complete response)
+        # Second request attempts to use the connection and discovers GOAWAY
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # The second request (stream 3) > last_stream_id (1), so safe to retry
+        assert exc_info.value.is_safe_to_retry is True
+
+
+
+
+# =============================================================================
+# Custom Mock Backend for Retry Tests
+# =============================================================================
+
+
+class AsyncMockStreamWithFailure(httpcore.AsyncMockStream):
+    """A mock stream that can simulate different behaviors for testing retries."""
+
+    def __init__(self, buffers_by_connection: list[list[bytes]], http2: bool = False):
+        self._all_buffers = buffers_by_connection
+        self._connection_index = 0
+        super().__init__(
+            buffers_by_connection[0] if buffers_by_connection else [], http2=http2
+        )
+
+
+class AsyncMockBackendWithRetry(httpcore.AsyncMockBackend):
+    """A mock backend that returns different data for each connection."""
+
+    def __init__(self, buffers_by_connection: list[list[bytes]], http2: bool = False):
+        self._all_buffers = buffers_by_connection
+        self._connection_index = 0
+        self._http2 = http2
+        super().__init__([], http2=http2)
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options=None,
+    ):
+        if self._connection_index < len(self._all_buffers):
+            buffer = list(self._all_buffers[self._connection_index])
+            self._connection_index += 1
+        else:
+            buffer = []
+        return httpcore.AsyncMockStream(buffer, http2=self._http2)
+
+
+# =============================================================================
+# Tests for Connection Pool GOAWAY Retry Logic
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_connection_pool_retries_when_safe_to_retry():
+    """
+    Connection pool should automatically retry when is_safe_to_retry is True
+    (stream_id > last_stream_id, guaranteed unprocessed).
+    """
+    network_backend = AsyncMockBackendWithRetry(
+        buffers_by_connection=[
+            # First connection: GOAWAY with last_stream_id=0 (stream 1 > 0, safe to retry)
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=0, last_stream_id=0
+                ).serialize(),
+                b"",
+            ],
+            # Second connection: normal response
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.HeadersFrame(
+                    stream_id=1,
+                    data=hpack.Encoder().encode(
+                        [
+                            (b":status", b"200"),
+                            (b"content-type", b"plain/text"),
+                        ]
+                    ),
+                    flags=["END_HEADERS"],
+                ).serialize(),
+                hyperframe.frame.DataFrame(
+                    stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]
+                ).serialize(),
+            ],
+        ],
+        http2=True,
+    )
+
+    async with httpcore.AsyncConnectionPool(
+        network_backend=network_backend,
+    ) as pool:
+        # Request should succeed after automatic retry
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_connection_pool_retries_graceful_no_side_effects():
+    """
+    Connection pool should retry when is_graceful_shutdown is True
+    AND may_have_side_effects is False (headers not sent yet, stream > last_stream).
+    """
+    network_backend = AsyncMockBackendWithRetry(
+        buffers_by_connection=[
+            # First connection: Graceful GOAWAY with last_stream_id=0
+            # stream 1 > 0, so safe to retry
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=0, last_stream_id=0
+                ).serialize(),
+                b"",
+            ],
+            # Second connection: normal response
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.HeadersFrame(
+                    stream_id=1,
+                    data=hpack.Encoder().encode(
+                        [
+                            (b":status", b"200"),
+                            (b"content-type", b"plain/text"),
+                        ]
+                    ),
+                    flags=["END_HEADERS"],
+                ).serialize(),
+                hyperframe.frame.DataFrame(
+                    stream_id=1, data=b"Success!", flags=["END_STREAM"]
+                ).serialize(),
+            ],
+        ],
+        http2=True,
+    )
+
+    async with httpcore.AsyncConnectionPool(
+        network_backend=network_backend,
+    ) as pool:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Success!"
+
+
+@pytest.mark.anyio
+async def test_connection_pool_raises_when_not_safe_to_retry():
+    """
+    Connection pool should raise RemoteProtocolError when is_safe_to_retry is False
+    and the request may have been processed.
+    """
+    network_backend = AsyncMockBackendWithRetry(
+        buffers_by_connection=[
+            # First connection: GOAWAY with last_stream_id=1 (stream 1 <= 1, not safe)
+            # Non-graceful shutdown (error_code=1)
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=1, last_stream_id=1
+                ).serialize(),
+                b"",
+            ],
+        ],
+        http2=True,
+    )
+
+    async with httpcore.AsyncConnectionPool(
+        network_backend=network_backend,
+    ) as pool:
+        with pytest.raises(httpcore.RemoteProtocolError) as exc_info:
+            await pool.request("GET", "https://example.com/")
+
+        # Verify the error message indicates GOAWAY was received
+        assert "GOAWAY" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_connection_pool_raises_when_may_have_side_effects():
+    """
+    Connection pool should raise RemoteProtocolError when graceful shutdown
+    but request may have had side effects (headers sent, stream <= last_stream_id).
+    """
+    network_backend = AsyncMockBackendWithRetry(
+        buffers_by_connection=[
+            # First connection: Graceful GOAWAY with last_stream_id=1
+            # Headers were sent, may have side effects
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=0, last_stream_id=1
+                ).serialize(),
+                b"",
+            ],
+        ],
+        http2=True,
+    )
+
+    async with httpcore.AsyncConnectionPool(
+        network_backend=network_backend,
+    ) as pool:
+        with pytest.raises(httpcore.RemoteProtocolError) as exc_info:
+            await pool.request("GET", "https://example.com/")
+
+        # Verify the error message indicates GOAWAY was received
+        assert "GOAWAY" in str(exc_info.value)
+
+
+# =============================================================================
+# Additional tests for specific code paths
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_receive_events_with_terminated_connection():
+    """
+    Test the _receive_events code path when connection is already terminated.
+    This covers the case where stream_id <= last_stream_id.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            # GOAWAY with last_stream_id=5 (so stream 1 <= 5, may have been processed)
+            # Non-graceful shutdown so connection goes to CLOSED, not DRAINING
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=1, last_stream_id=5
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            await conn.request("GET", "https://example.com/")
+
+        # Stream 1 <= last_stream_id (5), NOT safe to retry
+        assert exc_info.value.request_stream_id == 1
+        assert exc_info.value.last_stream_id == 5
+        assert exc_info.value.is_safe_to_retry is False
+
+
+@pytest.mark.anyio
+async def test_http2_goaway_connection_closed_after_graceful_goaway():
+    """
+    Test that connection is properly closed after handling graceful GOAWAY
+    when the request fails (due to server disconnect after GOAWAY).
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.GoAwayFrame(
+                stream_id=0, error_code=0, last_stream_id=1
+            ).serialize(),
+            b"",
+        ]
+    )
+    async with httpcore.AsyncHTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        with pytest.raises(httpcore.ConnectionGoingAway):
+            await conn.request("GET", "https://example.com/")
+
+        # After exception handling cleanup, connection should be closed
+        assert conn.is_closed()
+
+
+# =============================================================================
+# Tests for pool retry edge cases using mock connections
+# =============================================================================
+
+
+class MockConnectionGracefulGoaway:
+    """
+    Mock connection that raises ConnectionGoingAway with specific properties
+    to test the graceful shutdown + no side effects retry path.
+    """
+
+    def __init__(self, origin: httpcore.Origin, succeed_on_retry: bool = True):
+        self._origin = origin
+        self._calls = 0
+        self._succeed_on_retry = succeed_on_retry
+
+    def can_handle_request(self, origin: httpcore.Origin) -> bool:
+        return origin == self._origin
+
+    def is_available(self) -> bool:
+        return True
+
+    def is_idle(self) -> bool:
+        return self._calls == 0
+
+    def is_closed(self) -> bool:
+        return False
+
+    def has_expired(self) -> bool:
+        return False
+
+    async def handle_async_request(self, request: httpcore.Request) -> httpcore.Response:
+        self._calls += 1
+        if self._calls == 1:
+            # First call: raise ConnectionGoingAway with:
+            # - stream_id <= last_stream_id (not safe to retry based on RFC)
+            # - error_code = 0 (graceful shutdown)
+            # - headers_sent = False, body_sent = False (no side effects)
+            # This triggers the "elif exc.is_graceful_shutdown and not exc.may_have_side_effects" branch
+            raise httpcore.ConnectionGoingAway(
+                "Graceful shutdown before headers sent",
+                last_stream_id=5,  # >= stream_id (1)
+                error_code=0,  # graceful
+                request_stream_id=1,  # <= last_stream_id
+                headers_sent=False,  # no side effects
+                body_sent=False,
+            )
+        if self._succeed_on_retry:
+            return httpcore.Response(200, content=b"Success after retry!")
+        raise httpcore.ConnectionGoingAway(
+            "Another GOAWAY",
+            last_stream_id=5,
+            error_code=0,
+            request_stream_id=1,
+            headers_sent=False,
+            body_sent=False,
+        )
+
+    async def aclose(self) -> None:
+        pass
+
+    def info(self) -> str:
+        return "MockConnectionGracefulGoaway"
+
+
+@pytest.mark.anyio
+async def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
+    """
+    Test the pool retry path where:
+    - is_safe_to_retry = False (stream_id <= last_stream_id)
+    - is_graceful_shutdown = True (error_code = 0)
+    - may_have_side_effects = False (headers not sent yet)
+
+    This tests line 258 in connection_pool.py.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+
+    # Create a custom pool that returns our mock connection
+    class TestPool(httpcore.AsyncConnectionPool):
+        def __init__(self):
+            super().__init__()
+            self._mock_connections: list = []
+
+        def create_connection(self, origin: httpcore.Origin):
+            conn = MockConnectionGracefulGoaway(origin, succeed_on_retry=True)
+            self._mock_connections.append(conn)
+            return conn
+
+    async with TestPool() as pool:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Success after retry!"
+
+        # Verify the first connection was called twice (retry happened)
+        assert pool._mock_connections[0]._calls == 2
+
+

--- a/tests/_async/test_http2_goaway.py
+++ b/tests/_async/test_http2_goaway.py
@@ -891,7 +891,7 @@ async def test_http2_server_disconnect_with_h2_closed_state():
     # Create a mock stream that sets state to CLOSED BEFORE returning empty data
     # This simulates the race condition accurately
     class MockStreamWithClosedStateOnDisconnect(httpcore.AsyncMockStream):
-        def __init__(self, conn_ref: list) -> None:
+        def __init__(self, conn_ref: list[httpcore.AsyncHTTP2Connection]) -> None:
             self._conn_ref = conn_ref
             self._read_count = 0
             super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
@@ -900,7 +900,7 @@ async def test_http2_server_disconnect_with_h2_closed_state():
             self._read_count += 1
             if self._read_count == 1:
                 # First read returns settings
-                return hyperframe.frame.SettingsFrame().serialize()
+                return bytes(hyperframe.frame.SettingsFrame().serialize())
             # Before returning empty (disconnect), set h2 state to CLOSED
             # This simulates h2 having processed GOAWAY internally
             if self._conn_ref and self._conn_ref[0]:
@@ -910,7 +910,7 @@ async def test_http2_server_disconnect_with_h2_closed_state():
                 self._conn_ref[0]._connection_terminated = None
             return b""  # Server disconnect
 
-    conn_ref: list = []
+    conn_ref: list[httpcore.AsyncHTTP2Connection] = []
     stream = MockStreamWithClosedStateOnDisconnect(conn_ref)
 
     async with httpcore.AsyncHTTP2Connection(
@@ -958,7 +958,7 @@ async def test_http2_protocol_error_with_h2_closed_state():
     # Create a mock stream that sets state to CLOSED during write
     # This causes h2 to raise ProtocolError when trying to read the next frame
     class MockStreamWithClosedOnWrite(httpcore.AsyncMockStream):
-        def __init__(self, conn_ref: list) -> None:
+        def __init__(self, conn_ref: list[httpcore.AsyncHTTP2Connection]) -> None:
             self._conn_ref = conn_ref
             self._write_count = 0
             super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
@@ -973,7 +973,7 @@ async def test_http2_protocol_error_with_h2_closed_state():
                 ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
                 self._conn_ref[0]._connection_terminated = None
 
-    conn_ref: list = []
+    conn_ref: list[httpcore.AsyncHTTP2Connection] = []
     stream = MockStreamWithClosedOnWrite(conn_ref)
 
     async with httpcore.AsyncHTTP2Connection(

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -224,7 +224,7 @@ async def test_proxy_tunneling_with_403():
     """
     network_backend = AsyncMockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 

--- a/tests/_sync/test_http2.py
+++ b/tests/_sync/test_http2.py
@@ -214,7 +214,7 @@ def test_http2_connection_with_goaway():
     )
     with httpcore.HTTP2Connection(origin=origin, stream=stream) as conn:
         # The initial request has been closed midway, with an unrecoverable error.
-        with pytest.raises(httpcore.RemoteProtocolError):
+        with pytest.raises(httpcore.ConnectionGoingAway):
             conn.request("GET", "https://example.com/")
 
         # The second request can receive a graceful `ConnectionNotAvailable`,

--- a/tests/_sync/test_http2_goaway.py
+++ b/tests/_sync/test_http2_goaway.py
@@ -994,3 +994,43 @@ def test_http2_protocol_error_with_h2_closed_state():
 
         # Verify the exception properties
         assert exc_info.value.error_code == 0  # Assumed graceful
+
+
+def test_mock_backend_with_retry_exhausted_buffers():
+    """
+    Test the MockBackendWithRetry when more connections are made
+    than buffers provided. This covers the else branch at line 497.
+    """
+    network_backend = MockBackendWithRetry(
+        buffers_by_connection=[
+            # Only one buffer set provided
+            [
+                hyperframe.frame.SettingsFrame().serialize(),
+                hyperframe.frame.GoAwayFrame(
+                    stream_id=0, error_code=0, last_stream_id=0
+                ).serialize(),
+                b"",
+            ],
+        ],
+        http2=True,
+    )
+
+    # First connection uses the buffer
+    stream1 = network_backend.connect_tcp("example.com", 443)
+    assert stream1 is not None
+
+    # Second connection should hit the else branch (empty buffer)
+    stream2 = network_backend.connect_tcp("example.com", 443)
+    assert stream2 is not None
+
+
+def test_mock_connection_graceful_goaway_info():
+    """
+    Test the info() method of MockConnectionGracefulGoaway.
+    This covers line 795.
+    """
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    mock_conn = MockConnectionGracefulGoaway(origin)
+
+    # Verify the info method returns the expected string
+    assert mock_conn.info() == "MockConnectionGracefulGoaway"

--- a/tests/_sync/test_http2_goaway.py
+++ b/tests/_sync/test_http2_goaway.py
@@ -996,6 +996,7 @@ def test_http2_protocol_error_with_h2_closed_state():
         assert exc_info.value.error_code == 0  # Assumed graceful
 
 
+
 def test_mock_backend_with_retry_exhausted_buffers():
     """
     Test the MockBackendWithRetry when more connections are made
@@ -1022,6 +1023,7 @@ def test_mock_backend_with_retry_exhausted_buffers():
     # Second connection should hit the else branch (empty buffer)
     stream2 = network_backend.connect_tcp("example.com", 443)
     assert stream2 is not None
+
 
 
 def test_mock_connection_graceful_goaway_info():

--- a/tests/_sync/test_http2_goaway.py
+++ b/tests/_sync/test_http2_goaway.py
@@ -826,3 +826,171 @@ def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
 
         # Verify the first connection was called twice (retry happened)
         assert pool._mock_connections[0]._calls == 2  # type: ignore[attr-defined]
+
+
+# =============================================================================
+# Tests for edge cases in HTTP/2 GOAWAY handling
+# =============================================================================
+
+
+
+def test_http2_receive_events_with_terminated_connection_no_stream_id():
+    """
+    Test _receive_events when connection is terminated and stream_id is None.
+    This covers line 435 in http2.py - the RemoteProtocolError path.
+
+    This scenario occurs when _receive_events is called without a stream_id
+    (e.g., from _wait_for_outgoing_flow) after the connection has terminated.
+    We test this by directly manipulating the connection state.
+    """
+    import h2.events
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    stream = httpcore.MockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            # We'll manipulate the connection state after initialization
+        ]
+    )
+    with httpcore.HTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        # Directly set _connection_terminated to simulate a terminated connection
+        # This mimics the state after receiving a GOAWAY but before cleanup
+        terminated = h2.events.ConnectionTerminated()
+        terminated.error_code = 0
+        terminated.last_stream_id = 0
+        terminated.additional_data = b""
+        conn._connection_terminated = terminated
+
+        # Create a mock request for the _receive_events call
+        request = httpcore.Request(
+            method=b"GET",
+            url=httpcore.URL("https://example.com/"),
+            headers=[(b"host", b"example.com")],
+        )
+
+        # Call _receive_events with stream_id=None to trigger line 435
+        with pytest.raises(httpcore.RemoteProtocolError):
+            conn._receive_events(request, stream_id=None)
+
+
+
+def test_http2_server_disconnect_with_h2_closed_state():
+    """
+    Test server disconnect when h2 state machine is CLOSED but _connection_terminated
+    is not yet set. This covers line 558 in http2.py.
+
+    This simulates a race condition where h2 has processed GOAWAY internally
+    (transitioning to CLOSED state) but we haven't processed the event yet.
+    """
+    import h2.connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+
+    # Create a mock stream that sets state to CLOSED BEFORE returning empty data
+    # This simulates the race condition accurately
+    class MockStreamWithClosedStateOnDisconnect(httpcore.MockStream):
+        def __init__(self, conn_ref: list) -> None:
+            self._conn_ref = conn_ref
+            self._read_count = 0
+            super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
+
+        def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+            self._read_count += 1
+            if self._read_count == 1:
+                # First read returns settings
+                return hyperframe.frame.SettingsFrame().serialize()
+            # Before returning empty (disconnect), set h2 state to CLOSED
+            # This simulates h2 having processed GOAWAY internally
+            if self._conn_ref and self._conn_ref[0]:
+                self._conn_ref[
+                    0
+                ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
+                self._conn_ref[0]._connection_terminated = None
+            return b""  # Server disconnect
+
+    conn_ref: list = []
+    stream = MockStreamWithClosedStateOnDisconnect(conn_ref)
+
+    with httpcore.HTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        conn_ref.append(conn)
+
+        # Set up stream tracking for the request
+        conn._stream_requests[1] = {"headers_sent": True, "body_sent": False}
+
+        # Create a mock request
+        request = httpcore.Request(
+            method=b"GET",
+            url=httpcore.URL("https://example.com/"),
+            headers=[(b"host", b"example.com")],
+        )
+
+        # First call consumes the initial settings frame
+        conn._read_incoming_data(request, stream_id=1)
+
+        # Second call should hit line 558 when mock returns empty data
+        # and sets h2 state to CLOSED
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            conn._read_incoming_data(request, stream_id=1)
+
+        # Verify the exception has the expected properties
+        assert exc_info.value.request_stream_id == 1
+        assert exc_info.value.error_code == 0  # Assumed graceful
+
+
+
+def test_http2_protocol_error_with_h2_closed_state():
+    """
+    Test h2 ProtocolError when state machine is CLOSED.
+    This covers lines 213-225 in http2.py.
+
+    This simulates the race condition where h2 raises a ProtocolError
+    and the state machine is in CLOSED state, but _connection_terminated
+    is not yet set.
+    """
+    import h2.connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+
+    # Create a mock stream that sets state to CLOSED during write
+    # This causes h2 to raise ProtocolError when trying to read the next frame
+    class MockStreamWithClosedOnWrite(httpcore.MockStream):
+        def __init__(self, conn_ref: list) -> None:
+            self._conn_ref = conn_ref
+            self._write_count = 0
+            super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
+
+        def write(self, data: bytes, timeout: float | None = None) -> None:
+            self._write_count += 1
+            # After first write (settings ACK), set state to CLOSED
+            # to simulate race condition during request sending
+            if self._write_count > 1 and self._conn_ref and self._conn_ref[0]:
+                self._conn_ref[
+                    0
+                ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
+                self._conn_ref[0]._connection_terminated = None
+
+    conn_ref: list = []
+    stream = MockStreamWithClosedOnWrite(conn_ref)
+
+    with httpcore.HTTP2Connection(
+        origin=origin, stream=stream, keepalive_expiry=5.0
+    ) as conn:
+        conn_ref.append(conn)
+
+        # Use handle_request which has the try-except block
+        # The request will fail when h2 raises ProtocolError in CLOSED state
+        with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
+            conn.handle_request(
+                httpcore.Request(
+                    method=b"GET",
+                    url=httpcore.URL("https://example.com/"),
+                    headers=[(b"host", b"example.com")],
+                )
+            )
+
+        # Verify the exception properties
+        assert exc_info.value.error_code == 0  # Assumed graceful

--- a/tests/_sync/test_http2_goaway.py
+++ b/tests/_sync/test_http2_goaway.py
@@ -188,14 +188,14 @@ class TestConnectionGoingAwayException:
 # =============================================================================
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_non_graceful_shutdown():
+
+def test_http2_goaway_non_graceful_shutdown():
     """
     Non-graceful shutdown (error_code != 0) should raise ConnectionGoingAway
     with is_graceful_shutdown=False.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -215,26 +215,26 @@ async def test_http2_goaway_non_graceful_shutdown():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         # First request should fail with ConnectionGoingAway due to non-graceful GOAWAY
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Verify it's not a graceful shutdown
         assert exc_info.value.is_graceful_shutdown is False
         assert exc_info.value.error_code == 1
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_graceful_shutdown_properties():
+
+def test_http2_goaway_graceful_shutdown_properties():
     """
     When GOAWAY with NO_ERROR is received, the exception should have
     is_graceful_shutdown=True.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -254,26 +254,26 @@ async def test_http2_goaway_graceful_shutdown_properties():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         # Request should raise ConnectionGoingAway since GOAWAY is received
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Should be a graceful shutdown
         assert exc_info.value.is_graceful_shutdown is True
         assert exc_info.value.error_code == 0
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_stream_id_greater_than_last_stream_id():
+
+def test_http2_goaway_stream_id_greater_than_last_stream_id():
     """
     When stream_id > last_stream_id, the request is guaranteed unprocessed
     and should raise ConnectionGoingAway with is_safe_to_retry=True.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             # GOAWAY with last_stream_id=0 before any streams were processed
@@ -283,11 +283,11 @@ async def test_http2_goaway_stream_id_greater_than_last_stream_id():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Stream 1 > last_stream_id (0), so safe to retry
         assert exc_info.value.request_stream_id == 1
@@ -295,14 +295,14 @@ async def test_http2_goaway_stream_id_greater_than_last_stream_id():
         assert exc_info.value.is_safe_to_retry is True
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_stream_id_less_than_or_equal_to_last_stream_id():
+
+def test_http2_goaway_stream_id_less_than_or_equal_to_last_stream_id():
     """
     When stream_id <= last_stream_id and connection is not DRAINING,
     the request may have been processed and should raise ConnectionGoingAway.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -323,11 +323,11 @@ async def test_http2_goaway_stream_id_less_than_or_equal_to_last_stream_id():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Stream 1 <= last_stream_id (1), NOT safe to retry
         assert exc_info.value.request_stream_id == 1
@@ -335,14 +335,14 @@ async def test_http2_goaway_stream_id_less_than_or_equal_to_last_stream_id():
         assert exc_info.value.is_safe_to_retry is False
 
 
-@pytest.mark.anyio
-async def test_http2_server_disconnect_after_goaway():
+
+def test_http2_server_disconnect_after_goaway():
     """
     When server disconnects after sending GOAWAY, the exception should
     include GOAWAY context.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             # GOAWAY followed immediately by disconnect
@@ -352,24 +352,24 @@ async def test_http2_server_disconnect_after_goaway():
             b"",  # Server disconnect
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Should include GOAWAY context
         assert exc_info.value.last_stream_id == 0
         assert exc_info.value.is_graceful_shutdown is True
 
 
-@pytest.mark.anyio
-async def test_http2_tracks_request_phase_headers_sent():
+
+def test_http2_tracks_request_phase_headers_sent():
     """
     The connection should track when headers have been sent for GOAWAY context.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             # GOAWAY after headers would be sent but before response
@@ -379,23 +379,23 @@ async def test_http2_tracks_request_phase_headers_sent():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Headers should have been sent
         assert exc_info.value.headers_sent is True
 
 
-@pytest.mark.anyio
-async def test_http2_tracks_request_phase_body_sent():
+
+def test_http2_tracks_request_phase_body_sent():
     """
     The connection should track when body has been sent for GOAWAY context.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             # GOAWAY after body would be sent but before response
@@ -405,11 +405,11 @@ async def test_http2_tracks_request_phase_body_sent():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request(
+            conn.request(
                 "POST",
                 "https://example.com/",
                 headers={b"content-length": b"11"},
@@ -420,14 +420,14 @@ async def test_http2_tracks_request_phase_body_sent():
         assert exc_info.value.body_sent is True
 
 
-@pytest.mark.anyio
-async def test_http2_draining_connection_goaway_after_complete_response():
+
+def test_http2_draining_connection_goaway_after_complete_response():
     """
     When GOAWAY is sent after a complete response, the first request succeeds.
     The GOAWAY is only discovered on the next request attempt, which then fails.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -450,11 +450,11 @@ async def test_http2_draining_connection_goaway_after_complete_response():
             b"",  # Disconnect after GOAWAY
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         # First request should complete successfully
-        response = await conn.request("GET", "https://example.com/")
+        response = conn.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"
 
@@ -462,7 +462,7 @@ async def test_http2_draining_connection_goaway_after_complete_response():
         # (it comes after the complete response)
         # Second request attempts to use the connection and discovers GOAWAY
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # The second request (stream 3) > last_stream_id (1), so safe to retry
         assert exc_info.value.is_safe_to_retry is True
@@ -473,7 +473,7 @@ async def test_http2_draining_connection_goaway_after_complete_response():
 # =============================================================================
 
 
-class AsyncMockBackendWithRetry(httpcore.AsyncMockBackend):
+class MockBackendWithRetry(httpcore.MockBackend):
     """A mock backend that returns different data for each connection."""
 
     def __init__(self, buffers_by_connection: list[list[bytes]], http2: bool = False):
@@ -482,20 +482,20 @@ class AsyncMockBackendWithRetry(httpcore.AsyncMockBackend):
         self._http2 = http2
         super().__init__([], http2=http2)
 
-    async def connect_tcp(
+    def connect_tcp(
         self,
         host: str,
         port: int,
         timeout: float | None = None,
         local_address: str | None = None,
         socket_options: Any = None,
-    ) -> httpcore.AsyncMockStream:
+    ) -> httpcore.MockStream:
         if self._connection_index < len(self._all_buffers):
             buffer = list(self._all_buffers[self._connection_index])
             self._connection_index += 1
         else:
             buffer = []
-        return httpcore.AsyncMockStream(buffer, http2=self._http2)
+        return httpcore.MockStream(buffer, http2=self._http2)
 
 
 # =============================================================================
@@ -503,13 +503,13 @@ class AsyncMockBackendWithRetry(httpcore.AsyncMockBackend):
 # =============================================================================
 
 
-@pytest.mark.anyio
-async def test_connection_pool_retries_when_safe_to_retry():
+
+def test_connection_pool_retries_when_safe_to_retry():
     """
     Connection pool should automatically retry when is_safe_to_retry is True
     (stream_id > last_stream_id, guaranteed unprocessed).
     """
-    network_backend = AsyncMockBackendWithRetry(
+    network_backend = MockBackendWithRetry(
         buffers_by_connection=[
             # First connection: GOAWAY with last_stream_id=0 (stream 1 > 0, safe to retry)
             [
@@ -540,22 +540,22 @@ async def test_connection_pool_retries_when_safe_to_retry():
         http2=True,
     )
 
-    async with httpcore.AsyncConnectionPool(
+    with httpcore.ConnectionPool(
         network_backend=network_backend,
     ) as pool:
         # Request should succeed after automatic retry
-        response = await pool.request("GET", "https://example.com/")
+        response = pool.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"
 
 
-@pytest.mark.anyio
-async def test_connection_pool_retries_graceful_no_side_effects():
+
+def test_connection_pool_retries_graceful_no_side_effects():
     """
     Connection pool should retry when is_graceful_shutdown is True
     AND may_have_side_effects is False (headers not sent yet, stream > last_stream).
     """
-    network_backend = AsyncMockBackendWithRetry(
+    network_backend = MockBackendWithRetry(
         buffers_by_connection=[
             # First connection: Graceful GOAWAY with last_stream_id=0
             # stream 1 > 0, so safe to retry
@@ -587,21 +587,21 @@ async def test_connection_pool_retries_graceful_no_side_effects():
         http2=True,
     )
 
-    async with httpcore.AsyncConnectionPool(
+    with httpcore.ConnectionPool(
         network_backend=network_backend,
     ) as pool:
-        response = await pool.request("GET", "https://example.com/")
+        response = pool.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Success!"
 
 
-@pytest.mark.anyio
-async def test_connection_pool_raises_when_not_safe_to_retry():
+
+def test_connection_pool_raises_when_not_safe_to_retry():
     """
     Connection pool should raise RemoteProtocolError when is_safe_to_retry is False
     and the request may have been processed.
     """
-    network_backend = AsyncMockBackendWithRetry(
+    network_backend = MockBackendWithRetry(
         buffers_by_connection=[
             # First connection: GOAWAY with last_stream_id=1 (stream 1 <= 1, not safe)
             # Non-graceful shutdown (error_code=1)
@@ -616,23 +616,23 @@ async def test_connection_pool_raises_when_not_safe_to_retry():
         http2=True,
     )
 
-    async with httpcore.AsyncConnectionPool(
+    with httpcore.ConnectionPool(
         network_backend=network_backend,
     ) as pool:
         with pytest.raises(httpcore.RemoteProtocolError) as exc_info:
-            await pool.request("GET", "https://example.com/")
+            pool.request("GET", "https://example.com/")
 
         # Verify the error message indicates GOAWAY was received
         assert "GOAWAY" in str(exc_info.value)
 
 
-@pytest.mark.anyio
-async def test_connection_pool_raises_when_may_have_side_effects():
+
+def test_connection_pool_raises_when_may_have_side_effects():
     """
     Connection pool should raise RemoteProtocolError when graceful shutdown
     but request may have had side effects (headers sent, stream <= last_stream_id).
     """
-    network_backend = AsyncMockBackendWithRetry(
+    network_backend = MockBackendWithRetry(
         buffers_by_connection=[
             # First connection: Graceful GOAWAY with last_stream_id=1
             # Headers were sent, may have side effects
@@ -647,11 +647,11 @@ async def test_connection_pool_raises_when_may_have_side_effects():
         http2=True,
     )
 
-    async with httpcore.AsyncConnectionPool(
+    with httpcore.ConnectionPool(
         network_backend=network_backend,
     ) as pool:
         with pytest.raises(httpcore.RemoteProtocolError) as exc_info:
-            await pool.request("GET", "https://example.com/")
+            pool.request("GET", "https://example.com/")
 
         # Verify the error message indicates GOAWAY was received
         assert "GOAWAY" in str(exc_info.value)
@@ -662,14 +662,14 @@ async def test_connection_pool_raises_when_may_have_side_effects():
 # =============================================================================
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_receive_events_with_terminated_connection():
+
+def test_http2_goaway_receive_events_with_terminated_connection():
     """
     Test the _receive_events code path when connection is already terminated.
     This covers the case where stream_id <= last_stream_id.
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -690,11 +690,11 @@ async def test_http2_goaway_receive_events_with_terminated_connection():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway) as exc_info:
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # Stream 1 <= last_stream_id (5), NOT safe to retry
         assert exc_info.value.request_stream_id == 1
@@ -702,14 +702,14 @@ async def test_http2_goaway_receive_events_with_terminated_connection():
         assert exc_info.value.is_safe_to_retry is False
 
 
-@pytest.mark.anyio
-async def test_http2_goaway_connection_closed_after_graceful_goaway():
+
+def test_http2_goaway_connection_closed_after_graceful_goaway():
     """
     Test that connection is properly closed after handling graceful GOAWAY
     when the request fails (due to server disconnect after GOAWAY).
     """
     origin = httpcore.Origin(b"https", b"example.com", 443)
-    stream = httpcore.AsyncMockStream(
+    stream = httpcore.MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.HeadersFrame(
@@ -728,11 +728,11 @@ async def test_http2_goaway_connection_closed_after_graceful_goaway():
             b"",
         ]
     )
-    async with httpcore.AsyncHTTP2Connection(
+    with httpcore.HTTP2Connection(
         origin=origin, stream=stream, keepalive_expiry=5.0
     ) as conn:
         with pytest.raises(httpcore.ConnectionGoingAway):
-            await conn.request("GET", "https://example.com/")
+            conn.request("GET", "https://example.com/")
 
         # After exception handling cleanup, connection should be closed
         assert conn.is_closed()
@@ -743,7 +743,7 @@ async def test_http2_goaway_connection_closed_after_graceful_goaway():
 # =============================================================================
 
 
-class MockConnectionGracefulGoaway(httpcore.AsyncConnectionInterface):
+class MockConnectionGracefulGoaway(httpcore.ConnectionInterface):
     """
     Mock connection that raises ConnectionGoingAway with specific properties
     to test the graceful shutdown + no side effects retry path.
@@ -768,7 +768,7 @@ class MockConnectionGracefulGoaway(httpcore.AsyncConnectionInterface):
     def has_expired(self) -> bool:
         return False
 
-    async def handle_async_request(
+    def handle_request(
         self, request: httpcore.Request
     ) -> httpcore.Response:
         self._calls += 1
@@ -788,15 +788,15 @@ class MockConnectionGracefulGoaway(httpcore.AsyncConnectionInterface):
             )
         return httpcore.Response(200, content=b"Success after retry!")
 
-    async def aclose(self) -> None:
+    def close(self) -> None:
         pass
 
     def info(self) -> str:
         return "MockConnectionGracefulGoaway"
 
 
-@pytest.mark.anyio
-async def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
+
+def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
     """
     Test the pool retry path where:
     - is_safe_to_retry = False (stream_id <= last_stream_id)
@@ -807,7 +807,7 @@ async def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
     """
 
     # Create a custom pool that returns our mock connection
-    class TestPool(httpcore.AsyncConnectionPool):
+    class TestPool(httpcore.ConnectionPool):
         def __init__(self) -> None:
             super().__init__()
             self._mock_connections: list[MockConnectionGracefulGoaway] = []
@@ -819,8 +819,8 @@ async def test_connection_pool_retries_graceful_shutdown_no_headers_sent():
             self._mock_connections.append(conn)
             return conn
 
-    async with TestPool() as pool:
-        response = await pool.request("GET", "https://example.com/")
+    with TestPool() as pool:
+        response = pool.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Success after retry!"
 

--- a/tests/_sync/test_http2_goaway.py
+++ b/tests/_sync/test_http2_goaway.py
@@ -891,7 +891,7 @@ def test_http2_server_disconnect_with_h2_closed_state():
     # Create a mock stream that sets state to CLOSED BEFORE returning empty data
     # This simulates the race condition accurately
     class MockStreamWithClosedStateOnDisconnect(httpcore.MockStream):
-        def __init__(self, conn_ref: list) -> None:
+        def __init__(self, conn_ref: list[httpcore.HTTP2Connection]) -> None:
             self._conn_ref = conn_ref
             self._read_count = 0
             super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
@@ -900,7 +900,7 @@ def test_http2_server_disconnect_with_h2_closed_state():
             self._read_count += 1
             if self._read_count == 1:
                 # First read returns settings
-                return hyperframe.frame.SettingsFrame().serialize()
+                return bytes(hyperframe.frame.SettingsFrame().serialize())
             # Before returning empty (disconnect), set h2 state to CLOSED
             # This simulates h2 having processed GOAWAY internally
             if self._conn_ref and self._conn_ref[0]:
@@ -910,7 +910,7 @@ def test_http2_server_disconnect_with_h2_closed_state():
                 self._conn_ref[0]._connection_terminated = None
             return b""  # Server disconnect
 
-    conn_ref: list = []
+    conn_ref: list[httpcore.HTTP2Connection] = []
     stream = MockStreamWithClosedStateOnDisconnect(conn_ref)
 
     with httpcore.HTTP2Connection(
@@ -958,7 +958,7 @@ def test_http2_protocol_error_with_h2_closed_state():
     # Create a mock stream that sets state to CLOSED during write
     # This causes h2 to raise ProtocolError when trying to read the next frame
     class MockStreamWithClosedOnWrite(httpcore.MockStream):
-        def __init__(self, conn_ref: list) -> None:
+        def __init__(self, conn_ref: list[httpcore.HTTP2Connection]) -> None:
             self._conn_ref = conn_ref
             self._write_count = 0
             super().__init__([hyperframe.frame.SettingsFrame().serialize()], http2=True)
@@ -973,7 +973,7 @@ def test_http2_protocol_error_with_h2_closed_state():
                 ]._h2_state.state_machine.state = h2.connection.ConnectionState.CLOSED
                 self._conn_ref[0]._connection_terminated = None
 
-    conn_ref: list = []
+    conn_ref: list[httpcore.HTTP2Connection] = []
     stream = MockStreamWithClosedOnWrite(conn_ref)
 
     with httpcore.HTTP2Connection(

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -224,7 +224,7 @@ def test_proxy_tunneling_with_403():
     """
     network_backend = MockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 


### PR DESCRIPTION
# Fix HTTP/2 GOAWAY Race Conditions

⚠️GenAI was used in the development of this PR. It was all reviewed and tested manually by a human⚠️

## Problem

When using HTTPX with HTTP/2 under high concurrency, users encounter errors where connections are closed for streams beyond the `last_stream_id`. This forces applications to implement retry logic for what should be transparent library behavior.

The root cause is a set of race conditions between h2's state machine and httpcore's event processing:

1. **State machine race**: h2 transitions to CLOSED before httpcore processes the GOAWAY event
2. **Disconnect without context**: Server disconnects immediately after GOAWAY, raising generic `RemoteProtocolError("Server disconnected")` with no retry opportunity
3. **Insufficient exception context**: `ConnectionNotAvailable` didn't convey *why* the connection was unavailable, preventing informed retry decisions

A user proposed changing `>` to `>=` in the stream ID comparison ([discussion #1041](https://github.com/encode/httpcore/discussions/1041)), but this would violate [RFC 7540 Section 6.8](https://datatracker.ietf.org/doc/html/rfc7540#section-6.8):

> "The last stream identifier in the GOAWAY frame contains the highest-numbered stream identifier for which the sender of the GOAWAY frame might have taken some action on..."

A stream matching `last_stream_id` may have already been processed, making automatic retry unsafe for non-idempotent operations.

## Solution

This PR introduces proper GOAWAY handling that maintains RFC compliance while enabling safe automatic retries:  
 
### 1. New `ConnectionGoingAway` Exception 
  
A dedicated exception (subclass of `ConnectionNotAvailable`) that carries GOAWAY context:

- `last_stream_id` / `request_stream_id` for RFC 7540 stream comparison
- `error_code` to distinguish graceful shutdown (NO_ERROR) from errors
- `headers_sent` / `body_sent` to track request phase at time of GOAWAY
- Helper properties: `is_safe_to_retry`, `is_graceful_shutdown`, `may_have_side_effects`
  
This exception is exported publicly, allowing applications to implement idempotency-aware retry logic when needed. 

### 2. New `DRAINING` Connection State
  
Connections receiving a graceful GOAWAY (NO_ERROR) transition to `DRAINING` rather than `CLOSED`:

- Allows in-flight streams to complete normally
- Rejects new requests (connection reports `is_available() = False`)
- Connection expires once all streams complete

This fits naturally into the existing `HTTPConnectionState` enum pattern and makes state transitions easier to reason about.
  
### 3. Request Phase Tracking

Each stream tracks `headers_sent` and `body_sent` to determine potential side effects:
- If GOAWAY arrives before headers are sent → definitely no side effects
- If headers/body were sent → server may have processed the request

This information flows through `ConnectionGoingAway.may_have_side_effects` for retry decisions.

### 4. Connection Pool Retry Logic

The connection pool now handles `ConnectionGoingAway` with RFC-compliant retry semantics:

| Condition | Behavior |
|-----------|----------|
| `stream_id > last_stream_id` | Auto-retry (guaranteed unprocessed per RFC 7540) |
| Graceful shutdown + no side effects | Auto-retry (likely safe) |
| Otherwise | Raise `RemoteProtocolError` with context for application decision |

## Behavior Summary
  
| Scenario | Before | After |  
|----------|--------|-------|  
| Stream ID > last_stream_id | `ConnectionNotAvailable` (retry worked but was implicit) | Auto-retry with explicit RFC justification |
| Graceful shutdown, headers not sent | `RemoteProtocolError` or `ConnectionNotAvailable` | Auto-retry |
| Potentially processed request | Generic error | `RemoteProtocolError` with cause chain to `ConnectionGoingAway` |
| h2 CLOSED race condition | Generic protocol error | Proper `ConnectionGoingAway` with conservative assumptions |
| Server disconnect after GOAWAY | `RemoteProtocolError("Server disconnected")` | `ConnectionGoingAway` with retry context |

## Design Decisions

**Why a new connection state vs. a boolean flag?**
The `DRAINING` state fits the existing `HTTPConnectionState` pattern and makes state transitions explicit. A boolean would work but adds cognitive overhead when reasoning about valid state combinations.  

**Why track headers and body separately?**
Both are relevant for side-effect determination. Applications can use this granular information - for example, a read-only GET that sent headers but no body might be safer to retry than a POST with body sent.

**Why raise `RemoteProtocolError` instead of `ConnectionGoingAway` for potentially-processed requests?**
Balances API simplicity with power. Most users catch `RemoteProtocolError`; advanced users can inspect `__cause__` to access the full `ConnectionGoingAway` context. Since `ConnectionGoingAway` extends `ConnectionNotAvailable`, it's also catchable directly for those who need it.

**Why conservative assumptions when h2 is CLOSED without GOAWAY event?**
When the connection is closed but we haven't processed a GOAWAY event, we can't know the true `last_stream_id`. Assuming the current stream may have been processed is the safe default - better to surface an error than silently retry a potentially-processed request.

## Related Issues

- https://github.com/encode/httpx/issues/3324
- https://github.com/encode/httpcore/issues/45
- https://github.com/encode/httpcore/issues/730
- https://github.com/encode/httpcore/discussions/1041

## Test Plan

- [X] Unit tests for `ConnectionGoingAway` exception properties
- [X] Unit tests for DRAINING state transitions
- [ ] Integration tests simulating GOAWAY during request
- [ ] Integration tests for race condition scenarios (h2 CLOSED before event processing)
- [X] Verify existing tests still pass

---

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
