### PR TITLE
docs: fix SOCKS proxy dependency typo

### DIFF
--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -88,7 +88,7 @@ If you use proxies, keep in mind that the `httpcore` package only supports proxi
 
 The `httpcore` package also supports proxies using the SOCKS5 protocol.
 
-Make sure to install the optional dependancy using `pip install 'httpcore[socks]'`.
+Make sure to install the optional dependency using `pip install 'httpcore[socks]'`.
 
 The `SOCKSProxy` class should be using instead of a standard connection pool:
 


### PR DESCRIPTION
## Summary
- fix `dependancy` in the SOCKS proxy setup docs

## Related issue
- N/A (typo-only change; the template says previous discussion does not apply to typos)

## Guideline alignment
- Followed https://github.com/encode/httpcore/blob/master/.github/PULL_REQUEST_TEMPLATE.md
- Change stays within a single docs file and does not affect behavior.

## Validation
- `git diff --check`