### PR TITLE
fix: apply connect timeout to SOCKS5 handshake reads

### DIFF
--- a/httpcore/_async/socks_proxy.py
+++ b/httpcore/_async/socks_proxy.py
@@ -45,6 +45,7 @@ async def _init_socks5_connection(
     host: bytes,
     port: int,
     auth: tuple[bytes, bytes] | None = None,
+    timeout: float | None = None,
 ) -> None:
     conn = socksio.socks5.SOCKS5Connection()
 
@@ -59,7 +60,7 @@ async def _init_socks5_connection(
     await stream.write(outgoing_bytes)
 
     # Auth method response
-    incoming_bytes = await stream.read(max_bytes=4096)
+    incoming_bytes = await stream.read(max_bytes=4096, timeout=timeout)
     response = conn.receive_data(incoming_bytes)
     assert isinstance(response, socksio.socks5.SOCKS5AuthReply)
     if response.method != auth_method:
@@ -78,7 +79,7 @@ async def _init_socks5_connection(
         await stream.write(outgoing_bytes)
 
         # Username/password response
-        incoming_bytes = await stream.read(max_bytes=4096)
+        incoming_bytes = await stream.read(max_bytes=4096, timeout=timeout)
         response = conn.receive_data(incoming_bytes)
         assert isinstance(response, socksio.socks5.SOCKS5UsernamePasswordReply)
         if not response.success:
@@ -94,7 +95,7 @@ async def _init_socks5_connection(
     await stream.write(outgoing_bytes)
 
     # Connect response
-    incoming_bytes = await stream.read(max_bytes=4096)
+    incoming_bytes = await stream.read(max_bytes=4096, timeout=timeout)
     response = conn.receive_data(incoming_bytes)
     assert isinstance(response, socksio.socks5.SOCKS5Reply)
     if response.reply_code != socksio.socks5.SOCKS5ReplyCode.SUCCEEDED:
@@ -237,6 +238,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         "host": self._remote_origin.host.decode("ascii"),
                         "port": self._remote_origin.port,
                         "auth": self._proxy_auth,
+                        "timeout": timeout,
                     }
                     async with Trace(
                         "setup_socks5_connection", logger, request, kwargs

--- a/httpcore/_sync/socks_proxy.py
+++ b/httpcore/_sync/socks_proxy.py
@@ -45,6 +45,7 @@ def _init_socks5_connection(
     host: bytes,
     port: int,
     auth: tuple[bytes, bytes] | None = None,
+    timeout: float | None = None,
 ) -> None:
     conn = socksio.socks5.SOCKS5Connection()
 
@@ -59,7 +60,7 @@ def _init_socks5_connection(
     stream.write(outgoing_bytes)
 
     # Auth method response
-    incoming_bytes = stream.read(max_bytes=4096)
+    incoming_bytes = stream.read(max_bytes=4096, timeout=timeout)
     response = conn.receive_data(incoming_bytes)
     assert isinstance(response, socksio.socks5.SOCKS5AuthReply)
     if response.method != auth_method:
@@ -78,7 +79,7 @@ def _init_socks5_connection(
         stream.write(outgoing_bytes)
 
         # Username/password response
-        incoming_bytes = stream.read(max_bytes=4096)
+        incoming_bytes = stream.read(max_bytes=4096, timeout=timeout)
         response = conn.receive_data(incoming_bytes)
         assert isinstance(response, socksio.socks5.SOCKS5UsernamePasswordReply)
         if not response.success:
@@ -94,7 +95,7 @@ def _init_socks5_connection(
     stream.write(outgoing_bytes)
 
     # Connect response
-    incoming_bytes = stream.read(max_bytes=4096)
+    incoming_bytes = stream.read(max_bytes=4096, timeout=timeout)
     response = conn.receive_data(incoming_bytes)
     assert isinstance(response, socksio.socks5.SOCKS5Reply)
     if response.reply_code != socksio.socks5.SOCKS5ReplyCode.SUCCEEDED:
@@ -237,6 +238,7 @@ class Socks5Connection(ConnectionInterface):
                         "host": self._remote_origin.host.decode("ascii"),
                         "port": self._remote_origin.port,
                         "auth": self._proxy_auth,
+                        "timeout": timeout,
                     }
                     with Trace(
                         "setup_socks5_connection", logger, request, kwargs


### PR DESCRIPTION
## Summary
SOCKS5 handshake `stream.read()` calls ignored connect timeout, so hung proxies blocked forever (issue #1089).

## Change
Thread `timeout` into `_init_socks5_connection` and pass it to every `stream.read`.

Fixes #1089
