### PR TITLE
Fix SSL certificate verification failure for hostnames with trailing dots (#1063)

### DIFF
--- a/httpcore/_async/connection.py
+++ b/httpcore/_async/connection.py
@@ -148,8 +148,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
 
                     kwargs = {
                         "ssl_context": ssl_context,
-                        "server_hostname": sni_hostname
-                        or self._origin.host.decode("ascii"),
+                        "server_hostname": (
+                            sni_hostname or self._origin.host.decode("ascii")
+                        ).rstrip("."),
                         "timeout": timeout,
                     }
                     async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -309,7 +309,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip("."),
                     "timeout": timeout,
                 }
                 async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -309,7 +309,9 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip("."),
+                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip(
+                        "."
+                    ),
                     "timeout": timeout,
                 }
                 async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -258,8 +258,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
 
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": sni_hostname
-                            or self._remote_origin.host.decode("ascii"),
+                            "server_hostname": (
+                                sni_hostname or self._remote_origin.host.decode("ascii")
+                            ).rstrip("."),
                             "timeout": timeout,
                         }
                         async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/connection.py
+++ b/httpcore/_sync/connection.py
@@ -148,8 +148,9 @@ class HTTPConnection(ConnectionInterface):
 
                     kwargs = {
                         "ssl_context": ssl_context,
-                        "server_hostname": sni_hostname
-                        or self._origin.host.decode("ascii"),
+                        "server_hostname": (
+                            sni_hostname or self._origin.host.decode("ascii")
+                        ).rstrip("."),
                         "timeout": timeout,
                     }
                     with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -309,7 +309,7 @@ class TunnelHTTPConnection(ConnectionInterface):
 
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip("."),
                     "timeout": timeout,
                 }
                 with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -309,7 +309,9 @@ class TunnelHTTPConnection(ConnectionInterface):
 
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip("."),
+                    "server_hostname": self._remote_origin.host.decode("ascii").rstrip(
+                        "."
+                    ),
                     "timeout": timeout,
                 }
                 with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -258,8 +258,9 @@ class Socks5Connection(ConnectionInterface):
 
                         kwargs = {
                             "ssl_context": ssl_context,
-                            "server_hostname": sni_hostname
-                            or self._remote_origin.host.decode("ascii"),
+                            "server_hostname": (
+                                sni_hostname or self._remote_origin.host.decode("ascii")
+                            ).rstrip("."),
                             "timeout": timeout,
                         }
                         with Trace("start_tls", logger, request, kwargs) as trace:


### PR DESCRIPTION
## Problem

When using httpx/httpcore with FQDNs that have trailing dots (e.g., `myhost.mycompany.internal.`), SSL certificate verification fails with:

```
httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Host name mismatch, certificate is not valid for 'myhost.mycompany.internal.'.
```

This is a known issue — Python's `ssl` module doesn't handle trailing dots in `server_hostname`. The Python SSL team has acknowledged this as an application-layer issue: https://bugs.python.org/issue31997

## Solution

Strip the trailing dot from `server_hostname` before passing it to SSL backends. This follows the same approach used by [urllib3](https://github.com/urllib3/urllib3/blob/9ff0acf2391c80b363ddb08a566f38d707dc9826/src/urllib3/connection.py#L170-L186).

The fix is applied at the connection level (where `server_hostname` is constructed) rather than in each backend, keeping the change minimal and centralized across 6 files:

- `httpcore/_async/connection.py`
- `httpcore/_sync/connection.py`
- `httpcore/_async/http_proxy.py`
- `httpcore/_sync/http_proxy.py`
- `httpcore/_async/socks_proxy.py`
- `httpcore/_sync/socks_proxy.py`

DNS resolution still uses the original hostname with the trailing dot — only the SSL SNI is normalized.

Fixes #1063