### PR TITLE
Fix URL docstring typos

### DIFF
--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -183,13 +183,13 @@ class URL:
     """
     Represents the URL against which an HTTP request may be made.
 
-    The URL may either be specified as a plain string, for convienence:
+    The URL may either be specified as a plain string, for convenience:
 
     ```python
     url = httpcore.URL("https://www.example.com/")
     ```
 
-    Or be constructed with explicitily pre-parsed components:
+    Or be constructed with explicitly pre-parsed components:
 
     ```python
     url = httpcore.URL(scheme=b'https', host=b'www.example.com', port=None, target=b'/')


### PR DESCRIPTION
# Summary
Fix two URL docstring typos in `httpcore/_models.py`.
This is a documentation-only change in a single file with no behavior impact.

# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
