### PR TITLE
Drop stale unavailable pool connections

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -242,6 +242,17 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     #
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
+                    with self._optional_thread_lock:
+                        closing = []
+                        # If the connection still claims to be available then
+                        # it would be immediately assigned again, so drop it.
+                        if (
+                            connection in self._connections
+                            and connection.is_available()
+                        ):
+                            self._connections.remove(connection)
+                            closing.append(connection)
+                    await self._close_connections(closing)
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_async/http2.py
+++ b/httpcore/_async/http2.py
@@ -511,6 +511,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     def is_available(self) -> bool:
         return (
             self._state != HTTPConnectionState.CLOSED
+            and self._connection_terminated is None
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -242,6 +242,17 @@ class ConnectionPool(RequestInterface):
                     #
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
+                    with self._optional_thread_lock:
+                        closing = []
+                        # If the connection still claims to be available then
+                        # it would be immediately assigned again, so drop it.
+                        if (
+                            connection in self._connections
+                            and connection.is_available()
+                        ):
+                            self._connections.remove(connection)
+                            closing.append(connection)
+                    self._close_connections(closing)
                 else:
                     break  # pragma: nocover
 

--- a/httpcore/_sync/http2.py
+++ b/httpcore/_sync/http2.py
@@ -511,6 +511,7 @@ class HTTP2Connection(ConnectionInterface):
     def is_available(self) -> bool:
         return (
             self._state != HTTPConnectionState.CLOSED
+            and self._connection_terminated is None
             and not self._connection_error
             and not self._used_all_stream_ids
             and not (

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -452,6 +452,112 @@ async def test_connection_pool_with_connect_exception():
 
 
 @pytest.mark.anyio
+async def test_connection_pool_drops_stale_available_connection():
+    """
+    If a connection claims to be available but then refuses a request,
+    the pool should not keep assigning requests to that stale connection.
+    """
+
+    class StaleConnection(httpcore.AsyncConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def handle_async_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            raise httpcore.ConnectionNotAvailable()
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return True
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return True
+
+        def is_closed(self) -> bool:
+            return False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+        def info(self) -> str:
+            return "STALE"
+
+    class SuccessConnection(httpcore.AsyncConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def handle_async_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            async def content() -> typing.AsyncIterator[bytes]:
+                yield b"ok"
+
+            return httpcore.Response(200, content=content())
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return True
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return True
+
+        def is_closed(self) -> bool:
+            return False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+        def info(self) -> str:
+            return "OK"
+
+    class Pool(httpcore.AsyncConnectionPool):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stale_connection = StaleConnection()
+            self.success_connection = SuccessConnection()
+            self._created = 0
+
+        def create_connection(
+            self, origin: httpcore.Origin
+        ) -> httpcore.AsyncConnectionInterface:
+            self._created += 1
+            if self._created == 1:
+                return self.stale_connection
+            return self.success_connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    pool = Pool()
+    async with pool:
+        response = await pool.request("GET", "https://example.com/")
+
+        assert response.status == 200
+        assert response.content == b"ok"
+        assert pool.stale_connection.closed
+        assert len(pool.connections) == 1
+        connection = typing.cast(typing.Any, pool.connections[0])
+        assert connection is pool.success_connection
+        assert pool.stale_connection.can_handle_request(origin)
+        assert not pool.stale_connection.has_expired()
+        assert pool.stale_connection.is_idle()
+        assert not pool.stale_connection.is_closed()
+        assert pool.stale_connection.info() == "STALE"
+        assert pool.success_connection.can_handle_request(origin)
+        assert pool.success_connection.is_available()
+        assert pool.success_connection.info() == "OK"
+
+
+@pytest.mark.anyio
 async def test_connection_pool_with_immediate_expiry():
     """
     Connection pools with keepalive_expiry=0.0 should immediately expire

--- a/tests/_sync/test_connection_pool.py
+++ b/tests/_sync/test_connection_pool.py
@@ -452,6 +452,112 @@ def test_connection_pool_with_connect_exception():
 
 
 
+def test_connection_pool_drops_stale_available_connection():
+    """
+    If a connection claims to be available but then refuses a request,
+    the pool should not keep assigning requests to that stale connection.
+    """
+
+    class StaleConnection(httpcore.ConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def handle_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            raise httpcore.ConnectionNotAvailable()
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return True
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return True
+
+        def is_closed(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+        def info(self) -> str:
+            return "STALE"
+
+    class SuccessConnection(httpcore.ConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def handle_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            def content() -> typing.Iterator[bytes]:
+                yield b"ok"
+
+            return httpcore.Response(200, content=content())
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return True
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return True
+
+        def is_closed(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+        def info(self) -> str:
+            return "OK"
+
+    class Pool(httpcore.ConnectionPool):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stale_connection = StaleConnection()
+            self.success_connection = SuccessConnection()
+            self._created = 0
+
+        def create_connection(
+            self, origin: httpcore.Origin
+        ) -> httpcore.ConnectionInterface:
+            self._created += 1
+            if self._created == 1:
+                return self.stale_connection
+            return self.success_connection
+
+    origin = httpcore.Origin(b"https", b"example.com", 443)
+    pool = Pool()
+    with pool:
+        response = pool.request("GET", "https://example.com/")
+
+        assert response.status == 200
+        assert response.content == b"ok"
+        assert pool.stale_connection.closed
+        assert len(pool.connections) == 1
+        connection = typing.cast(typing.Any, pool.connections[0])
+        assert connection is pool.success_connection
+        assert pool.stale_connection.can_handle_request(origin)
+        assert not pool.stale_connection.has_expired()
+        assert pool.stale_connection.is_idle()
+        assert not pool.stale_connection.is_closed()
+        assert pool.stale_connection.info() == "STALE"
+        assert pool.success_connection.can_handle_request(origin)
+        assert pool.success_connection.is_available()
+        assert pool.success_connection.info() == "OK"
+
+
+
 def test_connection_pool_with_immediate_expiry():
     """
     Connection pools with keepalive_expiry=0.0 should immediately expire


### PR DESCRIPTION
# Summary

- remove an assigned connection from the pool if it still reports itself as available after raising `ConnectionNotAvailable`
- prevent HTTP/2 connections that have received GOAWAY from advertising availability
- add sync and async regression coverage for stale available connections

Closes #1066.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is not updated because this is an internal connection-pool bug fix.

# Validation

- Not run locally
- Static validation only: `git diff --check`.
- Relying on GitHub Actions for remote validation.