### PR TITLE
Close proxy tunnel connection when TLS raises during CONNECT (#921)

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -313,7 +313,11 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     "timeout": timeout,
                 }
                 async with Trace("start_tls", logger, request, kwargs) as trace:
-                    stream = await stream.start_tls(**kwargs)
+                    try:
+                        stream = await stream.start_tls(**kwargs)
+                    except Exception:
+                        await self._connection.aclose()
+                        raise
                     trace.return_value = stream
 
                 # Determine if we should be using HTTP/1.1 or HTTP/2

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -313,7 +313,11 @@ class TunnelHTTPConnection(ConnectionInterface):
                     "timeout": timeout,
                 }
                 with Trace("start_tls", logger, request, kwargs) as trace:
-                    stream = stream.start_tls(**kwargs)
+                    try:
+                        stream = stream.start_tls(**kwargs)
+                    except Exception:
+                        self._connection.close()
+                        raise
                     trace.return_value = stream
 
                 # Determine if we should be using HTTP/1.1 or HTTP/2

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -224,7 +224,7 @@ async def test_proxy_tunneling_with_403():
     """
     network_backend = AsyncMockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 
@@ -263,6 +263,69 @@ async def test_proxy_tunneling_with_auth():
         ),
         network_backend=network_backend,
     ) as proxy:
+        response = await proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_tls_failure_cleans_up():
+    """
+    When start_tls raises after a successful CONNECT through a proxy,
+    the tunnel connection is closed and removed from the pool, so
+    subsequent requests do not hit PoolTimeout.
+    """
+
+    class FailingTLSStream(AsyncMockStream):
+        async def start_tls(
+            self,
+            ssl_context: ssl.SSLContext,
+            server_hostname: typing.Optional[str] = None,
+            timeout: typing.Optional[float] = None,
+        ) -> AsyncNetworkStream:
+            raise OSError("TLS handshake failed")
+
+    class FailOnceBackend(AsyncMockBackend):
+        def __init__(self, buffer: typing.List[bytes]) -> None:
+            super().__init__(buffer)
+            self._should_fail = True
+
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        ) -> AsyncNetworkStream:
+            if self._should_fail:
+                self._should_fail = False
+                return FailingTLSStream(list(self._buffer))
+            return AsyncMockStream(list(self._buffer))
+
+    buffer = [
+        b"HTTP/1.1 200 OK\r\n\r\n",
+        b"HTTP/1.1 200 OK\r\n",
+        b"Content-Type: plain/text\r\n",
+        b"Content-Length: 13\r\n",
+        b"\r\n",
+        b"Hello, world!",
+    ]
+    backend = FailOnceBackend(buffer)
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        max_connections=1,
+        network_backend=backend,
+    ) as proxy:
+        # First request: CONNECT succeeds, start_tls raises OSError.
+        with pytest.raises(OSError, match="TLS handshake failed"):
+            await proxy.request("GET", "https://example.com/")
+
+        # The poisoned tunnel connection must have been cleaned up.
+        assert not proxy.connections
+
+        # Second request: pool is clean, so it succeeds normally.
         response = await proxy.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -224,7 +224,7 @@ def test_proxy_tunneling_with_403():
     """
     network_backend = MockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 
@@ -263,6 +263,69 @@ def test_proxy_tunneling_with_auth():
         ),
         network_backend=network_backend,
     ) as proxy:
+        response = proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+
+def test_proxy_tunneling_tls_failure_cleans_up():
+    """
+    When start_tls raises after a successful CONNECT through a proxy,
+    the tunnel connection is closed and removed from the pool, so
+    subsequent requests do not hit PoolTimeout.
+    """
+
+    class FailingTLSStream(MockStream):
+        def start_tls(
+            self,
+            ssl_context: ssl.SSLContext,
+            server_hostname: typing.Optional[str] = None,
+            timeout: typing.Optional[float] = None,
+        ) -> NetworkStream:
+            raise OSError("TLS handshake failed")
+
+    class FailOnceBackend(MockBackend):
+        def __init__(self, buffer: typing.List[bytes]) -> None:
+            super().__init__(buffer)
+            self._should_fail = True
+
+        def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        ) -> NetworkStream:
+            if self._should_fail:
+                self._should_fail = False
+                return FailingTLSStream(list(self._buffer))
+            return MockStream(list(self._buffer))
+
+    buffer = [
+        b"HTTP/1.1 200 OK\r\n\r\n",
+        b"HTTP/1.1 200 OK\r\n",
+        b"Content-Type: plain/text\r\n",
+        b"Content-Length: 13\r\n",
+        b"\r\n",
+        b"Hello, world!",
+    ]
+    backend = FailOnceBackend(buffer)
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        max_connections=1,
+        network_backend=backend,
+    ) as proxy:
+        # First request: CONNECT succeeds, start_tls raises OSError.
+        with pytest.raises(OSError, match="TLS handshake failed"):
+            proxy.request("GET", "https://example.com/")
+
+        # The poisoned tunnel connection must have been cleaned up.
+        assert not proxy.connections
+
+        # Second request: pool is clean, so it succeeds normally.
         response = proxy.request("GET", "https://example.com/")
         assert response.status == 200
         assert response.content == b"Hello, world!"


### PR DESCRIPTION
# Summary

Close proxy tunnel connection when TLS raises during CONNECT (#921)

This happened when I use python-telegram-bot library.

<details>

```
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/telegram/request/_httpxrequest.py", line 279, in do_request
    res = await self._client.request(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/httpx/_client.py", line 1540, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpx/_client.py", line 1629, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpx/_client.py", line 1730, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
    with map_httpcore_exceptions():
         ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/root/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/telegram/ext/_utils/networkloop.py", line 161, in network_retry_loop
    await do_action()
  File ".venv/lib/python3.13/site-packages/telegram/ext/_utils/networkloop.py", line 154, in do_action
    action_cb_task.result()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File ".venv/lib/python3.13/site-packages/telegram/ext/_updater.py", line 340, in polling_action_cb
    updates = await self.bot.get_updates(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/ext/_extbot.py", line 672, in get_updates
    updates = await super().get_updates(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/_bot.py", line 4865, in get_updates
    await self._post(
    ^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    ),
    ^
  File ".venv/lib/python3.13/site-packages/telegram/_bot.py", line 704, in _post
    return await self._do_post(
           ^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/ext/_extbot.py", line 370, in _do_post
    return await super()._do_post(
           ^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/_bot.py", line 733, in _do_post
    result = await request.post(
             ^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/request/_baserequest.py", line 198, in post
    result = await self._request_wrapper(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/request/_baserequest.py", line 305, in _request_wrapper
    code, payload = await self.do_request(
                    ^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/telegram/request/_httpxrequest.py", line 303, in do_request
    raise NetworkError(f"httpx.{err.__class__.__name__}: {err}") from err
telegram.error.NetworkError: httpx.ConnectError:
Exception happened while polling for updates.
Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
    yield
  File ".venv/lib/python3.13/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
    raise exc from None
  File ".venv/lib/python3.13/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
    response = await connection.handle_async_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        pool_request.request
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File ".venv/lib/python3.13/site-packages/httpcore/_async/http_proxy.py", line 316, in handle_async_request
    stream = await stream.start_tls(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpcore/_async/http11.py", line 376, in start_tls
    return await self._stream.start_tls(ssl_context, server_hostname, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpcore/_backends/anyio.py", line 67, in start_tls
    with map_exceptions(exc_map):
         ~~~~~~~~~~~~~~^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File ".venv/lib/python3.13/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
```

</details>


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- (N/A) I've updated the documentation accordingly.
