### PR TITLE
docs: fix SOCKS proxy setup wording

### DIFF
--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -88,9 +88,9 @@ If you use proxies, keep in mind that the `httpcore` package only supports proxi
 
 The `httpcore` package also supports proxies using the SOCKS5 protocol.
 
-Make sure to install the optional dependancy using `pip install 'httpcore[socks]'`.
+Make sure to install the optional dependency using `pip install 'httpcore[socks]'`.
 
-The `SOCKSProxy` class should be using instead of a standard connection pool:
+Use the `SOCKSProxy` class instead of a standard connection pool:
 
 ```python
 import httpcore


### PR DESCRIPTION
# Summary

- fix two small wording issues in the SOCKS proxy setup section

## Related issue

- N/A (trivial docs-only fix)

## Guideline alignment

- followed the repository PR template in `.github/PULL_REQUEST_TEMPLATE.md`
- kept the change to a single file and a single docs-only topic
- the template notes that prior discussion does not apply to typo fixes

## Validation

- not run (docs-only change)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
