### PR TITLE
Reclaim orphaned pool connections after cancellation

### DIFF
--- a/httpcore/_async/connection_pool.py
+++ b/httpcore/_async/connection_pool.py
@@ -297,6 +297,12 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 # log: "closing idle connection"
                 self._connections.remove(connection)
                 closing_connections.append(connection)
+            elif not connection.is_idle() and not any(
+                request.connection is connection for request in self._requests
+            ):
+                # log: "closing orphaned connection"
+                self._connections.remove(connection)
+                closing_connections.append(connection)
 
         # Assign queued requests to connections.
         queued_requests = [request for request in self._requests if request.is_queued()]

--- a/httpcore/_sync/connection_pool.py
+++ b/httpcore/_sync/connection_pool.py
@@ -297,6 +297,12 @@ class ConnectionPool(RequestInterface):
                 # log: "closing idle connection"
                 self._connections.remove(connection)
                 closing_connections.append(connection)
+            elif not connection.is_idle() and not any(
+                request.connection is connection for request in self._requests
+            ):
+                # log: "closing orphaned connection"
+                self._connections.remove(connection)
+                closing_connections.append(connection)
 
         # Assign queued requests to connections.
         queued_requests = [request for request in self._requests if request.is_queued()]

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -1,15 +1,12 @@
 import logging
 import typing
 
-import anyio
 import hpack
 import hyperframe.frame
 import pytest
 import trio as concurrency
 
 import httpcore
-from httpcore._async import connection_pool
-from httpcore._async.interfaces import AsyncConnectionInterface
 
 
 @pytest.mark.anyio
@@ -452,75 +449,6 @@ async def test_connection_pool_with_connect_exception():
         "connection.connect_tcp.started",
         "connection.connect_tcp.failed",
     ]
-
-
-@pytest.mark.anyio
-async def test_connection_pool_removes_connection_after_request_cancellation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request_assigned = anyio.Event()
-
-    class WaitingPoolRequest(connection_pool.AsyncPoolRequest):
-        async def wait_for_connection(
-            self, timeout: float | None = None
-        ) -> AsyncConnectionInterface:
-            await super().wait_for_connection(timeout)
-            request_assigned.set()
-            await anyio.sleep_forever()
-            raise AssertionError("Pool request must be cancelled")
-
-    monkeypatch.setattr(connection_pool, "AsyncPoolRequest", WaitingPoolRequest)
-
-    class ConnectingConnection(AsyncConnectionInterface):
-        def __init__(self) -> None:
-            self.closed = False
-
-        async def handle_async_request(
-            self, request: httpcore.Request
-        ) -> httpcore.Response:
-            raise AssertionError("Cancelled request must not reach the connection")
-
-        async def aclose(self) -> None:
-            self.closed = True
-
-        def can_handle_request(self, origin: httpcore.Origin) -> bool:
-            return True
-
-        def is_available(self) -> bool:
-            return False
-
-        def has_expired(self) -> bool:
-            return False
-
-        def is_idle(self) -> bool:
-            return False
-
-        def is_closed(self) -> bool:
-            return False
-
-        def info(self) -> str:
-            return "CONNECTING"
-
-    class TestPool(httpcore.AsyncConnectionPool):
-        def create_connection(
-            self, origin: httpcore.Origin
-        ) -> AsyncConnectionInterface:
-            return connection
-
-    connection = ConnectingConnection()
-    async with TestPool(max_connections=1) as pool:
-
-        async def request() -> None:
-            with pytest.raises(TimeoutError):
-                with anyio.fail_after(0.01):
-                    await pool.request("GET", "https://example.com/")
-
-        async with anyio.create_task_group() as task_group:
-            task_group.start_soon(request)
-            await request_assigned.wait()
-
-        assert pool.connections == []
-        assert connection.closed
 
 
 @pytest.mark.anyio

--- a/tests/_async/test_connection_pool.py
+++ b/tests/_async/test_connection_pool.py
@@ -1,12 +1,15 @@
 import logging
 import typing
 
+import anyio
 import hpack
 import hyperframe.frame
 import pytest
 import trio as concurrency
 
 import httpcore
+from httpcore._async import connection_pool
+from httpcore._async.interfaces import AsyncConnectionInterface
 
 
 @pytest.mark.anyio
@@ -449,6 +452,75 @@ async def test_connection_pool_with_connect_exception():
         "connection.connect_tcp.started",
         "connection.connect_tcp.failed",
     ]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_removes_connection_after_request_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_assigned = anyio.Event()
+
+    class WaitingPoolRequest(connection_pool.AsyncPoolRequest):
+        async def wait_for_connection(
+            self, timeout: float | None = None
+        ) -> AsyncConnectionInterface:
+            await super().wait_for_connection(timeout)
+            request_assigned.set()
+            await anyio.sleep_forever()
+            raise AssertionError("Pool request must be cancelled")
+
+    monkeypatch.setattr(connection_pool, "AsyncPoolRequest", WaitingPoolRequest)
+
+    class ConnectingConnection(AsyncConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def handle_async_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            raise AssertionError("Cancelled request must not reach the connection")
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return False
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return False
+
+        def is_closed(self) -> bool:
+            return False
+
+        def info(self) -> str:
+            return "CONNECTING"
+
+    class TestPool(httpcore.AsyncConnectionPool):
+        def create_connection(
+            self, origin: httpcore.Origin
+        ) -> AsyncConnectionInterface:
+            return connection
+
+    connection = ConnectingConnection()
+    async with TestPool(max_connections=1) as pool:
+
+        async def request() -> None:
+            with pytest.raises(TimeoutError):
+                with anyio.fail_after(0.01):
+                    await pool.request("GET", "https://example.com/")
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(request)
+            await request_assigned.wait()
+
+        assert pool.connections == []
+        assert connection.closed
 
 
 @pytest.mark.anyio

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -6,6 +6,8 @@ import hyperframe
 import pytest
 
 import httpcore
+from httpcore._async import connection_pool
+from httpcore._async.interfaces import AsyncConnectionInterface
 
 
 class SlowWriteStream(httpcore.AsyncNetworkStream):
@@ -93,6 +95,75 @@ class SlowReadBackend(httpcore.AsyncNetworkBackend):
         socket_options: typing.Optional[typing.Iterable[httpcore.SOCKET_OPTION]] = None,
     ) -> httpcore.AsyncNetworkStream:
         return SlowReadStream(self._buffer)
