### PR TITLE
docs: fix the is_socket_readable docstring typo

### DIFF
--- a/httpcore/_utils.py
+++ b/httpcore/_utils.py
@@ -7,7 +7,7 @@ import sys
 
 def is_socket_readable(sock: socket.socket | None) -> bool:
     """
-    Return whether a socket, as identifed by its file descriptor, is readable.
+    Return whether a socket, as identified by its file descriptor, is readable.
     "A socket is readable" means that the read buffer isn't empty, i.e. that calling
     .recv() on it would immediately return some data.
     """


### PR DESCRIPTION
# Summary

- fix a typo in the `is_socket_readable` docstring

## Related issue

- N/A (trivial docstring-only fix)

## Guideline alignment

- followed the repository PR template in `.github/PULL_REQUEST_TEMPLATE.md`
- kept the change to one file and one documentation-only topic
- the template notes that prior discussion does not apply to typo fixes

## Validation

- not run (docstring-only change)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
