### PR TITLE
docs: fix _models docstring typos

### DIFF
--- a/httpcore/_models.py
+++ b/httpcore/_models.py
@@ -54,7 +54,7 @@ def enforce_headers(
     value: HeadersAsMapping | HeadersAsSequence | None = None, *, name: str
 ) -> list[tuple[bytes, bytes]]:
     """
-    Convienence function that ensure all items in request or response headers
+    Convenience function that ensures all items in request or response headers
     are either bytes or strings in the plain ASCII range.
     """
     if value is None:
@@ -183,13 +183,13 @@ class URL:
     """
     Represents the URL against which an HTTP request may be made.
 
-    The URL may either be specified as a plain string, for convienence:
+    The URL may either be specified as a plain string, for convenience:
 
     ```python
     url = httpcore.URL("https://www.example.com/")
     ```
 
-    Or be constructed with explicitily pre-parsed components:
+    Or be constructed with explicitly pre-parsed components:
 
     ```python
     url = httpcore.URL(scheme=b'https', host=b'www.example.com', port=None, target=b'/')


### PR DESCRIPTION
# Summary

- fix docstring typos in `httpcore/_models.py`

## Related issue

- N/A (trivial docstring-only fix)

## Guideline alignment

- followed the repository PR template in `.github/PULL_REQUEST_TEMPLATE.md`
- kept the change to one file and one documentation-only topic
- the template notes that prior discussion does not apply to typo fixes

## Validation

- not run (docstring-only change)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