+
+
+@pytest.mark.anyio
+async def test_connection_pool_removes_connection_after_request_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_assigned = anyio.Event()
+
+    class WaitingPoolRequest(connection_pool.AsyncPoolRequest):
+        async def wait_for_connection(
+            self, timeout: float | None = None
+        ) -> AsyncConnectionInterface:
+            await super().wait_for_connection(timeout)
+            request_assigned.set()
+            await anyio.sleep_forever()
+            raise AssertionError("Pool request must be cancelled")
+
+    monkeypatch.setattr(connection_pool, "AsyncPoolRequest", WaitingPoolRequest)
+
+    class ConnectingConnection(AsyncConnectionInterface):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def handle_async_request(
+            self, request: httpcore.Request
+        ) -> httpcore.Response:
+            raise AssertionError("Cancelled request must not reach the connection")
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+        def can_handle_request(self, origin: httpcore.Origin) -> bool:
+            return True
+
+        def is_available(self) -> bool:
+            return False
+
+        def has_expired(self) -> bool:
+            return False
+
+        def is_idle(self) -> bool:
+            return False
+
+        def is_closed(self) -> bool:
+            return False
+
+        def info(self) -> str:
+            return "CONNECTING"
+
+    class TestPool(httpcore.AsyncConnectionPool):
+        def create_connection(
+            self, origin: httpcore.Origin
+        ) -> AsyncConnectionInterface:
+            return connection
+
+    connection = ConnectingConnection()
+    async with TestPool(max_connections=1) as pool:
+
+        async def request() -> None:
+            with pytest.raises(TimeoutError):
+                with anyio.fail_after(0.01):
+                    await pool.request("GET", "https://example.com/")
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(request)
+            await request_assigned.wait()
+
+        assert pool.connections == []
+        assert connection.closed
 
 
 @pytest.mark.anyio

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -110,7 +110,7 @@ async def test_connection_pool_removes_connection_after_request_cancellation(
             await super().wait_for_connection(timeout)
             request_assigned.set()
             await anyio.sleep_forever()
-            raise AssertionError("Pool request must be cancelled")
+            raise AssertionError("Pool request must be cancelled")  # pragma: nocover
 
     monkeypatch.setattr(connection_pool, "AsyncPoolRequest", WaitingPoolRequest)
 
@@ -121,16 +121,18 @@ async def test_connection_pool_removes_connection_after_request_cancellation(
         async def handle_async_request(
             self, request: httpcore.Request
         ) -> httpcore.Response:
-            raise AssertionError("Cancelled request must not reach the connection")
+            raise AssertionError(  # pragma: nocover
+                "Cancelled request must not reach the connection"
+            )
 
         async def aclose(self) -> None:
             self.closed = True
 
         def can_handle_request(self, origin: httpcore.Origin) -> bool:
-            return True
+            return True  # pragma: nocover
 
         def is_available(self) -> bool:
-            return False
+            return False  # pragma: nocover
 
         def has_expired(self) -> bool:
             return False
@@ -142,7 +144,7 @@ async def test_connection_pool_removes_connection_after_request_cancellation(
             return False
 
         def info(self) -> str:
-            return "CONNECTING"
+            return "CONNECTING"  # pragma: nocover
 
     class TestPool(httpcore.AsyncConnectionPool):
         def create_connection(

--- a/tests/test_cancellations.py
+++ b/tests/test_cancellations.py
@@ -105,7 +105,7 @@ async def test_connection_pool_removes_connection_after_request_cancellation(
 
     class WaitingPoolRequest(connection_pool.AsyncPoolRequest):
         async def wait_for_connection(
-            self, timeout: float | None = None
+            self, timeout: typing.Optional[float] = None
         ) -> AsyncConnectionInterface:
             await super().wait_for_connection(timeout)
             request_assigned.set()


### PR DESCRIPTION
Fixes #1093

## Summary
- Reclaim a non-idle connection when no remaining pool request owns it.
- Apply the same cleanup invariant to the synchronous and asynchronous pools.
- Add an async regression that cancels a request after assignment but before dispatching it to the connection.

## Root cause
A cancelled async request can be removed after receiving a newly created connection but before calling that connection. The connection is neither idle nor closed, and no longer belongs to any request, so it remains in the pool and consumes a connection slot indefinitely.

## Validation
- `python -m ruff format httpcore tests --check`
- `python -m ruff check httpcore tests`
- `python -m mypy httpcore/_async/connection_pool.py httpcore/_sync/connection_pool.py tests/_async/test_connection_pool.py`
- `python -m pytest -q` (216 passed, 6 xpassed)